### PR TITLE
Add deterministic daily term and adjust random term selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
     <h1>Cyber Security Dictionary</h1>
     <div id="definition-container" style="display: none;"></div>
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
+    <div id="daily-term"></div>
     <input type="text" id="search" placeholder="Search...">
 
     <button id="random-term" aria-label="Show random term">Random Term</button>
@@ -20,7 +21,7 @@
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 
-    <ul id="terms-list"></ul>
+      <ul id="terms-list"></ul>
   </main>
   <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
 

--- a/styles.css
+++ b/styles.css
@@ -91,6 +91,12 @@ body.dark-mode mark {
   margin-bottom: 20px;
 }
 
+#daily-term {
+  font-size: 20px;
+  margin-bottom: 15px;
+  text-align: center;
+}
+
 #search {
   width: 100%;
   padding: 10px;
@@ -201,6 +207,14 @@ body.dark-mode {
 
 body.dark-mode .container {
   background-color: #1e1e1e;
+}
+
+body.dark-mode #daily-term {
+  color: #fff;
+}
+
+body.dark-mode #daily-term a {
+  color: #66b2ff;
 }
 
 body.dark-mode #search {


### PR DESCRIPTION
## Summary
- Compute a deterministic "Term of the Day" based on the current date.
- Display the daily term above the search bar with a link to its definition.
- Update random term selection to exclude the daily term and add styling for the new section.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4a97d62248328a04a53eb0ef2f7dd