### PR TITLE
Add issue templates for term requests and bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,36 @@
+name: Bug Report
+description: Report an issue with the site.
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: input
+    id: page
+    attributes:
+      label: Affected Page or Feature
+      description: Where does the issue occur?
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Issue Description
+      description: What is the problem?
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: How can we reproduce the issue?
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Add any other information, screenshots, or logs.
+

--- a/.github/ISSUE_TEMPLATE/term_request.yml
+++ b/.github/ISSUE_TEMPLATE/term_request.yml
@@ -1,0 +1,26 @@
+name: Term Request
+description: Request a new cybersecurity term for the dictionary.
+title: "[Term]: "
+labels:
+  - term request
+body:
+  - type: input
+    id: term-name
+    attributes:
+      label: Term Name
+      description: What term should be added?
+    validations:
+      required: true
+  - type: textarea
+    id: definition
+    attributes:
+      label: Definition
+      description: Provide a clear, concise definition.
+    validations:
+      required: true
+  - type: textarea
+    id: sources
+    attributes:
+      label: Sources
+      description: Cite any sources for the definition.
+


### PR DESCRIPTION
## Summary
- add term request issue template with fields for term name, definition, and sources
- add bug report issue template for site issues

## Testing
- `npm test` *(fails: ENOENT, could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4b9ad8fac832882e251f9e1f2f911