### PR TITLE
docs: enhance README with setup and guidelines

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,11 @@
+# Code of Conduct
+
+We are committed to providing a welcoming and inspiring community for all. Participants are expected to:
+
+- Be respectful and considerate.
+- Refrain from harassing or discriminatory behavior.
+- Gracefully accept constructive criticism.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project maintainers.
+
+This code of conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+# Contributing
+
+Thank you for considering contributing to CyberSecuirtyDictionary! To propose changes:
+
+1. Fork the repository and create a new branch for your feature or fix.
+2. Make your changes and ensure any tests or linters pass.
+3. Commit your work with clear messages and open a pull request.
+4. Describe the motivation for the change and reference any relevant issues.
+
+By participating, you agree to abide by the [Code of Conduct](CODE_OF_CONDUCT.md).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Alex Unnippillil
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,29 @@
 # CyberSecuirtyDictionary
-https://alex-unnippillil.github.io/CyberSecuirtyDictionary/
 
+A simple web-based dictionary of common cybersecurity terms.
+
+https://alex-unnippillil.github.io/CyberSecuirtyDictionary/
 
 ![image](https://github.com/Alex-Unnippillil/CyberSecuirtyDictionary/assets/24538548/c5a54c56-babb-485d-b01c-4fdfb186325b)
 
+## Overview
+
+This project provides quick definitions for cybersecurity terminology using a lightweight HTML, CSS and JavaScript interface backed by a JSON data file.
+
+## Local Development
+
+1. Clone the repository.
+2. Open `index.html` directly in your browser or run a local server (e.g. `python -m http.server`) and navigate to `http://localhost:8000`.
+3. Edit `data.json`, `script.js`, or `styles.css` as needed and refresh the page to see changes.
+
+## Deployment
+
+The site is deployed with GitHub Pages. Push changes to the `main` branch and GitHub Pages will rebuild the site automatically.
+
+## Contributing
+
+Contributions are welcome! Please see the [contribution guidelines](CONTRIBUTING.md) and follow our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## License
+
+Distributed under the MIT License. See [LICENSE](LICENSE) for more information.


### PR DESCRIPTION
## Summary
- add project overview, local development steps, and deployment instructions
- document contributing guidelines and code of conduct
- include MIT license and link from README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4a98456208328a9c0d582263f8d58