### PR TITLE
feat: add icon-based theme toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,7 @@ https://alex-unnippillil.github.io/CyberSecuirtyDictionary/
 
 ![image](https://github.com/Alex-Unnippillil/CyberSecuirtyDictionary/assets/24538548/c5a54c56-babb-485d-b01c-4fdfb186325b)
 
+## Theme
+
+Use the sun/moon button to toggle between light and dark modes. Your choice is saved in your browser's local storage and automatically applied on your next visit.
+

--- a/index.html
+++ b/index.html
@@ -16,7 +16,9 @@
 
     <button id="random-term" aria-label="Show random term">Random Term</button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+    <button id="dark-mode-toggle" aria-label="Switch to dark mode">
+      <span id="dark-mode-icon" aria-hidden="true">🌙</span>
+    </button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 

--- a/script.js
+++ b/script.js
@@ -4,20 +4,36 @@ const searchInput = document.getElementById("search");
 const randomButton = document.getElementById("random-term");
 const alphaNav = document.getElementById("alpha-nav");
 const darkModeToggle = document.getElementById("dark-mode-toggle");
+const darkModeIcon = document.getElementById("dark-mode-icon");
 const showFavoritesToggle = document.getElementById("show-favorites");
 const favorites = new Set(JSON.parse(localStorage.getItem("favorites") || "[]"));
 
 let currentLetterFilter = "All";
 let termsData = { terms: [] };
 
-if (localStorage.getItem("darkMode") === "true") {
+function updateDarkModeControl(isDark) {
+  if (darkModeIcon) {
+    darkModeIcon.textContent = isDark ? "☀️" : "🌙";
+  }
+  if (darkModeToggle) {
+    darkModeToggle.setAttribute(
+      "aria-label",
+      isDark ? "Switch to light mode" : "Switch to dark mode"
+    );
+  }
+}
+
+const savedDarkMode = localStorage.getItem("darkMode") === "true";
+if (savedDarkMode) {
   document.body.classList.add("dark-mode");
 }
+updateDarkModeControl(savedDarkMode);
 
 if (darkModeToggle) {
   darkModeToggle.addEventListener("click", () => {
-    document.body.classList.toggle("dark-mode");
-    localStorage.setItem("darkMode", document.body.classList.contains("dark-mode"));
+    const isDark = document.body.classList.toggle("dark-mode");
+    localStorage.setItem("darkMode", isDark);
+    updateDarkModeControl(isDark);
   });
 }
 


### PR DESCRIPTION
## Summary
- replace the dark mode text button with a sun/moon icon and label it for accessibility
- persist the chosen theme in `localStorage` and sync the icon/label on load
- document light and dark theme behavior in the README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4a97b7ae8832883a1665ba6bfec83