### PR TITLE
Add text-to-speech playback for definitions

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,10 @@
 <body>
   <div class="container">
     <h1>Cyber Security Dictionary</h1>
-    <div id="definition-container" style="display: none;"></div>
+    <div id="definition-container" style="display: none;">
+      <button id="speak-btn" aria-label="Read definition">🔊</button>
+      <div id="definition-content"></div>
+    </div>
     <div id="alpha-nav"></div>
     <input type="text" id="search" placeholder="Search...">
 =======

--- a/script.js
+++ b/script.js
@@ -1,5 +1,7 @@
 const termsList = document.getElementById("terms-list");
 const definitionContainer = document.getElementById("definition-container");
+const definitionContent = document.getElementById("definition-content");
+const speakButton = document.getElementById("speak-btn");
 const searchInput = document.getElementById("search");
 const alphaNav = document.getElementById("alpha-nav");
 
@@ -177,8 +179,17 @@ function isMatchingTerm(term) {
 }
 
 function displayDefinition(term) {
+  window.speechSynthesis.cancel();
   definitionContainer.style.display = "block";
-  definitionContainer.innerHTML = `<h3>${term.term}</h3><p>${term.definition}</p>`;
+  definitionContent.innerHTML = `<h3>${term.term}</h3><p>${term.definition}</p>`;
+  speakButton.onclick = () => {
+    if (window.speechSynthesis.speaking) {
+      window.speechSynthesis.cancel();
+    } else {
+      const utterance = new SpeechSynthesisUtterance(term.definition);
+      window.speechSynthesis.speak(utterance);
+    }
+  };
 }
 
 // Handle the search input event

--- a/styles.css
+++ b/styles.css
@@ -84,6 +84,17 @@ mark {
   border-radius: 5px;
   box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
   margin-bottom: 20px;
+  position: relative;
+}
+
+#speak-btn {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1.2rem;
 }
 
 #search {


### PR DESCRIPTION
## Summary
- add a speaker button in the definition container
- read definitions aloud with the Web Speech API and allow toggle cancellation
- style the speaker button near the definition

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a307a311a083288a294000962a24c7