### PR TITLE
Render reference links and test URL availability

### DIFF
--- a/linkCheck.test.js
+++ b/linkCheck.test.js
@@ -1,0 +1,27 @@
+const fs = require('node:fs');
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { execFile } = require('node:child_process');
+const { promisify } = require('node:util');
+
+const execFileAsync = promisify(execFile);
+
+const data = JSON.parse(fs.readFileSync('terms.json', 'utf8'));
+
+for (const { term, references } of data.terms) {
+  if (Array.isArray(references)) {
+    for (const url of references) {
+      test(`Reference for ${term}: ${url}`, async () => {
+        const { stdout } = await execFileAsync('curl', [
+          '-o',
+          '/dev/null',
+          '-s',
+          '-w',
+          '%{http_code}',
+          url,
+        ]);
+        assert.strictEqual(stdout.trim(), '200');
+      });
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "cybersecuritydictionary",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/script.js
+++ b/script.js
@@ -26,7 +26,7 @@ window.addEventListener("DOMContentLoaded", () => {
 });
 
 function loadTerms() {
-  fetch("data.json")
+  fetch("terms.json")
     .then((response) => {
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);
@@ -180,7 +180,17 @@ function populateTermsList() {
 
 function displayDefinition(term) {
   definitionContainer.style.display = "block";
-  definitionContainer.innerHTML = `<h3>${term.term}</h3><p>${term.definition}</p>`;
+  let html = `<h3>${term.term}</h3><p>${term.definition}</p>`;
+  if (term.references && term.references.length) {
+    const refs = term.references
+      .map(
+        (url) =>
+          `<li><a href="${url}" target="_blank" rel="noopener">${url}</a></li>`
+      )
+      .join("");
+    html += `<h4>References</h4><ul>${refs}</ul>`;
+  }
+  definitionContainer.innerHTML = html;
   window.location.hash = encodeURIComponent(term.term);
 }
 

--- a/terms.json
+++ b/terms.json
@@ -2,23 +2,38 @@
   "terms": [
     {
       "term": "Phishing",
-      "definition": "An attempt to trick individuals into revealing sensitive information through fraudulent emails, websites, or messages."
+      "definition": "An attempt to trick individuals into revealing sensitive information through fraudulent emails, websites, or messages.",
+      "references": [
+        "https://en.wikipedia.org/wiki/Phishing"
+      ]
     },
     {
       "term": "Phishing Email",
-      "definition": "An email sent by attackers that appears legitimate but aims to trick recipients into revealing sensitive information or performing actions."
+      "definition": "An email sent by attackers that appears legitimate but aims to trick recipients into revealing sensitive information or performing actions.",
+      "references": [
+        "https://www.cisa.gov/news-events/news/avoiding-social-engineering-and-phishing-attacks"
+      ]
     },
     {
       "term": "Social Engineering Toolkit (SET)",
-      "definition": "A framework for simulating social engineering attacks, helping organizations test their security awareness."
+      "definition": "A framework for simulating social engineering attacks, helping organizations test their security awareness.",
+      "references": [
+        "https://github.com/trustedsec/social-engineer-toolkit"
+      ]
     },
     {
       "term": "Advanced Persistent Threat (APT)",
-      "definition": "A prolonged and targeted cyber attack in which attackers gain and maintain unauthorized access to a network."
+      "definition": "A prolonged and targeted cyber attack in which attackers gain and maintain unauthorized access to a network.",
+      "references": [
+        "https://en.wikipedia.org/wiki/Advanced_persistent_threat"
+      ]
     },
     {
       "term": "Cyber Espionage",
-      "definition": "The use of cyber techniques to steal sensitive information from governments, organizations, or individuals."
+      "definition": "The use of cyber techniques to steal sensitive information from governments, organizations, or individuals.",
+      "references": [
+        "https://en.wikipedia.org/wiki/Cyber-espionage"
+      ]
     },
     {
       "term": "Zero-Knowledge Proof",


### PR DESCRIPTION
## Summary
- load terms from new `terms.json` including reference URLs
- display references as outbound links in term details
- add curl-based tests ensuring reference URLs return 200

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4a97a4b9c83289496e13d143c7f70