### PR TITLE
Add Node build script for static site generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/build.js
+++ b/build.js
@@ -1,0 +1,103 @@
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const root = __dirname;
+const dist = path.join(root, 'dist');
+
+function slugify(str){
+  return str
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g,'-')
+    .replace(/^-+|-+$/g,'');
+}
+
+function loadYaml(file){
+  const p = path.join(root, file);
+  return yaml.load(fs.readFileSync(p, 'utf8'));
+}
+
+const config = loadYaml('config.yml');
+const termsData = loadYaml('terms.yml');
+const terms = termsData.map(t => ({...t, slug: slugify(t.term)}));
+
+// group by categories
+const categories = {};
+terms.forEach(t => {
+  if(!categories[t.category]) categories[t.category] = [];
+  categories[t.category].push(t);
+});
+
+// clean dist
+fs.rmSync(dist, {recursive:true, force:true});
+fs.mkdirSync(dist, {recursive:true});
+fs.mkdirSync(path.join(dist, 'terms'), {recursive:true});
+fs.mkdirSync(path.join(dist, 'categories'), {recursive:true});
+fs.mkdirSync(path.join(dist, 'search'), {recursive:true});
+fs.mkdirSync(path.join(dist, 'about'), {recursive:true});
+
+// copy assets
+['styles.css','script.js'].forEach(file => {
+  const src = path.join(root, file);
+  if(fs.existsSync(src)){
+    fs.copyFileSync(src, path.join(dist, file));
+  }
+});
+
+// basic html template
+function pageTemplate(title, body){
+  return `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"><title>${title}</title><link rel="stylesheet" href="/styles.css"></head><body><h1>${title}</h1>${body}</body></html>`;
+}
+
+// home page listing terms
+const homeBody = `<ul>` + terms.map(t=>`<li><a href="/terms/${t.slug}.html">${t.term}</a> - ${t.definition}</li>`).join('\n') + `</ul>`;
+fs.writeFileSync(path.join(dist, 'index.html'), pageTemplate(config.title, homeBody));
+
+// term pages
+terms.forEach(t=>{
+  const body = `<p>${t.definition}</p><p>Category: <a href="/categories/${slugify(t.category)}.html">${t.category}</a></p>`;
+  fs.writeFileSync(path.join(dist, 'terms', `${t.slug}.html`), pageTemplate(t.term, body));
+});
+
+// categories index page
+const catList = `<ul>` + Object.keys(categories).map(c => `<li><a href="/categories/${slugify(c)}.html">${c}</a> (${categories[c].length})</li>`).join('\n') + `</ul>`;
+fs.writeFileSync(path.join(dist, 'categories', 'index.html'), pageTemplate('Categories', catList));
+
+// category pages
+Object.keys(categories).forEach(c => {
+  const body = `<ul>` + categories[c].map(t => `<li><a href="/terms/${t.slug}.html">${t.term}</a></li>`).join('\n') + `</ul>`;
+  fs.writeFileSync(path.join(dist, 'categories', `${slugify(c)}.html`), pageTemplate(c, body));
+});
+
+// search page
+const searchBody = '<p>Search coming soon.</p>';
+fs.writeFileSync(path.join(dist, 'search', 'index.html'), pageTemplate('Search', searchBody));
+
+// about page
+const aboutBody = `<p>${config.description}</p><p>Author: ${config.author}</p>`;
+fs.writeFileSync(path.join(dist, 'about', 'index.html'), pageTemplate('About', aboutBody));
+
+// 404 page
+const notFoundBody = '<p>Page not found.</p>';
+fs.writeFileSync(path.join(dist, '404.html'), pageTemplate('404', notFoundBody));
+
+// robots.txt
+fs.writeFileSync(path.join(dist, 'robots.txt'), 'User-agent: *\nAllow: /');
+
+// sitemap.xml
+const urls = [`${config.baseUrl}/`, ...terms.map(t => `${config.baseUrl}/terms/${t.slug}.html`), `${config.baseUrl}/categories/`, ...Object.keys(categories).map(c => `${config.baseUrl}/categories/${slugify(c)}.html`), `${config.baseUrl}/search/`, `${config.baseUrl}/about/`];
+const sitemap = `<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">` + urls.map(u => `<url><loc>${u}</loc></url>`).join('') + `</urlset>`;
+fs.writeFileSync(path.join(dist, 'sitemap.xml'), sitemap);
+
+// manifest.json
+const manifest = { name: config.title, short_name: config.title, start_url: '/', display: 'standalone', icons: [] };
+fs.writeFileSync(path.join(dist, 'manifest.json'), JSON.stringify(manifest, null, 2));
+
+// service worker
+const sw = `self.addEventListener('install', () => self.skipWaiting());\nself.addEventListener('activate', e => e.waitUntil(clients.claim()));`;
+fs.writeFileSync(path.join(dist, 'service-worker.js'), sw);
+
+// terms.json
+fs.writeFileSync(path.join(dist, 'terms.json'), JSON.stringify(terms, null, 2));
+
+console.log('Build complete');

--- a/config.yml
+++ b/config.yml
@@ -1,0 +1,4 @@
+title: "Cyber Security Dictionary"
+description: "Glossary of cyber security terms"
+baseUrl: "https://example.com"
+author: "Example Author"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,34 @@
+{
+  "name": "cybersecuirtydictionary",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "cybersecuirtydictionary",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "js-yaml": "^4.1.0"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "cybersecuirtydictionary",
+  "version": "1.0.0",
+  "description": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/",
+  "main": "script.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "node build.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "js-yaml": "^4.1.0"
+  }
+}

--- a/terms.yml
+++ b/terms.yml
@@ -1,0 +1,12 @@
+- term: Phishing
+  definition: An attempt to trick individuals into revealing sensitive information through fraudulent messages.
+  category: Attack
+- term: Endpoint Security
+  definition: Protecting devices like laptops and phones from threats.
+  category: Defense
+- term: Malware
+  definition: Malicious software designed to harm or exploit systems.
+  category: Attack
+- term: Encryption
+  definition: The process of converting data into a coded form to prevent unauthorized access.
+  category: Defense


### PR DESCRIPTION
## Summary
- add YAML-driven build pipeline that slugifies terms, copies assets, and outputs static pages, sitemap, manifest and more
- include sample configuration and term data in YAML
- expose npm `build` script to run the generator

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b4ad6ae1508328be83c9aa85a13124