### PR TITLE
Add OG and Twitter meta tags to layout

### DIFF
--- a/layout.html
+++ b/layout.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Cyber Security Dictionary</title>
+  <link rel="stylesheet" href="styles.css">
+  <meta property="og:title" content="Cyber Security Dictionary">
+  <meta property="og:description" content="An interactive dictionary for cyber security terms.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/">
+  <meta property="og:image" content="https://github.com/Alex-Unnippillil/CyberSecuirtyDictionary/assets/24538548/c5a54c56-babb-485d-b01c-4fdfb186325b">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Cyber Security Dictionary">
+  <meta name="twitter:description" content="An interactive dictionary for cyber security terms.">
+  <meta name="twitter:url" content="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/">
+  <meta name="twitter:image" content="https://github.com/Alex-Unnippillil/CyberSecuirtyDictionary/assets/24538548/c5a54c56-babb-485d-b01c-4fdfb186325b">
+</head>
+<body>
+  <main class="container">
+    <h1>Cyber Security Dictionary</h1>
+    <div id="definition-container" style="display: none;"></div>
+    <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
+    <input type="text" id="search" placeholder="Search...">
+
+    <button id="random-term" aria-label="Show random term">Random Term</button>
+
+    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+    <input type="checkbox" id="show-favorites" aria-label="Show favorites">
+    <label for="show-favorites">Show Favorites</label>
+
+    <ul id="terms-list"></ul>
+  </main>
+  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+
+  <script src="script.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add layout.html with Open Graph and Twitter card meta tags for better sharing previews

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4ad718ef88328a454d3828a6c9376