### PR TITLE
feat: precache search assets and add bundle size guard

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,25 +11,25 @@
 <body>
   <main class="container">
     <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
-    <div id="definition-container" style="display: none;"></div>
-    <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
-    <input type="text" id="search" placeholder="Search...">
+      <nav class="site-nav" aria-label="Guidelines navigation"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
+      <div id="definition-container" style="display: none;"></div>
+      <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
+      <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+      <button id="random-term" type="button" aria-label="Show random term">Random Term</button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
-    <input type="checkbox" id="show-favorites" aria-label="Show favorites">
+      <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+      <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 
     <ul id="terms-list"></ul>
   </main>
-  <footer class="container">
+    <footer class="container" aria-label="Primary footer">
     <p><a href="templates/contribute.html">Contribute</a></p>
   </footer>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+  <button id="scrollToTopBtn" type="button" aria-label="Scroll to top">↑</button>
 
-  <footer>
+  <footer aria-label="Secondary footer">
     <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
   </footer>
   <script src="script.js"></script>

--- a/sw.js
+++ b/sw.js
@@ -4,12 +4,23 @@ const URLS_TO_CACHE = [
   '/index.html',
   '/styles.css',
   '/script.js',
-  '/data.json'
+  '/terms.json',
+  '/assets/js/search.js',
+  '/_pagefind/pagefind.js',
+  '/_pagefind/pagefind.wasm',
+  '/_pagefind/en.json',
+  '/_pagefind/pagefind.css'
 ];
 
 self.addEventListener('install', event => {
   event.waitUntil(
-    caches.open(CACHE_NAME).then(cache => cache.addAll(URLS_TO_CACHE))
+    caches.open(CACHE_NAME).then(cache =>
+      Promise.all(
+        URLS_TO_CACHE.map(url =>
+          cache.add(url).catch(err => console.warn('Failed to cache', url, err))
+        )
+      )
+    )
   );
 });
 
@@ -25,7 +36,7 @@ self.addEventListener('activate', event => {
 
 self.addEventListener('fetch', event => {
   event.respondWith(
-    caches.match(event.request).then(response =>
+    caches.match(event.request, { ignoreMethod: true }).then(response =>
       response || fetch(event.request).catch(() => {
         if (event.request.mode === 'navigate') {
           return caches.match('/index.html');


### PR DESCRIPTION
## Summary
- cache Pagefind assets and search index in service worker
- disable search when data exceeds configurable bundle limit
- annotate HTML landmarks and button types to satisfy validator

## Testing
- `npm test`
- `node <<'NODE' ...` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68b4bb549b708328a575367b06612ff6