### PR TITLE
Add security terms with references

### DIFF
--- a/data.json
+++ b/data.json
@@ -82,7 +82,8 @@
     },
     {
       "term": "Public Key Infrastructure (PKI)",
-      "definition": "A system for managing digital certificates and public-private key pairs used in asymmetric encryption."
+      "definition": "A system for managing digital certificates and public-private key pairs used in asymmetric encryption.",
+      "source": "https://csrc.nist.gov/glossary/term/public_key_infrastructure"
     },
     {
       "term": "Certificate Authority (CA)",
@@ -94,7 +95,8 @@
     },
     {
       "term": "Transport Layer Security (TLS)",
-      "definition": "A more secure successor to SSL, providing encryption and authentication for secure communication."
+      "definition": "A more secure successor to SSL, providing encryption and authentication for secure communication.",
+      "source": "https://csrc.nist.gov/glossary/term/transport_layer_security"
     },
     {
       "term": "Key Exchange",
@@ -131,6 +133,41 @@
     {
       "term": "Phishing Email",
       "definition": "An email sent by attackers that appears legitimate but aims to trick recipients into revealing sensitive information or performing actions."
+    },
+    {
+      "term": "Identity and Access Management (IAM)",
+      "definition": "A framework of policies, processes, and technologies that ensures the right individuals have appropriate access to resources.",
+      "source": "https://csrc.nist.gov/glossary/term/identity_and_access_management"
+    },
+    {
+      "term": "Multi-Factor Authentication (MFA)",
+      "definition": "An authentication method that requires two or more different factors to verify a user's identity.",
+      "source": "https://csrc.nist.gov/glossary/term/multifactor_authentication"
+    },
+    {
+      "term": "Zero Trust",
+      "definition": "A security model that assumes no implicit trust and continuously verifies users and devices before granting access.",
+      "source": "https://csrc.nist.gov/publications/detail/sp/800-207/final"
+    },
+    {
+      "term": "Cloud Security Posture Management (CSPM)",
+      "definition": "Tools and processes that continuously monitor and manage cloud configurations to reduce misconfigurations and security risks.",
+      "source": "https://cloudsecurityalliance.org/blog/2020/02/05/what-is-cloud-security-posture-management-cspm/"
+    },
+    {
+      "term": "Key Management System (KMS)",
+      "definition": "A system that generates, distributes, stores, rotates, and revokes cryptographic keys.",
+      "source": "https://csrc.nist.gov/glossary/term/key_management_service"
+    },
+    {
+      "term": "HTTP Strict Transport Security (HSTS)",
+      "definition": "A web security policy that forces browsers to use HTTPS and helps prevent protocol downgrade attacks.",
+      "source": "https://www.rfc-editor.org/rfc/rfc6797"
+    },
+    {
+      "term": "Content Security Policy (CSP)",
+      "definition": "A security standard that lets site owners control the sources of content the browser is allowed to load to mitigate injection attacks.",
+      "source": "https://www.w3.org/TR/CSP3/"
     }
   ]
 }

--- a/script.js
+++ b/script.js
@@ -169,6 +169,17 @@ function populateTermsList() {
         definitionPara.textContent = item.definition;
         termDiv.appendChild(definitionPara);
 
+        if (item.source) {
+          const sourcePara = document.createElement("p");
+          const sourceLink = document.createElement("a");
+          sourceLink.href = item.source;
+          sourceLink.textContent = "Source";
+          sourceLink.target = "_blank";
+          sourceLink.rel = "noopener noreferrer";
+          sourcePara.appendChild(sourceLink);
+          termDiv.appendChild(sourcePara);
+        }
+
         termDiv.addEventListener("click", () => {
           displayDefinition(item);
         });
@@ -180,7 +191,11 @@ function populateTermsList() {
 
 function displayDefinition(term) {
   definitionContainer.style.display = "block";
-  definitionContainer.innerHTML = `<h3>${term.term}</h3><p>${term.definition}</p>`;
+  let html = `<h3>${term.term}</h3><p>${term.definition}</p>`;
+  if (term.source) {
+    html += `<p>Source: <a href="${term.source}" target="_blank" rel="noopener noreferrer">${term.source}</a></p>`;
+  }
+  definitionContainer.innerHTML = html;
   window.location.hash = encodeURIComponent(term.term);
 }
 


### PR DESCRIPTION
## Summary
- add IAM, MFA, Zero Trust, CSPM, KMS, HSTS, CSP entries with authoritative sources
- include source links for existing PKI and TLS entries
- display term sources in the UI

## Testing
- `jq '.' data.json`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4b9b380f08328aca3761685a59eee