### PR TITLE
Render full alphabet and improve navigation accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,10 +8,10 @@
   <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet">
 </head>
 <body>
-  <main class="container">
+  <main class="container" role="main">
     <h1>Cyber Security Dictionary</h1>
     <div id="definition-container" style="display: none;"></div>
-    <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
+    <nav id="alpha-nav" aria-label="Alphabet navigation" role="navigation"></nav>
     <input type="text" id="search" placeholder="Search...">
 
     <button id="random-term" aria-label="Show random term">Random Term</button>

--- a/styles.css
+++ b/styles.css
@@ -163,11 +163,22 @@ label {
 }
 
 #alpha-nav button:hover,
-#alpha-nav button:focus {
+#alpha-nav button:focus-visible {
   background-color: #ddd;
 }
 
-#alpha-nav button.active {
+#alpha-nav button:focus-visible {
+  outline: 2px solid #007bff;
+  outline-offset: 2px;
+}
+
+#alpha-nav button[disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+#alpha-nav button.active,
+#alpha-nav button[aria-current="true"] {
   background-color: #007bff;
   border-color: #007bff;
   color: #fff;
@@ -263,11 +274,23 @@ body.dark-mode #alpha-nav button {
 }
 
 body.dark-mode #alpha-nav button:hover,
-body.dark-mode #alpha-nav button:focus {
+body.dark-mode #alpha-nav button:focus-visible {
   background-color: #555;
 }
 
-body.dark-mode #alpha-nav button.active {
+body.dark-mode #alpha-nav button:focus-visible {
+  outline: 2px solid #fff;
+  outline-offset: 2px;
+}
+
+body.dark-mode #alpha-nav button[disabled] {
+  opacity: 0.4;
+  cursor: not-allowed;
+  border-color: #444;
+}
+
+body.dark-mode #alpha-nav button.active,
+body.dark-mode #alpha-nav button[aria-current="true"] {
   background-color: #007bff;
   border-color: #007bff;
 }


### PR DESCRIPTION
## Summary
- Always render A–Z navigation, disabling letters without terms
- Add ARIA attributes and hash-synced active state for alpha navigation
- Introduce focus-visible and disabled button styles for better keyboard accessibility

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4a974b19c8328a0db330112b90499