### PR TITLE
Improve accessibility and contrast

### DIFF
--- a/script.js
+++ b/script.js
@@ -136,10 +136,10 @@ function populateTermsList() {
       const matchesLetter =
         currentLetterFilter === "All" || item.term.charAt(0).toUpperCase() === currentLetterFilter;
       if (matchesSearch && matchesFavorites && matchesLetter) {
-        const termDiv = document.createElement("div");
-        termDiv.classList.add("dictionary-item");
+        const termItem = document.createElement("li");
+        termItem.classList.add("dictionary-item");
 
-        const termHeader = document.createElement("h3");
+        const termHeader = document.createElement("h2");
         if (searchValue) {
           const escaped = searchValue.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
           const regex = new RegExp(`(${escaped})`, "gi");
@@ -163,24 +163,24 @@ function populateTermsList() {
           }
         });
         termHeader.appendChild(star);
-        termDiv.appendChild(termHeader);
+        termItem.appendChild(termHeader);
 
         const definitionPara = document.createElement("p");
         definitionPara.textContent = item.definition;
-        termDiv.appendChild(definitionPara);
+        termItem.appendChild(definitionPara);
 
-        termDiv.addEventListener("click", () => {
+        termItem.addEventListener("click", () => {
           displayDefinition(item);
         });
 
-        termsList.appendChild(termDiv);
+        termsList.appendChild(termItem);
       }
     });
 }
 
 function displayDefinition(term) {
   definitionContainer.style.display = "block";
-  definitionContainer.innerHTML = `<h3>${term.term}</h3><p>${term.definition}</p>`;
+  definitionContainer.innerHTML = `<h2>${term.term}</h2><p>${term.definition}</p>`;
   window.location.hash = encodeURIComponent(term.term);
 }
 

--- a/styles.css
+++ b/styles.css
@@ -31,21 +31,6 @@ ul {
   margin: 0;
 }
 
-li {
-  padding: 10px 20px;
-  background-color: #fff;
-  border-bottom: 1px solid #e0e0e0;
-  cursor: pointer;
-  transition: background-color 0.2s;
-}
-
-li:last-child {
-  border-bottom: none;
-}
-
-li:hover {
-  background-color: #f5f5f5;
-}
 
 mark {
   background-color: yellow;
@@ -66,7 +51,7 @@ body.dark-mode mark {
   transition: transform 0.2s;
 }
 
-.dictionary-item h3 {
+.dictionary-item h2 {
   font-size: 24px;
   margin: 0;
   padding-bottom: 10px;
@@ -107,13 +92,13 @@ body.dark-mode mark {
   padding: 10px;
   border: 1px solid #ccc;
   border-radius: 5px;
-  background-color: #007bff;
+  background-color: #0056b3;
   color: #fff;
   cursor: pointer;
 }
 
 #dark-mode-toggle:hover {
-  background-color: #0056b3;
+  background-color: #00408f;
 }
 
 label {
@@ -168,8 +153,8 @@ label {
 }
 
 #alpha-nav button.active {
-  background-color: #007bff;
-  border-color: #007bff;
+  background-color: #0056b3;
+  border-color: #0056b3;
   color: #fff;
 }
 
@@ -181,7 +166,7 @@ label {
   right: 20px;
   font-size: 20px;
   border: none;
-  background-color: #007bff;
+  background-color: #0056b3;
   color: #fff;
   cursor: pointer;
   width: 40px;
@@ -190,7 +175,7 @@ label {
 }
 
 #scrollToTopBtn:hover {
-  background-color: #0056b3;
+  background-color: #00408f;
 }
 
 /* Dark Mode styles */
@@ -215,21 +200,13 @@ body.dark-mode #dark-mode-toggle {
   border-color: #555;
 }
 
-body.dark-mode li {
-  background-color: #1e1e1e;
-  border-bottom: 1px solid #333;
-}
-
-body.dark-mode li:hover {
-  background-color: #333;
-}
 
 body.dark-mode .dictionary-item {
   background-color: #1e1e1e;
   border-color: #333;
 }
 
-body.dark-mode .dictionary-item h3 {
+body.dark-mode .dictionary-item h2 {
   color: #fff;
   border-bottom-color: #333;
 }
@@ -268,6 +245,6 @@ body.dark-mode #alpha-nav button:focus {
 }
 
 body.dark-mode #alpha-nav button.active {
-  background-color: #007bff;
-  border-color: #007bff;
+  background-color: #0056b3;
+  border-color: #0056b3;
 }


### PR DESCRIPTION
## Summary
- switch term rendering to semantic list items and `<h2>` headings for better structure
- strengthen button colors and update dark mode styles to meet contrast guidelines

## Testing
- `CHROME_PATH=$(which google-chrome-stable) npx -y lighthouse http://localhost:3000 --output=json --output-path=./lighthouse-report.json --chrome-flags="--headless --no-sandbox"`
- `jq '.categories | {performance: .performance.score, accessibility: .accessibility.score, seo: .seo.score}' lighthouse-report.json`


------
https://chatgpt.com/codex/tasks/task_e_68b4b9a733288328be59391ceb411d53