### PR TITLE
Add offline fallback via service worker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/build.js
+++ b/build.js
@@ -1,0 +1,30 @@
+const fs = require('fs');
+const path = require('path');
+
+const distDir = path.join(__dirname, 'dist');
+if (!fs.existsSync(distDir)) {
+  fs.mkdirSync(distDir);
+}
+
+const filesToCopy = ['index.html', 'styles.css', 'script.js', 'data.json', 'service-worker.js'];
+filesToCopy.forEach((file) => {
+  const srcPath = path.join(__dirname, file);
+  if (fs.existsSync(srcPath)) {
+    fs.copyFileSync(srcPath, path.join(distDir, file));
+  }
+});
+
+const offlineHtml = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Offline</title>
+</head>
+<body>
+  <h1>Offline</h1>
+  <p>You are currently offline. Please reconnect to use the Cyber Security Dictionary.</p>
+</body>
+</html>`;
+
+fs.writeFileSync(path.join(distDir, 'offline.html'), offlineHtml);
+console.log('Build complete');

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "cybersecuritydictionary",
+  "version": "1.0.0",
+  "description": "",
+  "scripts": {
+    "build": "node build.js"
+  }
+}

--- a/script.js
+++ b/script.js
@@ -243,3 +243,9 @@ scrollBtn.addEventListener("click", () =>
 
 definitionContainer.addEventListener("click", clearDefinition);
 
+
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('service-worker.js');
+  });
+}

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,38 @@
+const CACHE_NAME = 'csd-cache-v1';
+const OFFLINE_URL = 'offline.html';
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) =>
+      cache.addAll([
+        '/',
+        'index.html',
+        'styles.css',
+        'script.js',
+        'data.json',
+        OFFLINE_URL,
+      ])
+    )
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(
+        keys.filter((key) => key !== CACHE_NAME).map((key) => caches.delete(key))
+      )
+    )
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  event.respondWith(
+    caches.match(event.request).then((cached) => {
+      return (
+        cached ||
+        fetch(event.request).catch(() => caches.match(OFFLINE_URL))
+      );
+    })
+  );
+});


### PR DESCRIPTION
## Summary
- generate `dist/offline.html` with a friendly offline message during build
- add service worker to cache assets and serve `offline.html` when requests miss cache and network
- register service worker on page load

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b4ad7316a48328bee460094ef979bf