### PR TITLE
Add about page with security resource links

### DIFF
--- a/templates/about.html
+++ b/templates/about.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>About</title>
+</head>
+<body>
+  <h1>About this project</h1>
+  <p>Useful security resources:</p>
+  <ul>
+    <li><a href="https://nvlpubs.nist.gov/nistpubs/ir/2020/NIST.IR.7298r3.pdf">NISTIR 7298 r3</a></li>
+    <li><a href="https://nvd.nist.gov/">National Vulnerability Database (NVD)</a></li>
+    <li><a href="https://cve.mitre.org/">Common Vulnerabilities and Exposures (CVE)</a></li>
+    <li><a href="https://cwe.mitre.org/">Common Weakness Enumeration (CWE)</a></li>
+    <li><a href="https://www.first.org/cvss/v4-0/">CVSS v4.0</a></li>
+    <li><a href="https://attack.mitre.org/">MITRE ATT&amp;CK</a></li>
+    <li><a href="https://owasp.org/Top10/">OWASP Top 10</a></li>
+  </ul>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add `templates/about.html` with links to key cybersecurity standards and reference sites (NISTIR 7298 r3, NVD, CVE, CWE, CVSS v4.0, MITRE ATT&CK, OWASP Top 10)

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4ad76917883289385efc0764e3471