### PR TITLE
Highlight search term matches

### DIFF
--- a/script.js
+++ b/script.js
@@ -194,7 +194,13 @@ function populateTermsList() {
         termDiv.classList.add("dictionary-item");
 
         const termHeader = document.createElement("h3");
-        termHeader.textContent = item.term;
+        if (searchValue) {
+          const escaped = searchValue.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+          const regex = new RegExp(`(${escaped})`, "gi");
+          termHeader.innerHTML = item.term.replace(regex, "<mark>$1</mark>");
+        } else {
+          termHeader.textContent = item.term;
+        }
 
         const star = document.createElement("span");
         star.classList.add("favorite-star");

--- a/styles.css
+++ b/styles.css
@@ -52,6 +52,11 @@ mark {
   color: inherit;
 }
 
+body.dark-mode mark {
+  background-color: #ffeb3b;
+  color: #000;
+}
+
 .dictionary-item {
   margin-bottom: 20px;
   padding: 10px;


### PR DESCRIPTION
## Summary
- Highlight search matches within terms by wrapping matched segments in `<mark>` tags.
- Improve readability of highlighted text by adjusting `<mark>` styling for dark mode.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab45240a648328b4c94cf004938f3f