### PR TITLE
feat: support draft terms in build process

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,0 +1,48 @@
+const fs = require('fs');
+const path = require('path');
+
+const dataPath = path.join(__dirname, 'data.json');
+const data = JSON.parse(fs.readFileSync(dataPath, 'utf8'));
+
+const termsDir = path.join(__dirname, 'terms');
+fs.mkdirSync(termsDir, { recursive: true });
+
+const baseUrl = 'https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms';
+
+const urls = [];
+
+function slugify(term) {
+  return term
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+for (const term of data.terms) {
+  const slug = slugify(term.term);
+  const metaRobots = term.draft ? '<meta name="robots" content="noindex">' : '';
+  const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>${term.term}</title>
+  ${metaRobots}
+</head>
+<body>
+  <h1>${term.term}</h1>
+  <p>${term.definition}</p>
+</body>
+</html>`;
+  fs.writeFileSync(path.join(termsDir, `${slug}.html`), html);
+  if (!term.draft) {
+    urls.push(`${baseUrl}/${slug}.html`);
+  }
+}
+
+const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urls.map(u => `  <url><loc>${u}</loc></url>`).join('\n')}
+</urlset>
+`;
+
+fs.writeFileSync(path.join(__dirname, 'sitemap.xml'), sitemap);


### PR DESCRIPTION
## Summary
- add build script generating term pages and sitemap
- support `draft: true` to add noindex meta and skip sitemap

## Testing
- `node build.js`
- `cat terms/phishing.html`
- `grep -n 'phishing.html' sitemap.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b4ad7a00988328b11f51b4ded32a57