### PR TITLE
Add malware and incident response references

### DIFF
--- a/data.json
+++ b/data.json
@@ -62,7 +62,8 @@
     },
     {
       "term": "Incident Response",
-      "definition": "The process of managing and mitigating the impact of a cybersecurity incident or breach."
+      "definition": "A structured approach for handling and managing the aftermath of a security breach or cyberattack to reduce damage and recovery time.",
+      "reference": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-61r2.pdf"
     },
     {
       "term": "Privilege Escalation",
@@ -131,6 +132,31 @@
     {
       "term": "Phishing Email",
       "definition": "An email sent by attackers that appears legitimate but aims to trick recipients into revealing sensitive information or performing actions."
+    },
+    {
+      "term": "Malware",
+      "definition": "Malicious software designed to infiltrate, damage, or disrupt computer systems or data.",
+      "reference": "https://csrc.nist.gov/glossary/term/malware"
+    },
+    {
+      "term": "Ransomware",
+      "definition": "Malware that encrypts a victim's data and demands payment for the decryption key.",
+      "reference": "https://www.cisa.gov/stopransomware/ransomware-101"
+    },
+    {
+      "term": "Botnet",
+      "definition": "A network of compromised computers remotely controlled by an attacker for coordinated activities.",
+      "reference": "https://en.wikipedia.org/wiki/Botnet"
+    },
+    {
+      "term": "Sandbox",
+      "definition": "An isolated environment used to execute and analyze untrusted code without risking the host system.",
+      "reference": "https://en.wikipedia.org/wiki/Sandbox_(computer_security)"
+    },
+    {
+      "term": "Honeypot",
+      "definition": "A decoy system or resource intended to lure attackers and monitor their activities.",
+      "reference": "https://en.wikipedia.org/wiki/Honeypot_(computing)"
     }
   ]
 }

--- a/script.js
+++ b/script.js
@@ -180,7 +180,11 @@ function populateTermsList() {
 
 function displayDefinition(term) {
   definitionContainer.style.display = "block";
-  definitionContainer.innerHTML = `<h3>${term.term}</h3><p>${term.definition}</p>`;
+  let html = `<h3>${term.term}</h3><p>${term.definition}</p>`;
+  if (term.reference) {
+    html += `<p class="reference">Source: <a href="${term.reference}" target="_blank" rel="noopener noreferrer">${term.reference}</a></p>`;
+  }
+  definitionContainer.innerHTML = html;
   window.location.hash = encodeURIComponent(term.term);
 }
 

--- a/styles.css
+++ b/styles.css
@@ -79,6 +79,11 @@ body.dark-mode mark {
   color: #666;
 }
 
+.reference {
+  font-size: 14px;
+  color: #888;
+}
+
 .dictionary-item:hover {
   transform: scale(1.02);
 }
@@ -236,6 +241,10 @@ body.dark-mode .dictionary-item h3 {
 
 body.dark-mode .dictionary-item p {
   color: #ccc;
+}
+
+body.dark-mode .reference {
+  color: #bbb;
 }
 
 body.dark-mode #definition-container {


### PR DESCRIPTION
## Summary
- add malware, ransomware, botnet, sandbox, honeypot, and incident response definitions with sources
- display term references in definition view
- style reference links for clarity

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4b9b4df448328bf771e8ef37d081e