### PR TITLE
Add print support and styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
 <body>
   <div class="container">
     <h1>Cyber Security Dictionary</h1>
+    <button id="print-btn" class="print-btn">Print</button>
     <div id="definition-container" style="display: none;"></div>
     <div id="alpha-nav"></div>
     <input type="text" id="search" placeholder="Search...">

--- a/script.js
+++ b/script.js
@@ -2,6 +2,7 @@ const termsList = document.getElementById("terms-list");
 const definitionContainer = document.getElementById("definition-container");
 const searchInput = document.getElementById("search");
 const alphaNav = document.getElementById("alpha-nav");
+const printBtn = document.getElementById("print-btn");
 
 let currentLetterFilter = "All";
 =======
@@ -178,12 +179,21 @@ function isMatchingTerm(term) {
 
 function displayDefinition(term) {
   definitionContainer.style.display = "block";
-  definitionContainer.innerHTML = `<h3>${term.term}</h3><p>${term.definition}</p>`;
+  definitionContainer.innerHTML = `
+    <h3>${term.term}</h3>
+    <p>${term.definition}</p>
+    <button id="print-term-btn" class="print-btn">Print</button>
+  `;
+  const termPrintBtn = document.getElementById("print-term-btn");
+  termPrintBtn.addEventListener("click", (e) => {
+    e.stopPropagation();
+    window.print();
+  });
 }
 
 // Handle the search input event
 =======
-searchInput.addEventListener("input", populateTermsList); 
+searchInput.addEventListener("input", populateTermsList);
 const scrollToTopBtn = document.getElementById("scrollToTopBtn");
 const scrollThreshold = 200;
 
@@ -203,3 +213,9 @@ scrollToTopBtn.addEventListener("click", () => {
 toggleScrollToTopBtn();
 =======
 searchInput.addEventListener("input", populateTermsList);
+
+if (printBtn) {
+  printBtn.addEventListener("click", () => {
+    window.print();
+  });
+}

--- a/styles.css
+++ b/styles.css
@@ -206,3 +206,28 @@ body.dark-mode #definition-container {
   background-color: #1e1e1e;
   box-shadow: 0 0 5px rgba(255, 255, 255, 0.1);
 }
+
+@media print {
+  #alpha-nav,
+  .search-bar,
+  #scrollToTopBtn,
+  .print-btn {
+    display: none;
+  }
+
+  body {
+    background: #fff;
+    color: #000;
+  }
+
+  .container,
+  #definition-container {
+    box-shadow: none;
+    background: none;
+  }
+
+  #terms-list li {
+    page-break-inside: avoid;
+  }
+}
+


### PR DESCRIPTION
## Summary
- Add header print button and per-term print option
- Implement click handlers to trigger `window.print()`
- Hide navigation elements and style content for paper via `@media print`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a307a4656c8328b385a7ccdf881df7