### PR TITLE
Add resource links to about page footer

### DIFF
--- a/templates/about.html
+++ b/templates/about.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>About - Cyber Security Dictionary</title>
+  <link rel="stylesheet" href="../styles.css">
+  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet">
+</head>
+<body>
+  <main class="container">
+    <h1>About</h1>
+    <p>This site is a resource for cyber security terms.</p>
+  </main>
+  <footer>
+    <ul>
+      <li><a href="https://csrc.nist.gov/publications/detail/nistir/7298/rev-3/final" target="_blank" rel="noopener noreferrer">NISTIR 7298 r3</a></li>
+      <li><a href="https://nvd.nist.gov/" target="_blank" rel="noopener noreferrer">NVD</a></li>
+      <li><a href="https://www.cve.org/" target="_blank" rel="noopener noreferrer">CVE</a></li>
+      <li><a href="https://cwe.mitre.org/" target="_blank" rel="noopener noreferrer">CWE</a></li>
+      <li><a href="https://www.first.org/cvss/v4-0/" target="_blank" rel="noopener noreferrer">CVSS v4.0</a></li>
+      <li><a href="https://attack.mitre.org/" target="_blank" rel="noopener noreferrer">MITRE ATT&CK</a></li>
+      <li><a href="https://owasp.org/www-project-top-ten/" target="_blank" rel="noopener noreferrer">OWASP Top 10</a></li>
+    </ul>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `templates/about.html` with links to NISTIR 7298 r3, NVD, CVE, CWE, CVSS v4.0, MITRE ATT&CK, and OWASP Top 10

## Testing
- `npm test` (fails: Could not read package.json)
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4b9b5e27083288e83f95647981735