### PR TITLE
Add canonical link to generated pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
   <title>Cyber Security Dictionary</title>
   <link rel="stylesheet" href="styles.css">
   <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="canonical" id="canonical-link" href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/">
 </head>
 <body>
   <main class="container">

--- a/script.js
+++ b/script.js
@@ -6,6 +6,8 @@ const alphaNav = document.getElementById("alpha-nav");
 const darkModeToggle = document.getElementById("dark-mode-toggle");
 const showFavoritesToggle = document.getElementById("show-favorites");
 const favorites = new Set(JSON.parse(localStorage.getItem("favorites") || "[]"));
+const siteUrl = "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/";
+const canonicalLink = document.getElementById("canonical-link");
 
 let currentLetterFilter = "All";
 let termsData = { terms: [] };
@@ -182,12 +184,21 @@ function displayDefinition(term) {
   definitionContainer.style.display = "block";
   definitionContainer.innerHTML = `<h3>${term.term}</h3><p>${term.definition}</p>`;
   window.location.hash = encodeURIComponent(term.term);
+  if (canonicalLink) {
+    canonicalLink.setAttribute(
+      "href",
+      `${siteUrl}#${encodeURIComponent(term.term)}`
+    );
+  }
 }
 
 function clearDefinition() {
   definitionContainer.style.display = "none";
   definitionContainer.innerHTML = "";
   history.replaceState(null, "", window.location.pathname + window.location.search);
+  if (canonicalLink) {
+    canonicalLink.setAttribute("href", siteUrl);
+  }
 }
 
 function showRandomTerm() {


### PR DESCRIPTION
## Summary
- Include canonical `<link>` in page head to reference full site URL
- Dynamically update canonical link as dictionary terms or home view are shown

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4ad70608883289a4b925054a27a9d