### PR TITLE
Add SEO metadata and sitemap configuration

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,9 +3,20 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="A comprehensive dictionary of cyber security terms and definitions.">
+  <meta name="keywords" content="cyber security, dictionary, terms, definitions, glossary">
+  <meta property="og:title" content="Cyber Security Dictionary">
+  <meta property="og:description" content="A comprehensive dictionary of cyber security terms and definitions.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="Cyber Security Dictionary">
+  <meta name="twitter:description" content="A comprehensive dictionary of cyber security terms and definitions.">
   <title>Cyber Security Dictionary</title>
   <link rel="stylesheet" href="styles.css">
   <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="canonical" href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/">
+  <link rel="sitemap" type="application/xml" title="Sitemap" href="sitemap.xml">
 </head>
 <body>
   <main class="container">

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://alex-unnippillil.github.io/CyberSecuirtyDictionary/sitemap.xml
+

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://alex-unnippillil.github.io/CyberSecuirtyDictionary/</loc>
+    <lastmod>2025-08-31</lastmod>
+  </url>
+</urlset>
+


### PR DESCRIPTION
## Summary
- add SEO meta tags including description, keywords, OpenGraph, Twitter cards, canonical and sitemap link
- provide robots.txt with sitemap reference
- introduce basic sitemap.xml for site

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4a9703bfc8328a9f57ff26384cf2b