### PR TITLE
Add scenario-based questions page linking to terms

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,25 +11,25 @@
 <body>
   <main class="container">
     <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
+      <nav class="site-nav" aria-label="Site navigation"><a href="templates/guidelines.html">Definition Guidelines</a> | <a href="scenarios.html">Scenarios</a></nav>
     <div id="definition-container" style="display: none;"></div>
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+      <button id="random-term" aria-label="Show random term" type="button">Random Term</button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+      <button id="dark-mode-toggle" aria-label="Toggle dark mode" type="button">Toggle Dark Mode</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 
     <ul id="terms-list"></ul>
   </main>
-  <footer class="container">
+    <footer class="container" aria-label="Contribution links">
     <p><a href="templates/contribute.html">Contribute</a></p>
   </footer>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+    <button id="scrollToTopBtn" aria-label="Scroll to top" type="button">↑</button>
 
-  <footer>
+    <footer aria-label="Project information">
     <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
   </footer>
   <script src="script.js"></script>

--- a/scenarios.html
+++ b/scenarios.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Scenario-Based Questions</title>
+  <link rel="stylesheet" href="styles.css">
+  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet">
+</head>
+<body>
+  <main class="container">
+    <h1>Scenario-Based Questions</h1>
+    <ul>
+      <li>An employee receives a <a href="terms/phishing-email.html">Phishing Email</a> carrying a malicious <a href="terms/payload.html">Payload</a>, resulting in <a href="terms/identity-theft.html">Identity Theft</a>. Which security measure would most effectively prevent this attack?</li>
+      <li>The <a href="terms/security-operations-center-soc.html">Security Operations Center (SOC)</a> conducts <a href="terms/threat-hunting.html">Threat Hunting</a> after detecting an <a href="terms/advanced-persistent-threat-apt.html">Advanced Persistent Threat (APT)</a>, triggering <a href="terms/incident-response.html">Incident Response</a>. What should be the team's next step?</li>
+      <li>Developers discover a <a href="terms/zero-day-vulnerability.html">Zero-Day Vulnerability</a> and release a <a href="terms/security-patch.html">Security Patch</a> while enforcing <a href="terms/transport-layer-security-tls.html">Transport Layer Security (TLS)</a> with a certificate from a trusted <a href="terms/certificate-authority-ca.html">Certificate Authority (CA)</a>. How do these actions reduce risk?</li>
+    </ul>
+  </main>
+  <footer class="container">
+    <p><a href="index.html">Back to Dictionary</a></p>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add scenarios page with questions linking to relevant term definitions
- expose scenarios via site navigation and improve accessibility attributes

## Testing
- `npm test`
- `npx html-validate scenarios.html && echo "scenarios ok"`


------
https://chatgpt.com/codex/tasks/task_e_68b4bb63b4848328b7ef267dc3184807