### PR TITLE
Add definition guidelines page and navigation link

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
 <body>
   <main class="container">
     <h1>Cyber Security Dictionary</h1>
+    <nav class="site-nav"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
     <div id="definition-container" style="display: none;"></div>
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">

--- a/templates/guidelines.html
+++ b/templates/guidelines.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Definition Guidelines</title>
+  <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+  <main class="container">
+    <h1>Definition Guidelines</h1>
+    <p>Each entry in this dictionary should offer an original explanation of a term rather than copying text from other sources.</p>
+    <p>Write definitions in your own words and back them with reputable sources. Include citations or links to the materials that informed your description.</p>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add `templates/guidelines.html` page outlining expectations for original, source-backed definitions
- Link new guidelines page in site navigation on the home page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4ad7735988328ab1a10b2c19eecc8