### PR TITLE
Document sitemap URL limit in build script

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,0 +1,7 @@
+// Build script for site generation and maintenance.
+// NOTE: A single sitemap file supports up to 50,000 URLs.
+// If the dictionary grows beyond this, the sitemap should be split and
+// referenced from a sitemap index as described in the protocol at:
+// https://www.sitemaps.org/protocol.html
+
+console.log('Run build steps here');


### PR DESCRIPTION
## Summary
- add build script with note on 50k URL limit and protocol link for future sitemap splitting

## Testing
- `node build.js`
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4b9b63d5483289ea2ef2f28a02bab