### PR TITLE
Add offline fallback and recent term tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,25 +11,25 @@
 <body>
   <main class="container">
     <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
+    <nav class="site-nav" aria-label="Site navigation"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
     <div id="definition-container" style="display: none;"></div>
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+    <button id="random-term" type="button" aria-label="Show random term">Random Term</button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+    <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">Toggle Dark Mode</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 
     <ul id="terms-list"></ul>
   </main>
-  <footer class="container">
+  <footer class="container" aria-label="Footer links">
     <p><a href="templates/contribute.html">Contribute</a></p>
   </footer>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+  <button id="scrollToTopBtn" type="button" aria-label="Scroll to top">↑</button>
 
-  <footer>
+  <footer aria-label="Project contribution">
     <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
   </footer>
   <script src="script.js"></script>

--- a/offline.html
+++ b/offline.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Offline - Cyber Security Dictionary</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <h1>You are offline</h1>
+  <p>It looks like you're offline. Try these tips:</p>
+  <ul>
+    <li>Check your internet connection.</li>
+    <li>Verify the address is correct.</li>
+    <li>Search again when you're back online.</li>
+  </ul>
+  <h2>Recently viewed terms</h2>
+  <ul id="recently-viewed"></ul>
+  <script>
+    (function () {
+      const list = document.getElementById('recently-viewed');
+      let recent = [];
+      try {
+        recent = JSON.parse(localStorage.getItem('recentlyViewed')) || [];
+      } catch (e) {
+        /* ignore */
+      }
+      if (recent.length) {
+        recent.forEach((term) => {
+          const li = document.createElement('li');
+          const a = document.createElement('a');
+          a.href = '/index.html#' + encodeURIComponent(term);
+          a.textContent = term;
+          li.appendChild(a);
+          list.appendChild(li);
+        });
+      } else {
+        list.innerHTML = '<li>No recently viewed terms.</li>';
+      }
+    })();
+  </script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -95,6 +95,20 @@ function toggleFavorite(term) {
     // Ignore storage errors
   }
 }
+function addToRecentlyViewed(term) {
+  let recent = [];
+  try {
+    recent = JSON.parse(localStorage.getItem("recentlyViewed")) || [];
+  } catch (e) {}
+  recent = recent.filter((t) => t !== term);
+  recent.unshift(term);
+  if (recent.length > 5) {
+    recent = recent.slice(0, 5);
+  }
+  try {
+    localStorage.setItem("recentlyViewed", JSON.stringify(recent));
+  } catch (e) {}
+}
 
 function highlightActiveButton(button) {
   alphaNav.querySelectorAll("button").forEach((btn) => btn.classList.remove("active"));
@@ -190,6 +204,8 @@ function displayDefinition(term) {
       `${siteUrl}#${encodeURIComponent(term.term)}`
     );
   }
+  addToRecentlyViewed(term.term);
+
 }
 
 function clearDefinition() {

--- a/sw.js
+++ b/sw.js
@@ -1,10 +1,11 @@
-const CACHE_NAME = 'csd-cache-v1';
+const CACHE_NAME = 'csd-cache-v2';
 const URLS_TO_CACHE = [
   '/',
   '/index.html',
   '/styles.css',
   '/script.js',
-  '/data.json'
+  '/data.json',
+  '/offline.html'
 ];
 
 self.addEventListener('install', event => {
@@ -25,12 +26,21 @@ self.addEventListener('activate', event => {
 
 self.addEventListener('fetch', event => {
   event.respondWith(
-    caches.match(event.request).then(response =>
-      response || fetch(event.request).catch(() => {
-        if (event.request.mode === 'navigate') {
-          return caches.match('/index.html');
+    caches.match(event.request).then(cached => {
+      if (cached) {
+        return cached;
+      }
+      return fetch(event.request).then(response => {
+        if (!response.ok && event.request.mode === 'navigate') {
+          return caches.match('/offline.html');
         }
-      })
-    )
+        return response;
+      }).catch(() => {
+        if (event.request.mode === 'navigate') {
+          return caches.match('/offline.html');
+        }
+      });
+    })
   );
 });
+


### PR DESCRIPTION
## Summary
- add offline fallback page with search guidance and recent term links
- track recently viewed terms in local storage
- serve cached offline page when navigation fails or returns 404
- address html validation issues by labelling landmarks and button types

## Testing
- `npm test`
- `npx html-validate offline.html`
- `node - <<'NODE' ... (network failure simulation) NODE`
- `node - <<'NODE' ... (404 simulation) NODE`


------
https://chatgpt.com/codex/tasks/task_e_68b4bb571200832886d38fbe2e25f909