### PR TITLE
docs: clarify robots.txt and noindex

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,10 @@ https://alex-unnippillil.github.io/CyberSecuirtyDictionary/
 
 ![image](https://github.com/Alex-Unnippillil/CyberSecuirtyDictionary/assets/24538548/c5a54c56-babb-485d-b01c-4fdfb186325b)
 
+## Search Engine Indexing
+
+The `robots.txt` file only controls how crawlers access your site; it does not
+prevent pages from appearing in search results. To explicitly exclude a page
+from indexing, add a `<meta name="robots" content="noindex">` tag to the page
+itself.
+


### PR DESCRIPTION
## Summary
- note that robots.txt controls crawling, not indexing
- recommend meta `noindex` tag for excluding pages from search results

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4b9b70cf48328b9724e187df4b193