### PR TITLE
Add PWA manifest and service worker

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Cyber Security Dictionary</title>
   <link rel="stylesheet" href="styles.css">
+  <link rel="manifest" href="manifest.json">
   <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet">
 </head>
 <body>

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,9 @@
+{
+  "name": "Cyber Security Dictionary",
+  "short_name": "CyberSecDict",
+  "start_url": "./",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#000000",
+  "description": "A dictionary of cybersecurity terms for quick reference."
+}

--- a/script.js
+++ b/script.js
@@ -7065,4 +7065,11 @@ function displayDefinition(term) {
 }
 
 // Handle the search input event
-searchInput.addEventListener("input", populateTermsList); 
+searchInput.addEventListener("input", populateTermsList);
+
+// Register the service worker after the window loads
+window.addEventListener('load', () => {
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.register('sw.js');
+  }
+});

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,24 @@
+const CACHE_NAME = 'cybersec-dictionary-cache-v1';
+const ASSETS_TO_CACHE = [
+  '/',
+  '/index.html',
+  '/styles.css',
+  '/script.js',
+  '/data.json'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => {
+      return cache.addAll(ASSETS_TO_CACHE);
+    })
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => {
+      return response || fetch(event.request);
+    })
+  );
+});


### PR DESCRIPTION
## Summary
- link new PWA manifest in index.html
- add service worker to cache key assets for offline use
- register service worker on window load

## Testing
- `npm test` (fails: Could not read package.json)
- `npx --yes -p puppeteer@latest node <script>` (fails: Cannot find module 'puppeteer')

------
https://chatgpt.com/codex/tasks/task_e_68a305a5f2ec8328bf84f11fc20f4b4c