### PR TITLE
Add quiz mode with random multiple-choice questions

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,12 +12,12 @@
     <h1>Cyber Security Dictionary</h1>
     <div id="definition-container" style="display: none;"></div>
     <div id="alpha-nav"></div>
-    <input type="text" id="search" placeholder="Search...">
-=======
     <div class="search-bar">
       <input type="text" id="search" placeholder="Search...">
       <button id="dark-mode-toggle">Dark Mode</button>
     </div>
+    <button id="quiz-btn">Quiz Me</button>
+    <div id="quiz-container" class="quiz-container"></div>
     <ul id="terms-list"></ul>
   </div>
   <button id="scrollToTopBtn">↑</button>
@@ -25,4 +25,3 @@
   <script src="script.js"></script>
 </body>
 </html>
-

--- a/script.js
+++ b/script.js
@@ -1,45 +1,31 @@
-const termsList = document.getElementById("terms-list");
-const definitionContainer = document.getElementById("definition-container");
-const searchInput = document.getElementById("search");
-const alphaNav = document.getElementById("alpha-nav");
+const termsList = document.getElementById('terms-list');
+const definitionContainer = document.getElementById('definition-container');
+const searchInput = document.getElementById('search');
+const alphaNav = document.getElementById('alpha-nav');
+const darkModeToggle = document.getElementById('dark-mode-toggle');
+const scrollToTopBtn = document.getElementById('scrollToTopBtn');
+const quizBtn = document.getElementById('quiz-btn');
+const quizContainer = document.getElementById('quiz-container');
 
-let currentLetterFilter = "All";
-=======
-const darkModeToggle = document.getElementById("dark-mode-toggle");
-
-=======
-// Apply persisted theme preference
-if (localStorage.getItem("darkMode") === "true") {
-  document.body.classList.add("dark-mode");
-}
-
-// Toggle dark mode and store the preference
-darkModeToggle.addEventListener("click", () => {
-  document.body.classList.toggle("dark-mode");
-  localStorage.setItem(
-    "darkMode",
-    document.body.classList.contains("dark-mode")
-  );
-});
-=======
-
-// Apply persisted theme preference
-if (localStorage.getItem("darkMode") === "true") {
-  document.body.classList.add("dark-mode");
-}
-
-// Toggle dark mode and store the preference
-darkModeToggle.addEventListener("click", () => {
-  document.body.classList.toggle("dark-mode");
-  localStorage.setItem(
-    "darkMode",
-    document.body.classList.contains("dark-mode")
-  );
-});
-
+let currentLetterFilter = 'All';
 let termsData = { terms: [] };
+const QUIZ_TOTAL = 5; // configurable number of quiz questions
+let quizScore = 0;
+let quizCount = 0;
 
-window.addEventListener("DOMContentLoaded", () => {
+// Apply persisted theme preference
+if (localStorage.getItem('darkMode') === 'true') {
+  document.body.classList.add('dark-mode');
+}
+
+// Toggle dark mode and store the preference
+darkModeToggle.addEventListener('click', () => {
+  document.body.classList.toggle('dark-mode');
+  localStorage.setItem('darkMode', document.body.classList.contains('dark-mode'));
+});
+
+// Fetch terms and initialize
+document.addEventListener('DOMContentLoaded', () => {
   fetch('data.json')
     .then((response) => {
       if (!response.ok) {
@@ -50,13 +36,13 @@ window.addEventListener("DOMContentLoaded", () => {
     .then((data) => {
       termsData = data;
       removeDuplicateTermsAndDefinitions();
-      displayDictionary();
+      buildAlphaNav();
       populateTermsList();
     })
     .catch((error) => {
-      definitionContainer.style.display = "block";
-      definitionContainer.textContent = "Failed to load dictionary data.";
-      console.error("Error fetching data:", error);
+      definitionContainer.style.display = 'block';
+      definitionContainer.textContent = 'Failed to load dictionary data.';
+      console.error('Error fetching data:', error);
     });
 });
 
@@ -76,8 +62,8 @@ function removeDuplicateTermsAndDefinitions() {
 }
 
 function highlightActiveButton(button) {
-  alphaNav.querySelectorAll("button").forEach((btn) => btn.classList.remove("active"));
-  button.classList.add("active");
+  alphaNav.querySelectorAll('button').forEach((btn) => btn.classList.remove('active'));
+  button.classList.add('active');
 }
 
 function buildAlphaNav() {
@@ -85,19 +71,19 @@ function buildAlphaNav() {
     new Set(termsData.terms.map((t) => t.term.charAt(0).toUpperCase()))
   ).sort();
 
-  const allButton = document.createElement("button");
-  allButton.textContent = "All";
-  allButton.addEventListener("click", () => {
-    currentLetterFilter = "All";
+  const allButton = document.createElement('button');
+  allButton.textContent = 'All';
+  allButton.addEventListener('click', () => {
+    currentLetterFilter = 'All';
     highlightActiveButton(allButton);
     populateTermsList();
   });
   alphaNav.appendChild(allButton);
 
   letters.forEach((letter) => {
-    const btn = document.createElement("button");
+    const btn = document.createElement('button');
     btn.textContent = letter;
-    btn.addEventListener("click", () => {
+    btn.addEventListener('click', () => {
       currentLetterFilter = letter;
       highlightActiveButton(btn);
       populateTermsList();
@@ -108,46 +94,13 @@ function buildAlphaNav() {
   highlightActiveButton(allButton);
 }
 
-function displayDictionary() {
-  termsData.terms.sort((a, b) => a.term.localeCompare(b.term));
-
-  termsData.terms.forEach((item) => {
-    const termDiv = document.createElement("div");
-    termDiv.classList.add("dictionary-item");
-
-    const termHeader = document.createElement("h3");
-    termHeader.textContent = item.term;
-    termDiv.appendChild(termHeader);
-
-    const definitionPara = document.createElement("p");
-    definitionPara.textContent = item.definition;
-    termDiv.appendChild(definitionPara);
-
-    termDiv.addEventListener("click", () => {
-      displayDefinition(item);
-    });
-
-    termsList.appendChild(termDiv);
-  });
-}
-
-// Prepare data and render
-removeDuplicateTermsAndDefinitions();
-termsData.terms.sort((a, b) => a.term.localeCompare(b.term));
-buildAlphaNav();
-populateTermsList();
-
 function populateTermsList() {
-  termsList.innerHTML = "";
-=======
-function populateTermsList() {
-  termsList.innerHTML = "";
-=======
+  termsList.innerHTML = '';
   const searchValue = searchInput.value.trim().toLowerCase();
-=======
+
   termsData.terms.forEach((term) => {
     if (isMatchingTerm(term)) {
-      const listItem = document.createElement("li");
+      const listItem = document.createElement('li');
       if (searchValue) {
         const termText = term.term;
         const index = termText.toLowerCase().indexOf(searchValue);
@@ -158,7 +111,7 @@ function populateTermsList() {
       } else {
         listItem.textContent = term.term;
       }
-      listItem.addEventListener("click", () => {
+      listItem.addEventListener('click', () => {
         displayDefinition(term);
       });
       termsList.appendChild(listItem);
@@ -168,38 +121,80 @@ function populateTermsList() {
 
 function isMatchingTerm(term) {
   const searchValue = searchInput.value.trim().toLowerCase();
-  const matchesSearch =
-    searchValue === "" || term.term.toLowerCase().includes(searchValue);
+  const matchesSearch = searchValue === '' || term.term.toLowerCase().includes(searchValue);
   const matchesLetter =
-    currentLetterFilter === "All" ||
+    currentLetterFilter === 'All' ||
     term.term.charAt(0).toUpperCase() === currentLetterFilter;
   return matchesSearch && matchesLetter;
 }
 
 function displayDefinition(term) {
-  definitionContainer.style.display = "block";
+  definitionContainer.style.display = 'block';
   definitionContainer.innerHTML = `<h3>${term.term}</h3><p>${term.definition}</p>`;
 }
 
-// Handle the search input event
-=======
-searchInput.addEventListener("input", populateTermsList); 
-const scrollToTopBtn = document.getElementById("scrollToTopBtn");
+searchInput.addEventListener('input', populateTermsList);
+
+// Scroll to top button
 const scrollThreshold = 200;
 
 function toggleScrollToTopBtn() {
   if (window.scrollY > scrollThreshold) {
-    scrollToTopBtn.style.display = "block";
+    scrollToTopBtn.style.display = 'block';
   } else {
-    scrollToTopBtn.style.display = "none";
+    scrollToTopBtn.style.display = 'none';
   }
 }
 
-window.addEventListener("scroll", toggleScrollToTopBtn);
-scrollToTopBtn.addEventListener("click", () => {
+window.addEventListener('scroll', toggleScrollToTopBtn);
+scrollToTopBtn.addEventListener('click', () => {
   window.scrollTo({ top: 0, behavior: 'smooth' });
 });
 
 toggleScrollToTopBtn();
-=======
-searchInput.addEventListener("input", populateTermsList);
+
+// Quiz functionality
+quizBtn.addEventListener('click', startQuiz);
+
+function startQuiz() {
+  quizScore = 0;
+  quizCount = 0;
+  quizContainer.innerHTML = '';
+  quizContainer.style.display = 'block';
+  showNextQuestion();
+}
+
+function showNextQuestion() {
+  if (quizCount >= QUIZ_TOTAL) {
+    quizContainer.innerHTML = `<div class="quiz-results">You scored ${quizScore} out of ${QUIZ_TOTAL}</div>`;
+    return;
+  }
+
+  quizCount++;
+  const correctTerm = termsData.terms[Math.floor(Math.random() * termsData.terms.length)];
+
+  const options = new Set([correctTerm]);
+  while (options.size < Math.min(4, termsData.terms.length)) {
+    options.add(termsData.terms[Math.floor(Math.random() * termsData.terms.length)]);
+  }
+  const optionArray = Array.from(options).sort(() => Math.random() - 0.5);
+
+  quizContainer.innerHTML = `<div class="quiz-question">${correctTerm.definition}</div>`;
+  const optionsDiv = document.createElement('div');
+  optionsDiv.className = 'quiz-options';
+
+  optionArray.forEach((opt) => {
+    const btn = document.createElement('button');
+    btn.className = 'quiz-option';
+    btn.textContent = opt.term;
+    btn.addEventListener('click', () => {
+      if (opt === correctTerm) {
+        quizScore++;
+      }
+      showNextQuestion();
+    });
+    optionsDiv.appendChild(btn);
+  });
+
+  quizContainer.appendChild(optionsDiv);
+}

--- a/styles.css
+++ b/styles.css
@@ -117,7 +117,6 @@ mark {
   background-color: #007bff;
   color: #fff;
 }
-=======
 .search-bar {
   display: flex;
   gap: 10px;
@@ -205,4 +204,60 @@ body.dark-mode .dictionary-item p {
 body.dark-mode #definition-container {
   background-color: #1e1e1e;
   box-shadow: 0 0 5px rgba(255, 255, 255, 0.1);
+}
+#quiz-btn {
+  margin-top: 10px;
+  padding: 10px;
+  font-size: 16px;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  background-color: #fff;
+  cursor: pointer;
+}
+
+.quiz-container {
+  margin-top: 20px;
+}
+
+.quiz-question {
+  font-size: 18px;
+  margin-bottom: 10px;
+}
+
+.quiz-options {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.quiz-option {
+  padding: 10px;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  background-color: #fff;
+  cursor: pointer;
+}
+
+.quiz-option:hover {
+  background-color: #f5f5f5;
+}
+
+.quiz-results {
+  font-weight: bold;
+  margin-top: 15px;
+}
+body.dark-mode #quiz-btn {
+  background-color: #333;
+  color: #fff;
+  border-color: #555;
+}
+
+body.dark-mode .quiz-option {
+  background-color: #1e1e1e;
+  color: #fff;
+  border-color: #333;
+}
+
+body.dark-mode .quiz-option:hover {
+  background-color: #333;
 }


### PR DESCRIPTION
## Summary
- Add "Quiz Me" button and container to launch interactive quiz mode.
- Implement quiz logic to generate random definition questions with multiple-choice options and scoring.
- Style quiz interface including buttons, question text, and result display with light/dark mode support.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a307a5d1988328a7e04e37aa9bd0ec