### PR TITLE
Add link check script with retries and CI enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,4 @@ jobs:
       - name: cSpell
         run: npx cspell README.md terms.json
       - name: Link checker
-        uses: lycheeverse/lychee-action@v2
-        with:
-          args: --no-cache terms.json
+        run: npm run linkcheck

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "node scripts/build.js",
     "test": "html-validate index.html",
-    "watch": "chokidar \"**/*.html\" -c \"npm run build\""
+    "watch": "chokidar \"**/*.html\" -c \"npm run build\"",
+    "linkcheck": "node scripts/check-links.js"
   },
   "keywords": [],
   "author": "",

--- a/scripts/check-links.js
+++ b/scripts/check-links.js
@@ -1,0 +1,72 @@
+const fs = require('fs');
+const yaml = require('js-yaml');
+const { exec } = require('child_process');
+
+async function fetchWithRetry(url, retries = 3, delay = 1000) {
+  for (let attempt = 1; attempt <= retries; attempt++) {
+    try {
+      const status = await new Promise((resolve, reject) => {
+        exec(
+          `curl -I -L -A \"Mozilla/5.0\" --max-time 10 -o /dev/null -s -w \"%{http_code}\" ${url}`,
+          (err, stdout) => {
+            if (err) {
+              reject(err);
+            } else {
+              resolve(stdout.trim());
+            }
+          }
+        );
+      });
+      if (status === '200') {
+        return true;
+      }
+      throw new Error(`Status ${status}`);
+    } catch (err) {
+      if (attempt === retries) {
+        throw err;
+      }
+      await new Promise((r) => setTimeout(r, delay));
+    }
+  }
+}
+
+async function main() {
+  const file = fs.readFileSync('data/terms.yaml', 'utf8');
+  const terms = yaml.load(file);
+  const urls = new Set();
+
+  if (Array.isArray(terms)) {
+    for (const term of terms) {
+      if (Array.isArray(term.sources)) {
+        for (const url of term.sources) {
+          urls.add(url);
+        }
+      }
+    }
+  }
+
+  // allow extra URLs via CLI args for testing
+  for (const arg of process.argv.slice(2)) {
+    urls.add(arg);
+  }
+
+  let allOk = true;
+  for (const url of urls) {
+    try {
+      await fetchWithRetry(url);
+      console.log(`✔️  ${url}`);
+    } catch (err) {
+      console.error(`❌ ${url}: ${err.message}`);
+      allOk = false;
+    }
+  }
+
+  if (!allOk) {
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a Node script to validate URLs in terms.yaml with retries
- expose script via `npm run linkcheck`
- run link check in CI to fail on broken links

## Testing
- `node scripts/check-links.js https://httpstat.us/404 || echo "link check failed"`
- `npm run linkcheck && echo "link check passed"`
- `npm test` *(fails: Landmarks must have a non-empty and unique accessible name)*

------
https://chatgpt.com/codex/tasks/task_e_68b4bb5b56788328a2247deeec3e725b