### PR TITLE
Add Leitner-based flashcards

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,8 @@
 https://alex-unnippillil.github.io/CyberSecuirtyDictionary/
 ![image](https://github.com/Alex-Unnippillil/CyberSecuirtyDictionary/assets/24538548/c5a54c56-babb-485d-b01c-4fdfb186325b)
 
+## Flashcards
+Study terms using a flashcard session powered by a Leitner box algorithm.
+
 ## Security
 For information on reporting vulnerabilities, please see our [Security Policy](SECURITY.md).

--- a/flashcards.html
+++ b/flashcards.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Flashcards - Cyber Security Dictionary</title>
+  <link rel="stylesheet" href="styles.css">
+  <script defer src="flashcards.js"></script>
+</head>
+<body>
+  <main class="container" id="flashcard-container">
+    <h1>Flashcards</h1>
+    <div id="card">
+      <h2 id="term">Loading...</h2>
+      <p id="definition" class="hidden"></p>
+    </div>
+    <div id="controls">
+      <button id="show-answer" type="button">Show Answer</button>
+      <button id="know-it" type="button">I was Correct</button>
+      <button id="dont-know" type="button">I was Incorrect</button>
+    </div>
+    <p id="progress"></p>
+  </main>
+  <footer class="container">
+    <p><a href="index.html">Back to Dictionary</a></p>
+  </footer>
+</body>
+</html>

--- a/flashcards.js
+++ b/flashcards.js
@@ -1,0 +1,105 @@
+const BOX_COUNT = 5;
+let terms = [];
+let leitnerBoxes = {};
+let currentIndex = null;
+let currentBox = 1;
+
+const termEl = document.getElementById('term');
+const definitionEl = document.getElementById('definition');
+const showAnswerBtn = document.getElementById('show-answer');
+const knowBtn = document.getElementById('know-it');
+const dontKnowBtn = document.getElementById('dont-know');
+const progressEl = document.getElementById('progress');
+
+window.addEventListener('DOMContentLoaded', () => {
+  fetch('terms.json')
+    .then(res => res.json())
+    .then(data => {
+      terms = data.terms;
+      initBoxes();
+      updateProgress();
+      showCard();
+    });
+});
+
+function initBoxes() {
+  try {
+    const stored = JSON.parse(localStorage.getItem('leitnerBoxes'));
+    if (stored) {
+      leitnerBoxes = stored;
+    }
+  } catch (e) {
+    // ignore corrupted storage
+  }
+  for (let i = 1; i <= BOX_COUNT; i++) {
+    if (!Array.isArray(leitnerBoxes[i])) {
+      leitnerBoxes[i] = [];
+    }
+  }
+  const present = new Set(Object.values(leitnerBoxes).flat());
+  terms.forEach((_, idx) => {
+    if (!present.has(idx)) {
+      leitnerBoxes[1].push(idx);
+    }
+  });
+  saveBoxes();
+}
+
+function saveBoxes() {
+  try {
+    localStorage.setItem('leitnerBoxes', JSON.stringify(leitnerBoxes));
+  } catch (e) {
+    // ignore storage errors
+  }
+}
+
+function getNextCard() {
+  for (let i = 1; i <= BOX_COUNT; i++) {
+    if (leitnerBoxes[i].length > 0) {
+      currentBox = i;
+      const rand = Math.floor(Math.random() * leitnerBoxes[i].length);
+      currentIndex = leitnerBoxes[i][rand];
+      return terms[currentIndex];
+    }
+  }
+  return null;
+}
+
+function showCard() {
+  const card = getNextCard();
+  if (!card) {
+    termEl.textContent = 'No cards available';
+    definitionEl.textContent = '';
+    return;
+  }
+  termEl.textContent = card.term;
+  definitionEl.textContent = card.definition;
+  definitionEl.classList.add('hidden');
+}
+
+function updateProgress() {
+  const parts = [];
+  for (let i = 1; i <= BOX_COUNT; i++) {
+    parts.push(`Box ${i}: ${leitnerBoxes[i].length}`);
+  }
+  progressEl.textContent = parts.join(' | ');
+}
+
+function moveCard(correct) {
+  leitnerBoxes[currentBox] = leitnerBoxes[currentBox].filter(idx => idx !== currentIndex);
+  if (correct) {
+    const nextBox = Math.min(currentBox + 1, BOX_COUNT);
+    leitnerBoxes[nextBox].push(currentIndex);
+  } else {
+    leitnerBoxes[1].push(currentIndex);
+  }
+  saveBoxes();
+  updateProgress();
+  showCard();
+}
+
+showAnswerBtn.addEventListener('click', () => {
+  definitionEl.classList.remove('hidden');
+});
+knowBtn.addEventListener('click', () => moveCard(true));
+dontKnowBtn.addEventListener('click', () => moveCard(false));

--- a/index.html
+++ b/index.html
@@ -11,27 +11,30 @@
 <body>
   <main class="container">
     <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
+    <nav class="site-nav" aria-label="Site navigation">
+      <a href="templates/guidelines.html">Definition Guidelines</a>
+      <a href="flashcards.html">Flashcards</a>
+    </nav>
     <div id="definition-container" style="display: none;"></div>
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+      <button id="random-term" aria-label="Show random term" type="button">Random Term</button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+      <button id="dark-mode-toggle" aria-label="Toggle dark mode" type="button">Toggle Dark Mode</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 
     <ul id="terms-list"></ul>
   </main>
-  <footer class="container">
-    <p><a href="templates/contribute.html">Contribute</a></p>
-  </footer>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+    <footer class="container" aria-label="Contribution footer">
+      <p><a href="templates/contribute.html">Contribute</a></p>
+    </footer>
+    <button id="scrollToTopBtn" aria-label="Scroll to top" type="button">↑</button>
 
-  <footer>
-    <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
-  </footer>
+    <footer aria-label="Project footer">
+      <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
+    </footer>
   <script src="script.js"></script>
   <script src="assets/js/app.js"></script>
 </body>

--- a/styles.css
+++ b/styles.css
@@ -347,3 +347,25 @@ body.dark-mode #alpha-nav button.active {
     font-size: 14px;
   }
 }
+
+.hidden {
+  display: none;
+}
+
+#flashcard-container #card {
+  text-align: center;
+  margin-bottom: 1em;
+}
+
+#controls button {
+  margin: 0 5px;
+  padding: 10px;
+  min-width: 44px;
+  min-height: 44px;
+}
+
+#progress {
+  margin-top: 1em;
+  text-align: center;
+  font-size: 0.9em;
+}


### PR DESCRIPTION
## Summary
- Add flashcard study mode using Leitner boxes stored in localStorage
- Track progress and adapt sessions based on answers
- Link flashcards from main page and update styles

## Testing
- `npm test`
- `npx html-validate flashcards.html`


------
https://chatgpt.com/codex/tasks/task_e_68b4bb608cd0832897f0651a37bdeb7d