### PR TITLE
Add base stylesheet with theme variables and utility classes

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,0 +1,93 @@
+:root {
+  --color-bg: #f8f9fa;
+  --color-text: #212529;
+  --color-link: #0d6efd;
+  --color-link-hover: #0a58ca;
+  --color-card-bg: #ffffff;
+  --color-badge-bg: #e9ecef;
+  --color-badge-text: #212529;
+}
+
+[data-theme="dark"] {
+  --color-bg: #121212;
+  --color-text: #f8f9fa;
+  --color-link: #79b8ff;
+  --color-link-hover: #c8e1ff;
+  --color-card-bg: #1e1e1e;
+  --color-badge-bg: #343a40;
+  --color-badge-text: #f8f9fa;
+}
+
+body {
+  margin: 0;
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  line-height: 1.6;
+}
+
+.container {
+  max-width: 72rem;
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+a {
+  color: var(--color-link);
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  color: var(--color-link-hover);
+  text-decoration: underline;
+}
+
+/* Grid and cards */
+.grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+}
+
+.card {
+  background: var(--color-card-bg);
+  border-radius: 0.5rem;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  padding: 1rem;
+}
+
+.badge {
+  display: inline-block;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.75rem;
+  background: var(--color-badge-bg);
+  color: var(--color-badge-text);
+  border-radius: 0.25rem;
+}
+
+/* Accessibility */
+.skip-link {
+  position: absolute;
+  top: 0;
+  left: 0;
+  padding: 0.5rem 1rem;
+  background: var(--color-link);
+  color: #fff;
+  transform: translateY(-100%);
+  transition: transform 0.2s;
+}
+
+.skip-link:focus {
+  transform: translateY(0);
+}
+
+/* Typography */
+h1,h2,h3,h4,h5,h6 {
+  line-height: 1.25;
+}
+
+p {
+  margin-top: 0;
+  margin-bottom: 1rem;
+}


### PR DESCRIPTION
## Summary
- add `assets/css/style.css` with light/dark theme variables
- include responsive container, link, grid card, badge, skip-link, and typography rules

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4ad5e541083288bfe0d82aaa2c67a