### PR TITLE
Add opt-in analytics modal and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,7 @@ https://alex-unnippillil.github.io/CyberSecuirtyDictionary/
 
 ![image](https://github.com/Alex-Unnippillil/CyberSecuirtyDictionary/assets/24538548/c5a54c56-babb-485d-b01c-4fdfb186325b)
 
+## Data Collection
+
+This project uses [Google Analytics 4](https://marketingplatform.google.com/about/analytics/) to collect anonymous usage statistics. Analytics is **opt-in** only. On your first visit, you will be asked whether you allow analytics cookies. If you decline, no analytics scripts are loaded and no data is sent. Consent is stored in your browser's local storage and can be reset by clearing your site data.
+

--- a/index.html
+++ b/index.html
@@ -24,6 +24,14 @@
   </main>
   <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
 
+  <div id="analytics-modal" class="modal" role="dialog" aria-modal="true">
+    <div class="modal-content">
+      <p>We use analytics to improve this site. Do you consent to anonymous analytics?</p>
+      <button id="analytics-accept">Allow</button>
+      <button id="analytics-decline">Decline</button>
+    </div>
+  </div>
+
   <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -6,6 +6,10 @@ const alphaNav = document.getElementById("alpha-nav");
 const darkModeToggle = document.getElementById("dark-mode-toggle");
 const showFavoritesToggle = document.getElementById("show-favorites");
 const favorites = new Set(JSON.parse(localStorage.getItem("favorites") || "[]"));
+const analyticsModal = document.getElementById("analytics-modal");
+const acceptAnalyticsBtn = document.getElementById("analytics-accept");
+const declineAnalyticsBtn = document.getElementById("analytics-decline");
+const GA_MEASUREMENT_ID = "G-XXXXXXXXXX"; // Replace with your GA4 Measurement ID
 
 let currentLetterFilter = "All";
 let termsData = { terms: [] };
@@ -23,6 +27,7 @@ if (darkModeToggle) {
 
 window.addEventListener("DOMContentLoaded", () => {
   loadTerms();
+  initAnalytics();
 });
 
 function loadTerms() {
@@ -63,7 +68,45 @@ function loadTerms() {
           loadTerms();
         });
       }
-    });
+  });
+}
+
+function loadAnalytics() {
+  if (window.gaLoaded) return;
+  window.gaLoaded = true;
+  const gtagScript = document.createElement("script");
+  gtagScript.async = true;
+  gtagScript.src = `https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`;
+  document.head.appendChild(gtagScript);
+
+  window.dataLayer = window.dataLayer || [];
+  function gtag() {
+    dataLayer.push(arguments);
+  }
+  window.gtag = gtag;
+  gtag("js", new Date());
+  gtag("config", GA_MEASUREMENT_ID);
+}
+
+function initAnalytics() {
+  const consent = localStorage.getItem("analyticsConsent");
+  if (consent === "true") {
+    loadAnalytics();
+  } else if (consent === null && analyticsModal) {
+    analyticsModal.style.display = "flex";
+  }
+}
+
+if (acceptAnalyticsBtn && declineAnalyticsBtn) {
+  acceptAnalyticsBtn.addEventListener("click", () => {
+    localStorage.setItem("analyticsConsent", "true");
+    analyticsModal.style.display = "none";
+    loadAnalytics();
+  });
+  declineAnalyticsBtn.addEventListener("click", () => {
+    localStorage.setItem("analyticsConsent", "false");
+    analyticsModal.style.display = "none";
+  });
 }
 
 function removeDuplicateTermsAndDefinitions() {

--- a/styles.css
+++ b/styles.css
@@ -271,3 +271,34 @@ body.dark-mode #alpha-nav button.active {
   background-color: #007bff;
   border-color: #007bff;
 }
+
+/* Analytics consent modal */
+.modal {
+  display: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.modal-content {
+  background-color: #fff;
+  padding: 20px;
+  border-radius: 5px;
+  max-width: 400px;
+  text-align: center;
+}
+
+.modal-content button {
+  margin: 5px;
+}
+
+body.dark-mode .modal-content {
+  background-color: #1e1e1e;
+  color: #fff;
+}


### PR DESCRIPTION
## Summary
- Add user consent modal for analytics and conditionally load GA4 script based on consent.
- Style modal and ensure compatibility with dark mode.
- Document optional data collection policy in README.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4a982203c83288f528c0592aa5578