### PR TITLE
feat: add install banner with weekly cap

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,5 +1,83 @@
-if ('serviceWorker' in navigator) {
-  window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/sw.js');
+if ("serviceWorker" in navigator) {
+  window.addEventListener("load", () => {
+    navigator.serviceWorker.register("/sw.js");
   });
 }
+
+// Custom install banner with weekly frequency cap
+(function () {
+  const PROMPT_KEY = "installPromptTimestamp";
+  const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+  let deferredPrompt;
+
+  function shouldPrompt() {
+    try {
+      const last = parseInt(localStorage.getItem(PROMPT_KEY), 10);
+      return !last || Date.now() - last > WEEK_MS;
+    } catch (e) {
+      return true;
+    }
+  }
+
+  function markPromptShown() {
+    try {
+      localStorage.setItem(PROMPT_KEY, Date.now().toString());
+    } catch (e) {
+      // Ignore storage errors
+    }
+  }
+
+  function createBanner(message, actionText, action) {
+    const banner = document.createElement("div");
+    banner.className = "install-banner";
+
+    const text = document.createElement("span");
+    text.textContent = message;
+
+    const actions = document.createElement("div");
+    const btn = document.createElement("button");
+    btn.textContent = actionText;
+    btn.addEventListener("click", () => {
+      action();
+      banner.remove();
+    });
+
+    const close = document.createElement("button");
+    close.textContent = "✕";
+    close.addEventListener("click", () => banner.remove());
+
+    actions.appendChild(btn);
+    actions.appendChild(close);
+
+    banner.appendChild(text);
+    banner.appendChild(actions);
+    document.body.appendChild(banner);
+    markPromptShown();
+  }
+
+  // Desktop install prompt
+  window.addEventListener("beforeinstallprompt", (e) => {
+    e.preventDefault();
+    if (!shouldPrompt()) {
+      return;
+    }
+    deferredPrompt = e;
+    createBanner("Install Cyber Security Dictionary?", "Install", () => {
+      deferredPrompt.prompt();
+      deferredPrompt = null;
+    });
+  });
+
+  // iOS installation instructions
+  const isIos = /iphone|ipad|ipod/i.test(window.navigator.userAgent);
+  const isStandalone =
+    window.matchMedia("(display-mode: standalone)").matches ||
+    window.navigator.standalone;
+  if (isIos && !isStandalone && shouldPrompt()) {
+    createBanner(
+      "Install this app: tap Share then Add to Home Screen.",
+      "Dismiss",
+      () => {},
+    );
+  }
+})();

--- a/index.html
+++ b/index.html
@@ -1,39 +1,53 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Cyber Security Dictionary</title>
-  <link rel="stylesheet" href="styles.css">
-  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet">
-  <link rel="canonical" id="canonical-link" href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/">
-</head>
-<body>
-  <main class="container">
-    <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
-    <div id="definition-container" style="display: none;"></div>
-    <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
-    <input type="text" id="search" placeholder="Search...">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Cyber Security Dictionary</title>
+    <link rel="stylesheet" href="styles.css" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      rel="canonical"
+      id="canonical-link"
+      href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/"
+    />
+  </head>
+  <body>
+    <main class="container">
+      <h1>Cyber Security Dictionary</h1>
+      <nav class="site-nav" aria-label="Site navigation">
+        <a href="templates/guidelines.html">Definition Guidelines</a>
+      </nav>
+      <div id="definition-container" style="display: none"></div>
+      <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
+      <input type="text" id="search" placeholder="Search..." />
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+      <button id="random-term" type="button" aria-label="Show random term">
+        Random Term
+      </button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
-    <input type="checkbox" id="show-favorites" aria-label="Show favorites">
-    <label for="show-favorites">Show Favorites</label>
+      <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">
+        Toggle Dark Mode
+      </button>
+      <input type="checkbox" id="show-favorites" aria-label="Show favorites" />
+      <label for="show-favorites">Show Favorites</label>
 
-    <ul id="terms-list"></ul>
-  </main>
-  <footer class="container">
-    <p><a href="templates/contribute.html">Contribute</a></p>
-  </footer>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+      <ul id="terms-list"></ul>
+    </main>
+    <footer class="container" aria-label="Contribute footer">
+      <p><a href="templates/contribute.html">Contribute</a></p>
+    </footer>
+    <button id="scrollToTopBtn" type="button" aria-label="Scroll to top">
+      ↑
+    </button>
 
-  <footer>
-    <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
-  </footer>
-  <script src="script.js"></script>
-  <script src="assets/js/app.js"></script>
-</body>
+    <footer aria-label="Project footer">
+      <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
+    </footer>
+    <script src="script.js"></script>
+    <script src="assets/js/app.js"></script>
+  </body>
 </html>
-

--- a/styles.css
+++ b/styles.css
@@ -25,7 +25,7 @@ body {
 
 h1 {
   text-align: center;
-  font-family: 'Cinzel', serif;
+  font-family: "Cinzel", serif;
   font-weight: 700;
   font-size: 48px;
   margin-bottom: 20px;
@@ -110,7 +110,6 @@ body.dark-mode mark {
   box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
   min-height: 44px;
 }
-
 
 /* Controls styling */
 #random-term {
@@ -206,7 +205,9 @@ label {
   border-radius: 4px;
   padding: 10px;
   cursor: pointer;
-  transition: background-color 0.2s, color 0.2s;
+  transition:
+    background-color 0.2s,
+    color 0.2s;
   min-width: 44px;
   min-height: 44px;
 }
@@ -346,4 +347,23 @@ body.dark-mode #alpha-nav button.active {
   #alpha-nav button {
     font-size: 14px;
   }
+}
+
+/* Install banner styles */
+.install-banner {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: #333;
+  color: #fff;
+  padding: 10px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  z-index: 1000;
+}
+
+.install-banner button {
+  margin-left: 5px;
 }


### PR DESCRIPTION
## Summary
- add custom install banner for desktop and iOS
- limit banner to once per week via timestamped localStorage
- ensure HTML validates by labeling navigation, footers and buttons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4bb561fb88328aa3ad927f113ab51