### PR TITLE
Add dark mode toggle with persistence

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,10 @@
   <div class="container">
     <h1>Cyber Security Dictionary</h1>
     <div id="definition-container" style="display: none;"></div>
-    <input type="text" id="search" placeholder="Search...">
+    <div class="search-bar">
+      <input type="text" id="search" placeholder="Search...">
+      <button id="dark-mode-toggle">Dark Mode</button>
+    </div>
     <ul id="terms-list"></ul>
   </div>
   <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -1,6 +1,21 @@
 const termsList = document.getElementById("terms-list");
 const definitionContainer = document.getElementById("definition-container");
 const searchInput = document.getElementById("search");
+const darkModeToggle = document.getElementById("dark-mode-toggle");
+
+// Apply persisted theme preference
+if (localStorage.getItem("darkMode") === "true") {
+  document.body.classList.add("dark-mode");
+}
+
+// Toggle dark mode and store the preference
+darkModeToggle.addEventListener("click", () => {
+  document.body.classList.toggle("dark-mode");
+  localStorage.setItem(
+    "darkMode",
+    document.body.classList.contains("dark-mode")
+  );
+});
 
 
 

--- a/styles.css
+++ b/styles.css
@@ -89,6 +89,26 @@ li:hover {
   border-radius: 5px;
   box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
 }
+
+.search-bar {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.search-bar input {
+  flex: 1;
+}
+
+#dark-mode-toggle {
+  padding: 10px;
+  font-size: 16px;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  background-color: #fff;
+  cursor: pointer;
+}
+
 /* Scroll to Top button styles */
 #scrollToTopBtn {
   display: none;
@@ -110,7 +130,51 @@ li:hover {
 }
 
 /* Dark Mode styles */
-.dark-mode {
+body.dark-mode {
   background-color: #121212;
   color: #fff;
+}
+
+body.dark-mode .container {
+  background-color: #1e1e1e;
+}
+
+body.dark-mode #search {
+  background-color: #1e1e1e;
+  color: #fff;
+  border-color: #333;
+}
+
+body.dark-mode #dark-mode-toggle {
+  background-color: #333;
+  color: #fff;
+  border-color: #555;
+}
+
+body.dark-mode li {
+  background-color: #1e1e1e;
+  border-bottom: 1px solid #333;
+}
+
+body.dark-mode li:hover {
+  background-color: #333;
+}
+
+body.dark-mode .dictionary-item {
+  background-color: #1e1e1e;
+  border-color: #333;
+}
+
+body.dark-mode .dictionary-item h3 {
+  color: #fff;
+  border-bottom-color: #333;
+}
+
+body.dark-mode .dictionary-item p {
+  color: #ccc;
+}
+
+body.dark-mode #definition-container {
+  background-color: #1e1e1e;
+  box-shadow: 0 0 5px rgba(255, 255, 255, 0.1);
 }


### PR DESCRIPTION
## Summary
- add dark mode toggle button to index
- persist user's theme preference with localStorage
- style inputs, list items and cards for dark mode

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a304c4c4048328b40a80568974b45c