### PR TITLE
Add dark mode toggle and favorites filter controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,9 @@
 
     <button id="random-term">Random Term</button>
 
+    <button id="dark-mode-toggle">Toggle Dark Mode</button>
+    <label><input type="checkbox" id="show-favorites"> Show Favorites</label>
+
     <ul id="terms-list"></ul>
   </div>
   <button id="scrollToTopBtn">↑</button>

--- a/styles.css
+++ b/styles.css
@@ -96,6 +96,31 @@ mark {
 }
 
 
+/* Controls styling */
+#dark-mode-toggle {
+  margin-top: 10px;
+  padding: 10px;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  background-color: #007bff;
+  color: #fff;
+  cursor: pointer;
+}
+
+#dark-mode-toggle:hover {
+  background-color: #0056b3;
+}
+
+label {
+  margin-left: 10px;
+  margin-top: 10px;
+  display: inline-block;
+}
+
+#show-favorites {
+  margin-right: 5px;
+}
+
 /* Scroll to Top button styles */
 #scrollToTopBtn {
   display: none;


### PR DESCRIPTION
## Summary
- Add dark mode toggle button and favorites checkbox before the dictionary list for improved accessibility
- Style new controls for consistent look and feel

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3698257808328a087de06866e4e7f