### PR TITLE
Improve accessibility with landmarks and focus styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,10 +8,15 @@
   <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet">
 </head>
 <body>
-  <main class="container">
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <header class="container">
     <h1>Cyber Security Dictionary</h1>
-    <div id="definition-container" style="display: none;"></div>
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
+  </header>
+
+  <main id="main-content" class="container">
+    <div id="definition-container" style="display: none;"></div>
     <input type="text" id="search" placeholder="Search...">
 
     <button id="random-term" aria-label="Show random term">Random Term</button>
@@ -22,7 +27,12 @@
 
     <ul id="terms-list"></ul>
   </main>
+
   <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+
+  <footer class="container">
+    <p>&copy; 2023 Cyber Security Dictionary</p>
+  </footer>
 
   <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -136,10 +136,12 @@ function populateTermsList() {
       const matchesLetter =
         currentLetterFilter === "All" || item.term.charAt(0).toUpperCase() === currentLetterFilter;
       if (matchesSearch && matchesFavorites && matchesLetter) {
-        const termDiv = document.createElement("div");
+        const termLi = document.createElement("li");
+        const termDiv = document.createElement("button");
         termDiv.classList.add("dictionary-item");
+        termDiv.type = "button";
 
-        const termHeader = document.createElement("h3");
+        const termHeader = document.createElement("h2");
         if (searchValue) {
           const escaped = searchValue.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
           const regex = new RegExp(`(${escaped})`, "gi");
@@ -148,8 +150,10 @@ function populateTermsList() {
           termHeader.textContent = item.term;
         }
 
-        const star = document.createElement("span");
+        const star = document.createElement("button");
         star.classList.add("favorite-star");
+        star.type = "button";
+        star.setAttribute("aria-label", `Toggle favorite for ${item.term}`);
         star.textContent = "★";
         if (favorites.has(item.term)) {
           star.classList.add("favorited");
@@ -173,14 +177,15 @@ function populateTermsList() {
           displayDefinition(item);
         });
 
-        termsList.appendChild(termDiv);
+        termLi.appendChild(termDiv);
+        termsList.appendChild(termLi);
       }
     });
 }
 
 function displayDefinition(term) {
   definitionContainer.style.display = "block";
-  definitionContainer.innerHTML = `<h3>${term.term}</h3><p>${term.definition}</p>`;
+  definitionContainer.innerHTML = `<h2>${term.term}</h2><p>${term.definition}</p>`;
   window.location.hash = encodeURIComponent(term.term);
 }
 

--- a/styles.css
+++ b/styles.css
@@ -6,6 +6,34 @@ body {
   padding: 0;
 }
 
+a:focus,
+button:focus,
+input:focus,
+[tabindex]:focus {
+  outline: 3px solid #007bff;
+  outline-offset: 2px;
+}
+
+.skip-link {
+  position: absolute;
+  left: -999px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+
+.skip-link:focus {
+  left: 0;
+  top: 0;
+  width: auto;
+  height: auto;
+  background: #007bff;
+  color: #fff;
+  padding: 8px;
+  z-index: 100;
+}
+
 .container {
   max-width: 800px;
   margin: 0 auto;
@@ -31,22 +59,6 @@ ul {
   margin: 0;
 }
 
-li {
-  padding: 10px 20px;
-  background-color: #fff;
-  border-bottom: 1px solid #e0e0e0;
-  cursor: pointer;
-  transition: background-color 0.2s;
-}
-
-li:last-child {
-  border-bottom: none;
-}
-
-li:hover {
-  background-color: #f5f5f5;
-}
-
 mark {
   background-color: yellow;
   color: inherit;
@@ -57,6 +69,7 @@ body.dark-mode mark {
   color: #000;
 }
 
+
 .dictionary-item {
   margin-bottom: 20px;
   padding: 10px;
@@ -64,9 +77,12 @@ body.dark-mode mark {
   border-radius: 5px;
   cursor: pointer;
   transition: transform 0.2s;
+  background-color: #fff;
+  width: 100%;
+  text-align: left;
 }
 
-.dictionary-item h3 {
+.dictionary-item h2 {
   font-size: 24px;
   margin: 0;
   padding-bottom: 10px;
@@ -133,6 +149,14 @@ label {
   cursor: pointer;
   margin-left: 5px;
   transition: color 0.2s;
+  background: none;
+  border: none;
+  padding: 10px;
+  width: 48px;
+  height: 48px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .favorite-star:hover,


### PR DESCRIPTION
## Summary
- add skip link and semantic header/nav/main/footer structure
- introduce visible focus outlines and accessible favorite controls
- make term entries keyboard-friendly

## Testing
- `npx --yes lighthouse http://localhost:8000 --only-categories=accessibility --quiet --chrome-flags="--headless --no-sandbox" --output=json --output-path=lighthouse.json` (score 0.95)


------
https://chatgpt.com/codex/tasks/task_e_68b4ad6ec8e083289acfa170d340e895