### PR TITLE
Improve category badge contrast for light and dark modes

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -144,6 +144,16 @@ label {
   color: #ffd700;
 }
 
+/* Category badge styles */
+.badge {
+  display: inline-block;
+  padding: 2px 8px;
+  font-size: 0.75em;
+  border-radius: 12px;
+  background-color: #0056b3;
+  color: #fff;
+}
+
 /* Alphabet navigation styles */
 #alpha-nav {
   display: flex;
@@ -254,6 +264,11 @@ body.dark-mode .favorite-star:focus {
 
 body.dark-mode .favorited {
   color: #ffd700;
+}
+
+body.dark-mode .badge {
+  background-color: #1e90ff;
+  color: #000;
 }
 
 body.dark-mode #alpha-nav button {


### PR DESCRIPTION
## Summary
- add `.badge` styling with accessible colors
- adjust dark mode badge styling for legibility

## Testing
- `npm test`
- `node -e "function lum(c){c=c.replace('#','');let r=parseInt(c.substr(0,2),16)/255,g=parseInt(c.substr(2,2),16)/255,b=parseInt(c.substr(4,2),16)/255;[r,g,b]=[r,g,b].map(v=>v<=0.03928?v/12.92:Math.pow((v+0.055)/1.055,2.4));return 0.2126*r+0.7152*g+0.0722*b;} function contrast(c1,c2){let L1=lum(c1); let L2=lum(c2); if(L1<L2)[L1,L2]=[L2,L1]; return (L1+0.05)/(L2+0.05);} console.log('contrast light badge',contrast('#0056b3','#ffffff')); console.log('contrast dark badge',contrast('#1e90ff','#000000'));"`

------
https://chatgpt.com/codex/tasks/task_e_68b4ad757c648328b18af12e06bf2df8