### PR TITLE
ci: set base and site URLs for user pages

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -21,6 +21,10 @@ concurrency:
   group: "pages"
   cancel-in-progress: false
 
+env:
+  BASE_URL: /
+  SITE_URL: https://${{ github.repository_owner }}.github.io/
+
 jobs:
   # Build job
   build:

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -21,6 +21,10 @@ concurrency:
   group: "pages"
   cancel-in-progress: false
 
+env:
+  BASE_URL: /
+  SITE_URL: https://${{ github.repository_owner }}.github.io/
+
 jobs:
   # Single deploy job since we're just deploying
   deploy:


### PR DESCRIPTION
## Summary
- add global BASE_URL and SITE_URL env vars to workflows for <username>.github.io deployments

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68b4b9a633b48328ac4b505d96708441