### PR TITLE
chore: add markdown linting

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 ## Summary
 - Describe your changes.
 
-## Related Issues
+## Related issues
 - Closes #<issue-number>
 
 ## Checklist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,15 @@ jobs:
         with:
           node-version: 20
       - name: Install linters
-        run: npm install --no-save eslint@8 stylelint cspell
+        run: npm install --no-save eslint@8 stylelint cspell remark-cli remark-lint remark-lint-prohibited-strings remark-lint-write-good unist-util-visit mdast-util-to-string
       - name: ESLint
         run: npx eslint@8 --no-eslintrc --env browser --env es2021 script.js
       - name: stylelint
         run: npx stylelint styles.css
       - name: cSpell
         run: npx cspell README.md terms.json
+      - name: remark-lint
+        run: npx remark .
       - name: Link checker
         uses: lycheeverse/lychee-action@v2
         with:

--- a/.remarkrc.cjs
+++ b/.remarkrc.cjs
@@ -1,0 +1,10 @@
+const headingSentenceCase = require('./scripts/remark-heading-sentence-case.js');
+
+module.exports = {
+  plugins: [
+    'remark-lint',
+    headingSentenceCase,
+    ['remark-lint-prohibited-strings', [{ no: 'utilized', yes: 'use' }]],
+    'remark-lint-write-good'
+  ]
+};

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Thank you for taking the time to contribute to the Cyber Security Dictionary!
 2. **Submit a pull request**
    - Fork the repository and update `data.json` with your term.
    - Reference the issue in your pull request.
-   - Ensure any related documentation is updated.
+   - Update any related documentation.
 
 ## Pull request checklist
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# CyberSecuirtyDictionary
+# Cyber security dictionary
 https://alex-unnippillil.github.io/CyberSecuirtyDictionary/
 ![image](https://github.com/Alex-Unnippillil/CyberSecuirtyDictionary/assets/24538548/c5a54c56-babb-485d-b01c-4fdfb186325b)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,8 +1,8 @@
-# Security Policy
+# Security policy
 
-We take the security of this project seriously.
+We value this project's security.
 
-## Reporting a Vulnerability
+## Reporting a vulnerability
 
 If you believe you've found a security vulnerability in this project, please email us at [security@example.com](mailto:security@example.com) with details.
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "node scripts/build.js",
     "test": "html-validate index.html",
-    "watch": "chokidar \"**/*.html\" -c \"npm run build\""
+    "watch": "chokidar \"**/*.html\" -c \"npm run build\"",
+    "lint:markdown": "remark ."
   },
   "keywords": [],
   "author": "",
@@ -16,6 +17,12 @@
     "html-validate": "^10.0.0",
     "http-server": "^14.1.1",
     "js-yaml": "^4.1.0",
-    "prettier": "^3.6.2"
+    "prettier": "^3.6.2",
+    "remark-cli": "^12.0.1",
+    "remark-lint": "^10.0.1",
+    "remark-lint-prohibited-strings": "^4.0.0",
+    "remark-lint-write-good": "^1.2.0",
+    "unist-util-visit": "^5.0.0",
+    "mdast-util-to-string": "^4.0.0"
   }
 }

--- a/scripts/remark-heading-sentence-case.js
+++ b/scripts/remark-heading-sentence-case.js
@@ -1,0 +1,15 @@
+const {visit} = require('unist-util-visit');
+const {toString} = require('mdast-util-to-string');
+
+module.exports = function remarkHeadingSentenceCase() {
+  return (tree, file) => {
+    visit(tree, 'heading', node => {
+      const text = toString(node);
+      if (!text) return;
+      const expected = text.charAt(0).toUpperCase() + text.slice(1).toLowerCase();
+      if (text !== expected) {
+        file.message(`Headings should be in sentence case: \`${expected}\``, node);
+      }
+    });
+  };
+};


### PR DESCRIPTION
## Summary
- add remark-lint with sentence case, passive voice, and banned phrase checks
- run markdown lint in CI
- fix existing docs to satisfy new rules

## Testing
- `npm run lint:markdown`
- `npm test` *(fails: Landmarks must have a non-empty and unique accessible name (aria-label or aria-labelledby))*
- `npx remark violation.md` *(fails: sample file shows sentence case, passive voice, and banned phrase warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b4bb5c320883288099cbbaf5bf91ed