### PR TITLE
Add analytics hooks for install, offline usage, and updates

### DIFF
--- a/analytics.js
+++ b/analytics.js
@@ -1,0 +1,31 @@
+(function (global) {
+  const ANALYTICS_URL =
+    global.analyticsEndpoint || "https://example.com/analytics";
+
+  function sendAnalyticsEvent(eventName) {
+    const payload = { event: eventName, timestamp: Date.now() };
+    const body = JSON.stringify(payload);
+    try {
+      if (
+        global.navigator &&
+        typeof global.navigator.sendBeacon === "function"
+      ) {
+        global.navigator.sendBeacon(ANALYTICS_URL, body);
+        return Promise.resolve();
+      }
+      return fetch(ANALYTICS_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body,
+        keepalive: true,
+      });
+    } catch (err) {
+      return Promise.reject(err);
+    }
+  }
+
+  global.sendAnalyticsEvent = sendAnalyticsEvent;
+  if (typeof module !== "undefined") {
+    module.exports = { sendAnalyticsEvent };
+  }
+})(typeof self !== "undefined" ? self : this);

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,5 +1,11 @@
-if ('serviceWorker' in navigator) {
-  window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/sw.js');
+if ("serviceWorker" in navigator) {
+  window.addEventListener("load", () => {
+    navigator.serviceWorker.register("/sw.js");
   });
 }
+
+window.addEventListener("appinstalled", () => {
+  if (typeof sendAnalyticsEvent === "function") {
+    sendAnalyticsEvent("install");
+  }
+});

--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
@@ -11,29 +11,29 @@
 <body>
   <main class="container">
     <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
-    <div id="definition-container" style="display: none;"></div>
+    <nav class="site-nav" aria-label="Site navigation"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
+    <div id="definition-container" style="display: none"></div>
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+    <button id="random-term" aria-label="Show random term" type="button">Random Term</button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+    <button id="dark-mode-toggle" aria-label="Toggle dark mode" type="button">Toggle Dark Mode</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 
     <ul id="terms-list"></ul>
   </main>
-  <footer class="container">
+  <footer class="container" aria-label="Main footer">
     <p><a href="templates/contribute.html">Contribute</a></p>
   </footer>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+  <button id="scrollToTopBtn" aria-label="Scroll to top" type="button">↑</button>
 
-  <footer>
+  <footer aria-label="Project footer">
     <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
   </footer>
+  <script src="analytics.js"></script>
   <script src="script.js"></script>
   <script src="assets/js/app.js"></script>
 </body>
 </html>
-

--- a/sw.js
+++ b/sw.js
@@ -1,36 +1,45 @@
-const CACHE_NAME = 'csd-cache-v1';
+importScripts("analytics.js");
+
+const CACHE_NAME = "csd-cache-v1";
 const URLS_TO_CACHE = [
-  '/',
-  '/index.html',
-  '/styles.css',
-  '/script.js',
-  '/data.json'
+  "/",
+  "/index.html",
+  "/styles.css",
+  "/script.js",
+  "/data.json",
 ];
 
-self.addEventListener('install', event => {
+self.addEventListener("install", (event) => {
   event.waitUntil(
-    caches.open(CACHE_NAME).then(cache => cache.addAll(URLS_TO_CACHE))
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(URLS_TO_CACHE)),
   );
 });
 
-self.addEventListener('activate', event => {
+self.addEventListener("activate", (event) => {
   event.waitUntil(
-    caches.keys().then(keys =>
-      Promise.all(
-        keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key))
-      )
-    )
+    caches.keys().then((keys) => {
+      const oldKeys = keys.filter((key) => key !== CACHE_NAME);
+      if (oldKeys.length > 0 && typeof sendAnalyticsEvent === "function") {
+        sendAnalyticsEvent("update-accepted");
+      }
+      return Promise.all(oldKeys.map((key) => caches.delete(key)));
+    }),
   );
 });
 
-self.addEventListener('fetch', event => {
+self.addEventListener("fetch", (event) => {
   event.respondWith(
-    caches.match(event.request).then(response =>
-      response || fetch(event.request).catch(() => {
-        if (event.request.mode === 'navigate') {
-          return caches.match('/index.html');
-        }
-      })
-    )
+    caches.match(event.request).then(
+      (response) =>
+        response ||
+        fetch(event.request).catch(() => {
+          if (event.request.mode === "navigate") {
+            if (typeof sendAnalyticsEvent === "function") {
+              sendAnalyticsEvent("offline-used");
+            }
+            return caches.match("/index.html");
+          }
+        }),
+    ),
   );
 });


### PR DESCRIPTION
## Summary
- Add shared analytics helper and load it in the app
- Track PWA install via `appinstalled` event
- Report offline fallback and update acceptance from the service worker
- Clean up HTML to satisfy validation rules

## Testing
- `npm test`
- `curl -s -X POST https://httpbin.org/post -H 'Content-Type: application/json' -d '{"event":"install","timestamp":0}'`
- `curl -s -X POST https://httpbin.org/post -H 'Content-Type: application/json' -d '{"event":"offline-used","timestamp":0}'`
- `curl -s -X POST https://httpbin.org/post -H 'Content-Type: application/json' -d '{"event":"update-accepted","timestamp":0}'`


------
https://chatgpt.com/codex/tasks/task_e_68b4bb5787ec8328af97dc04caa5f011