### PR TITLE
Add IOC, TTPs, Kill Chain, and MITRE ATT&CK entries

### DIFF
--- a/data.json
+++ b/data.json
@@ -131,6 +131,22 @@
     {
       "term": "Phishing Email",
       "definition": "An email sent by attackers that appears legitimate but aims to trick recipients into revealing sensitive information or performing actions."
+    },
+    {
+      "term": "Indicator of Compromise (IOC)",
+      "definition": "Artifacts such as file hashes, IP addresses, or domains that signal potential intrusion. ATT&CK Matrix Reference: used across techniques for detecting adversary activity."
+    },
+    {
+      "term": "Tactics, Techniques, and Procedures (TTPs)",
+      "definition": "Patterns of adversary behavior. ATT&CK Matrix Reference: each TTP maps to tactics and techniques in the MITRE ATT&CK framework."
+    },
+    {
+      "term": "Cyber Kill Chain",
+      "definition": "A model describing stages of a cyber attack from reconnaissance to actions on objectives. ATT&CK Matrix Reference: stages align with ATT&CK tactics like Initial Access (TA0001) and Execution (TA0002)."
+    },
+    {
+      "term": "MITRE ATT&CK",
+      "definition": "A globally accessible knowledge base of adversary tactics and techniques organized into the ATT&CK Matrix."
     }
   ]
 }


### PR DESCRIPTION
## Summary
- expand dictionary with entries for Indicator of Compromise, Tactics Techniques and Procedures, Cyber Kill Chain, and MITRE ATT&CK
- each definition links the concept to the MITRE ATT&CK matrix

## Testing
- `python -m json.tool data.json`


------
https://chatgpt.com/codex/tasks/task_e_68b4b9b2e65c8328b4924676525a0dd1