### PR TITLE
feat: add term collision detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,52 @@ jobs:
         uses: lycheeverse/lychee-action@v2
         with:
           args: --no-cache terms.json
+  collisions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install pyyaml scikit-learn
+      - name: Run collision check
+        run: python tools/check_collisions.py --data data/terms.yaml --output collisions.json
+      - name: Comment on collisions
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            if (!fs.existsSync('collisions.json')) {
+              return;
+            }
+            const report = JSON.parse(fs.readFileSync('collisions.json', 'utf8'));
+            if (report.total === 0) {
+              return;
+            }
+            const base = `https://${context.repo.owner}.github.io/${context.repo.repo}/`;
+            let body = '### Collision Report\n';
+            if (report.title_collisions.length) {
+              body += '\n**Title Collisions**\n';
+              for (const c of report.title_collisions) {
+                body += `- ${c.title}: ${c.slugs.map(s => '['+s+']('+base+s+')').join(', ')}\n`;
+              }
+            }
+            if (report.synonym_collisions.length) {
+              body += '\n**Synonym Collisions**\n';
+              for (const c of report.synonym_collisions) {
+                body += `- ${c.synonym}: ${c.slugs.map(s => '['+s+']('+base+s+')').join(', ')}\n`;
+              }
+            }
+            if (report.definition_collisions.length) {
+              body += '\n**Definition Similarities**\n';
+              for (const c of report.definition_collisions) {
+                body += `- ${c.slugs.map(s => '['+s+']('+base+s+')').join(' and ')} (score ${c.similarity.toFixed(2)})\n`;
+              }
+            }
+            await github.rest.issues.createComment({
+              ...context.repo,
+              issue_number: context.issue.number,
+              body
+            });

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/tools/check_collisions.py
+++ b/tools/check_collisions.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+import argparse
+import json
+from itertools import combinations
+import yaml
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.metrics.pairwise import cosine_similarity
+
+def load_terms(path):
+    with open(path, 'r', encoding='utf-8') as f:
+        return yaml.safe_load(f)
+
+def check_collisions(data, threshold=0.8):
+    results = {
+        'title_collisions': [],
+        'synonym_collisions': [],
+        'definition_collisions': []
+    }
+    title_map = {}
+    synonym_map = {}
+    definitions = []
+    slugs = []
+    titles = []
+
+    for entry in data:
+        title = entry.get('name', '').strip().lower()
+        slug = entry.get('slug')
+        titles.append(title)
+        slugs.append(slug)
+        definitions.append(entry.get('definition', ''))
+        title_map.setdefault(title, []).append(slug)
+        for syn in entry.get('synonyms', []) or []:
+            syn_l = syn.strip().lower()
+            synonym_map.setdefault(syn_l, []).append(slug)
+
+    for title, sl in title_map.items():
+        if len(sl) > 1:
+            results['title_collisions'].append({'title': title, 'slugs': sl})
+
+    for syn, sl in synonym_map.items():
+        overlap = set(sl)
+        if syn in title_map:
+            overlap.update(title_map[syn])
+        if len(overlap) > 1:
+            results['synonym_collisions'].append({'synonym': syn, 'slugs': sorted(overlap)})
+
+    if len(definitions) > 1:
+        vectorizer = TfidfVectorizer().fit_transform(definitions)
+        sim_matrix = cosine_similarity(vectorizer)
+        for i, j in combinations(range(len(definitions)), 2):
+            score = sim_matrix[i, j]
+            if score >= threshold:
+                results['definition_collisions'].append({
+                    'slugs': [slugs[i], slugs[j]],
+                    'similarity': float(score)
+                })
+    results['total'] = (len(results['title_collisions']) +
+                         len(results['synonym_collisions']) +
+                         len(results['definition_collisions']))
+    return results
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Check term collisions.')
+    parser.add_argument('--data', default='data/terms.yaml', help='Path to terms YAML file')
+    parser.add_argument('--output', default='collisions.json', help='File to write collision report JSON')
+    parser.add_argument('--threshold', type=float, default=0.8, help='Cosine similarity threshold')
+    args = parser.parse_args()
+
+    terms = load_terms(args.data)
+    report = check_collisions(terms, threshold=args.threshold)
+
+    with open(args.output, 'w', encoding='utf-8') as f:
+        json.dump(report, f, indent=2)
+
+    if report['total']:
+        print(json.dumps(report, indent=2))
+
+if __name__ == '__main__':
+    main()

--- a/tools/sample_terms.yaml
+++ b/tools/sample_terms.yaml
@@ -1,0 +1,15 @@
+- name: Alpha
+  slug: alpha
+  definition: A common security term.
+  synonyms:
+    - Start
+- name: Beta
+  slug: beta
+  definition: A common security term.
+  synonyms:
+    - Alpha
+- name: Alpha
+  slug: alpha-duplicate
+  definition: Different meaning.
+  synonyms:
+    - Begin


### PR DESCRIPTION
## Summary
- add Python script to detect duplicate titles, synonyms, and similar definitions
- include sample term dataset for demonstrating collision detection
- update CI to run collision check and comment on pull requests with term links

## Testing
- `python tools/check_collisions.py --data tools/sample_terms.yaml --output /tmp/sample_report.json`
- `npm test` *(fails: Landmarks must have a non-empty and unique accessible name)*


------
https://chatgpt.com/codex/tasks/task_e_68b4bb5a75c88328ac7d75a07261e5c7