### PR TITLE
Add theme toggle and footer year script

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,0 +1,34 @@
+// Theme toggling and footer year update
+// Updates footer year and toggles site theme with persistence
+
+document.addEventListener('DOMContentLoaded', () => {
+  // Update footer year
+  const yearSpan = document.getElementById('year');
+  if (yearSpan) {
+    yearSpan.textContent = new Date().getFullYear();
+  }
+
+  // Theme toggle logic
+  const themeToggle = document.getElementById('theme-toggle');
+  if (!themeToggle) return;
+
+  const root = document.documentElement;
+  const storedTheme = localStorage.getItem('theme') || 'light';
+  root.setAttribute('data-theme', storedTheme);
+  document.body.classList.toggle('dark-mode', storedTheme === 'dark');
+  themeToggle.setAttribute('aria-pressed', storedTheme === 'dark');
+
+  themeToggle.addEventListener('click', () => {
+    const currentTheme = root.getAttribute('data-theme') === 'dark' ? 'dark' : 'light';
+    const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
+    root.setAttribute('data-theme', newTheme);
+    document.body.classList.toggle('dark-mode', newTheme === 'dark');
+    themeToggle.setAttribute('aria-pressed', newTheme === 'dark');
+    try {
+      localStorage.setItem('theme', newTheme);
+    } catch (e) {
+      // Ignore storage errors
+    }
+  });
+});
+

--- a/index.html
+++ b/index.html
@@ -16,15 +16,19 @@
 
     <button id="random-term" aria-label="Show random term">Random Term</button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+    <button id="theme-toggle" aria-label="Toggle dark mode" aria-pressed="false">Toggle Dark Mode</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 
     <ul id="terms-list"></ul>
   </main>
   <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+  <footer>
+    <p>&copy; <span id="year"></span></p>
+  </footer>
 
   <script src="script.js"></script>
+  <script src="assets/js/app.js"></script>
 </body>
 </html>
 

--- a/styles.css
+++ b/styles.css
@@ -102,7 +102,7 @@ body.dark-mode mark {
 
 
 /* Controls styling */
-#dark-mode-toggle {
+#theme-toggle {
   margin-top: 10px;
   padding: 10px;
   border: 1px solid #ccc;
@@ -112,7 +112,7 @@ body.dark-mode mark {
   cursor: pointer;
 }
 
-#dark-mode-toggle:hover {
+#theme-toggle:hover {
   background-color: #0056b3;
 }
 
@@ -209,7 +209,7 @@ body.dark-mode #search {
   border-color: #333;
 }
 
-body.dark-mode #dark-mode-toggle {
+body.dark-mode #theme-toggle {
   background-color: #333;
   color: #fff;
   border-color: #555;


### PR DESCRIPTION
## Summary
- Add `assets/js/app.js` to update footer year and persist theme choice
- Replace dark mode button with `#theme-toggle` and add footer in `index.html`
- Style new theme toggle button

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4ad5fd9f08328bd6202cbe7584ca1