### PR TITLE
feat: add search script and page

### DIFF
--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -1,0 +1,77 @@
+(function(){
+  const resultsContainer = document.getElementById('results');
+  const searchInput = document.getElementById('search-box');
+  let terms = [];
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const baseUrl = window.__BASE_URL__ || '';
+    fetch(`${baseUrl}/terms.json`)
+      .then(r => r.ok ? r.json() : Promise.reject(r.statusText))
+      .then(data => {
+        // terms.json may either be an array or object with terms property
+        terms = Array.isArray(data) ? data : (data.terms || []);
+      })
+      .catch(err => {
+        console.error('Failed to load terms.json', err);
+      });
+
+    searchInput.addEventListener('input', handleSearch);
+  });
+
+  function handleSearch(){
+    const query = searchInput.value.trim().toLowerCase();
+    resultsContainer.innerHTML = '';
+    if(!query){
+      return;
+    }
+    const matches = terms
+      .map(term => ({ term, score: score(term, query) }))
+      .filter(item => item.score > 0)
+      .sort((a,b) => b.score - a.score);
+
+    matches.forEach(({ term }) => {
+      resultsContainer.appendChild(renderCard(term));
+    });
+  }
+
+  function score(term, query){
+    let s = 0;
+    const name = (term.name || term.term || '').toLowerCase();
+    const def = (term.definition || '').toLowerCase();
+    const category = (term.category || '').toLowerCase();
+    const syns = (term.synonyms || []).map(s=>s.toLowerCase());
+    if(name.includes(query)) s += 3;
+    if(def.includes(query)) s += 1;
+    if(category.includes(query)) s += 1;
+    if(syns.some(syn => syn.includes(query))) s += 2;
+    return s;
+  }
+
+  function renderCard(term){
+    const card = document.createElement('div');
+    card.className = 'result-card';
+
+    const title = document.createElement('h3');
+    title.textContent = term.name || term.term || '';
+    card.appendChild(title);
+
+    if(term.category){
+      const cat = document.createElement('p');
+      cat.className = 'category';
+      cat.textContent = term.category;
+      card.appendChild(cat);
+    }
+
+    const def = document.createElement('p');
+    def.textContent = term.definition || '';
+    card.appendChild(def);
+
+    if(term.synonyms && term.synonyms.length){
+      const syn = document.createElement('p');
+      syn.className = 'synonyms';
+      syn.textContent = `Synonyms: ${term.synonyms.join(', ')}`;
+      card.appendChild(syn);
+    }
+    return card;
+  }
+})();

--- a/search.html
+++ b/search.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Search</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <main class="container">
+    <h1>Search</h1>
+    <input id="search-box" type="text" placeholder="Search terms..." />
+    <div id="results"></div>
+  </main>
+  <script>
+    window.__BASE_URL__ = window.__BASE_URL__ || '';
+  </script>
+  <script src="assets/js/search.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add search page with base URL support
- implement search.js fetching terms.json and rendering scored result cards

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4ad6c90748328a9387c3788bf296f