### PR TITLE
feat: add term generator script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "node scripts/build.js",
     "test": "html-validate index.html",
-    "watch": "chokidar \"**/*.html\" -c \"npm run build\""
+    "watch": "chokidar \"**/*.html\" -c \"npm run build\"",
+    "term:new": "node scripts/term-new.js"
   },
   "keywords": [],
   "author": "",

--- a/scripts/term-new.js
+++ b/scripts/term-new.js
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const [,, title] = process.argv;
+
+if (!title) {
+  console.error('Usage: pnpm term:new "Title"');
+  process.exit(1);
+}
+
+const slugify = str => str
+  .toLowerCase()
+  .trim()
+  .replace(/[^a-z0-9]+/g, '-')
+  .replace(/^-+|-+$/g, '');
+
+const baseSlug = slugify(title);
+const contentDir = path.join(__dirname, '..', 'content', 'terms');
+fs.mkdirSync(contentDir, { recursive: true });
+
+let slug = baseSlug;
+let filePath = path.join(contentDir, `${slug}.md`);
+let counter = 1;
+while (fs.existsSync(filePath)) {
+  slug = `${baseSlug}-${counter++}`;
+  filePath = path.join(contentDir, `${slug}.md`);
+}
+
+const frontMatterData = { title, slug };
+let frontMatterYaml;
+try {
+  frontMatterYaml = yaml.dump(frontMatterData, { lineWidth: 100 });
+  yaml.load(frontMatterYaml); // validate YAML
+} catch (err) {
+  console.error(`Invalid frontmatter: ${err.message}`);
+  process.exit(1);
+}
+
+const starterSections = `\n## Definition\n\nTBD.\n\n## Sources\n\n- TBD\n`;
+const fileContents = `---\n${frontMatterYaml}---${starterSections}`;
+
+fs.writeFileSync(filePath, fileContents, 'utf8');
+console.log(`Created ${filePath}`);


### PR DESCRIPTION
## Summary
- add `term:new` CLI to scaffold markdown terms with unique slugs
- include default frontmatter and starter sections for new term files

## Testing
- `pnpm term:new "Test Term"`
- `pnpm term:new "Test Term"`
- `pnpm test` *(fails: unique-landmark, no-implicit-button-type)*

------
https://chatgpt.com/codex/tasks/task_e_68b4bb586bf4832897cb93ea6c389c6d