### PR TITLE
feat: add service worker for offline support

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,0 +1,5 @@
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/sw.js');
+  });
+}

--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
   <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
 
   <script src="script.js"></script>
+  <script src="assets/js/app.js"></script>
 </body>
 </html>
 

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,36 @@
+const CACHE_NAME = 'csd-cache-v1';
+const URLS_TO_CACHE = [
+  '/',
+  '/index.html',
+  '/styles.css',
+  '/script.js',
+  '/data.json'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(URLS_TO_CACHE))
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(
+        keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key))
+      )
+    )
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response =>
+      response || fetch(event.request).catch(() => {
+        if (event.request.mode === 'navigate') {
+          return caches.match('/index.html');
+        }
+      })
+    )
+  );
+});


### PR DESCRIPTION
## Summary
- register service worker on load if supported
- add service worker to cache app assets for offline use

## Testing
- `python3 -m http.server 3000 & SERVER_PID=$! && sleep 1 && node test-sw.js && kill $SERVER_PID` *(with required dependencies installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b4ad6e40608328a308abc704752874