### PR TITLE
Add Content Security Policy and SRI for CDN resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # CyberSecuirtyDictionary
 https://alex-unnippillil.github.io/CyberSecuirtyDictionary/
 
-
 ![image](https://github.com/Alex-Unnippillil/CyberSecuirtyDictionary/assets/24538548/c5a54c56-babb-485d-b01c-4fdfb186325b)
 
+## Security
+
+This project sets a strict Content Security Policy to limit where resources can load from.
+
+```
+Content-Security-Policy: default-src 'self'; script-src 'self' https://cdn.jsdelivr.net; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com;
+```
+
+The policy is applied via a `<meta http-equiv="Content-Security-Policy">` tag in `index.html`. When deploying, you may set the same value as an HTTP response header.

--- a/index.html
+++ b/index.html
@@ -2,15 +2,16 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.jsdelivr.net; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com;">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Cyber Security Dictionary</title>
   <link rel="stylesheet" href="styles.css">
-  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet" integrity="sha384-QLtLsWkm4K1LJIx85AECMgBdNWyYx3d9pykqVnGenPZjRVss9IMhyxjKBYIGSKHV" crossorigin="anonymous">
 </head>
 <body>
   <main class="container">
     <h1>Cyber Security Dictionary</h1>
-    <div id="definition-container" style="display: none;"></div>
+    <div id="definition-container"></div>
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">
 
@@ -24,6 +25,7 @@
   </main>
   <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
 
+  <script src="https://cdn.jsdelivr.net/npm/fuse.js@6.6.2/dist/fuse.min.js" integrity="sha384-zPE55eyESN+FxCWGEnlNxGyAPJud6IZ6TtJmXb56OFRGhxZPN4akj9rjA3gw5Qqa" crossorigin="anonymous"></script>
   <script src="script.js"></script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -84,6 +84,7 @@ body.dark-mode mark {
 }
 
 #definition-container {
+  display: none;
   padding: 20px;
   background-color: #f2f2f2;
   border-radius: 5px;


### PR DESCRIPTION
## Summary
- enforce HTTPS loading with SRI for Google Fonts and Fuse.js
- add Content-Security-Policy meta tag and document it in the README
- move inline hidden style into CSS for CSP compatibility

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4a97fb7648328b2ce44dea86992ae