### PR TITLE
Add recent terms history with clear option

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,12 +12,11 @@
     <h1>Cyber Security Dictionary</h1>
     <div id="definition-container" style="display: none;"></div>
     <div id="alpha-nav"></div>
-    <input type="text" id="search" placeholder="Search...">
-=======
     <div class="search-bar">
       <input type="text" id="search" placeholder="Search...">
       <button id="dark-mode-toggle">Dark Mode</button>
     </div>
+    <div id="recent-terms"></div>
     <ul id="terms-list"></ul>
   </div>
   <button id="scrollToTopBtn">↑</button>

--- a/styles.css
+++ b/styles.css
@@ -117,7 +117,7 @@ mark {
   background-color: #007bff;
   color: #fff;
 }
-=======
+
 .search-bar {
   display: flex;
   gap: 10px;
@@ -157,6 +157,39 @@ mark {
   background-color: #0056b3;
 }
 
+#recent-terms {
+  margin-top: 10px;
+}
+
+#recent-terms ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+#recent-terms li {
+  cursor: pointer;
+  text-decoration: underline;
+  color: #007bff;
+}
+
+#recent-terms li:hover {
+  color: #0056b3;
+}
+
+#clear-history {
+  margin-top: 10px;
+  padding: 5px 10px;
+  font-size: 14px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background-color: #fff;
+  cursor: pointer;
+}
+
 /* Dark Mode styles */
 body.dark-mode {
   background-color: #121212;
@@ -174,6 +207,16 @@ body.dark-mode #search {
 }
 
 body.dark-mode #dark-mode-toggle {
+  background-color: #333;
+  color: #fff;
+  border-color: #555;
+}
+
+body.dark-mode #recent-terms li {
+  color: #80bdff;
+}
+
+body.dark-mode #clear-history {
   background-color: #333;
   color: #fff;
   border-color: #555;


### PR DESCRIPTION
## Summary
- Track viewed terms in localStorage and render a recent history list with a clear button.
- Add recent terms container and styles including dark mode support.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a307a3c79c8328a67d676c59b2e366