### PR TITLE
feat: add streak reminder UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,39 +1,59 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Cyber Security Dictionary</title>
-  <link rel="stylesheet" href="styles.css">
-  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet">
-  <link rel="canonical" id="canonical-link" href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/">
-</head>
-<body>
-  <main class="container">
-    <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
-    <div id="definition-container" style="display: none;"></div>
-    <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
-    <input type="text" id="search" placeholder="Search...">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cyber Security Dictionary</title>
+    <link rel="stylesheet" href="styles.css">
+    <link
+      href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap"
+      rel="stylesheet"
+    >
+    <link
+      rel="canonical"
+      id="canonical-link"
+      href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/"
+    >
+  </head>
+  <body>
+    <main class="container">
+      <h1>Cyber Security Dictionary</h1>
+      <nav class="site-nav" aria-label="Site navigation">
+        <a href="templates/guidelines.html">Definition Guidelines</a>
+      </nav>
+      <div id="definition-container" style="display: none"></div>
+      <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
+      <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+      <button id="random-term" aria-label="Show random term" type="button">
+        Random Term
+      </button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
-    <input type="checkbox" id="show-favorites" aria-label="Show favorites">
-    <label for="show-favorites">Show Favorites</label>
+      <div id="streak-reminder" role="status" aria-live="polite"></div>
 
-    <ul id="terms-list"></ul>
-  </main>
-  <footer class="container">
-    <p><a href="templates/contribute.html">Contribute</a></p>
-  </footer>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+      <button
+        id="dark-mode-toggle"
+        aria-label="Toggle dark mode"
+        type="button"
+      >
+        Toggle Dark Mode
+      </button>
+      <input type="checkbox" id="show-favorites" aria-label="Show favorites">
+      <label for="show-favorites">Show Favorites</label>
 
-  <footer>
-    <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
-  </footer>
-  <script src="script.js"></script>
-  <script src="assets/js/app.js"></script>
-</body>
+      <ul id="terms-list"></ul>
+    </main>
+    <footer class="container" aria-label="Contribute section">
+      <p><a href="templates/contribute.html">Contribute</a></p>
+    </footer>
+    <button id="scrollToTopBtn" aria-label="Scroll to top" type="button">
+      ↑
+    </button>
+
+    <footer aria-label="Project information">
+      <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
+    </footer>
+    <script src="script.js"></script>
+    <script src="assets/js/app.js"></script>
+  </body>
 </html>
-

--- a/script.js
+++ b/script.js
@@ -5,9 +5,12 @@ const randomButton = document.getElementById("random-term");
 const alphaNav = document.getElementById("alpha-nav");
 const darkModeToggle = document.getElementById("dark-mode-toggle");
 const showFavoritesToggle = document.getElementById("show-favorites");
-const favorites = new Set(JSON.parse(localStorage.getItem("favorites") || "[]"));
+const favorites = new Set(
+  JSON.parse(localStorage.getItem("favorites") || "[]"),
+);
 const siteUrl = "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/";
 const canonicalLink = document.getElementById("canonical-link");
+const streakReminder = document.getElementById("streak-reminder");
 
 let currentLetterFilter = "All";
 let termsData = { terms: [] };
@@ -19,13 +22,62 @@ if (localStorage.getItem("darkMode") === "true") {
 if (darkModeToggle) {
   darkModeToggle.addEventListener("click", () => {
     document.body.classList.toggle("dark-mode");
-    localStorage.setItem("darkMode", document.body.classList.contains("dark-mode"));
+    localStorage.setItem(
+      "darkMode",
+      document.body.classList.contains("dark-mode"),
+    );
   });
 }
 
 window.addEventListener("DOMContentLoaded", () => {
+  updateStreak();
   loadTerms();
 });
+
+function updateStreak() {
+  const today = new Date().toDateString();
+  let data;
+  try {
+    data = JSON.parse(localStorage.getItem("streak")) || {
+      count: 0,
+      last: null,
+    };
+  } catch (e) {
+    data = { count: 0, last: null };
+  }
+
+  let message = "";
+  if (data.last === today) {
+    message = `🔥 You're on a ${data.count}-day streak!`;
+  } else {
+    const yesterday = new Date(Date.now() - 86400000).toDateString();
+    if (data.last === yesterday) {
+      data.count += 1;
+      message = `🔥 You're on a ${data.count}-day streak!`;
+    } else {
+      if (data.count > 0) {
+        message = `You broke your ${data.count}-day streak. Start again today!`;
+      } else {
+        message = "Start your learning streak today!";
+      }
+      data.count = 1;
+    }
+    data.last = today;
+    try {
+      localStorage.setItem("streak", JSON.stringify(data));
+    } catch (e) {
+      // Ignore storage errors
+    }
+  }
+
+  if (streakReminder) {
+    streakReminder.textContent = message;
+    streakReminder.style.display = "block";
+    setTimeout(() => {
+      streakReminder.style.display = "none";
+    }, 5000);
+  }
+}
 
 function loadTerms() {
   fetch("terms.json")
@@ -43,9 +95,11 @@ function loadTerms() {
       populateTermsList();
 
       if (window.location.hash) {
-        const termFromHash = decodeURIComponent(window.location.hash.substring(1));
+        const termFromHash = decodeURIComponent(
+          window.location.hash.substring(1),
+        );
         const matchedTerm = termsData.terms.find(
-          (t) => t.term.toLowerCase() === termFromHash.toLowerCase()
+          (t) => t.term.toLowerCase() === termFromHash.toLowerCase(),
         );
         if (matchedTerm) {
           displayDefinition(matchedTerm);
@@ -56,7 +110,7 @@ function loadTerms() {
       console.error("Detailed error fetching data:", error);
       definitionContainer.style.display = "block";
       definitionContainer.innerHTML =
-        '<p>Unable to load dictionary data. Please check your connection and try again.</p>' +
+        "<p>Unable to load dictionary data. Please check your connection and try again.</p>" +
         '<button id="retry-fetch">Retry</button>';
       const retryBtn = document.getElementById("retry-fetch");
       if (retryBtn) {
@@ -97,12 +151,16 @@ function toggleFavorite(term) {
 }
 
 function highlightActiveButton(button) {
-  alphaNav.querySelectorAll("button").forEach((btn) => btn.classList.remove("active"));
+  alphaNav
+    .querySelectorAll("button")
+    .forEach((btn) => btn.classList.remove("active"));
   button.classList.add("active");
 }
 
 function buildAlphaNav() {
-  const letters = Array.from(new Set(termsData.terms.map((t) => t.term.charAt(0).toUpperCase()))).sort();
+  const letters = Array.from(
+    new Set(termsData.terms.map((t) => t.term.charAt(0).toUpperCase())),
+  ).sort();
 
   const allButton = document.createElement("button");
   allButton.textContent = "All";
@@ -134,9 +192,13 @@ function populateTermsList() {
     .sort((a, b) => a.term.localeCompare(b.term))
     .forEach((item) => {
       const matchesSearch = item.term.toLowerCase().includes(searchValue);
-      const matchesFavorites = !showFavoritesToggle || !showFavoritesToggle.checked || favorites.has(item.term);
+      const matchesFavorites =
+        !showFavoritesToggle ||
+        !showFavoritesToggle.checked ||
+        favorites.has(item.term);
       const matchesLetter =
-        currentLetterFilter === "All" || item.term.charAt(0).toUpperCase() === currentLetterFilter;
+        currentLetterFilter === "All" ||
+        item.term.charAt(0).toUpperCase() === currentLetterFilter;
       if (matchesSearch && matchesFavorites && matchesLetter) {
         const termDiv = document.createElement("div");
         termDiv.classList.add("dictionary-item");
@@ -187,7 +249,7 @@ function displayDefinition(term) {
   if (canonicalLink) {
     canonicalLink.setAttribute(
       "href",
-      `${siteUrl}#${encodeURIComponent(term.term)}`
+      `${siteUrl}#${encodeURIComponent(term.term)}`,
     );
   }
 }
@@ -195,19 +257,27 @@ function displayDefinition(term) {
 function clearDefinition() {
   definitionContainer.style.display = "none";
   definitionContainer.innerHTML = "";
-  history.replaceState(null, "", window.location.pathname + window.location.search);
+  history.replaceState(
+    null,
+    "",
+    window.location.pathname + window.location.search,
+  );
   if (canonicalLink) {
     canonicalLink.setAttribute("href", siteUrl);
   }
 }
 
 function showRandomTerm() {
-  const randomTerm = termsData.terms[Math.floor(Math.random() * termsData.terms.length)];
+  const randomTerm =
+    termsData.terms[Math.floor(Math.random() * termsData.terms.length)];
   displayDefinition(randomTerm);
 
   const today = new Date().toDateString();
   try {
-    localStorage.setItem("lastRandomTerm", JSON.stringify({ date: today, term: randomTerm }));
+    localStorage.setItem(
+      "lastRandomTerm",
+      JSON.stringify({ date: today, term: randomTerm }),
+    );
   } catch (e) {
     // Ignore storage errors
   }
@@ -249,8 +319,7 @@ window.addEventListener("scroll", () => {
   scrollBtn.style.display = window.scrollY > 200 ? "block" : "none";
 });
 scrollBtn.addEventListener("click", () =>
-  window.scrollTo({ top: 0, behavior: "smooth" })
+  window.scrollTo({ top: 0, behavior: "smooth" }),
 );
 
 definitionContainer.addEventListener("click", clearDefinition);
-

--- a/styles.css
+++ b/styles.css
@@ -25,7 +25,7 @@ body {
 
 h1 {
   text-align: center;
-  font-family: 'Cinzel', serif;
+  font-family: "Cinzel", serif;
   font-weight: 700;
   font-size: 48px;
   margin-bottom: 20px;
@@ -111,7 +111,6 @@ body.dark-mode mark {
   min-height: 44px;
 }
 
-
 /* Controls styling */
 #random-term {
   margin-top: 10px;
@@ -123,6 +122,15 @@ body.dark-mode mark {
   cursor: pointer;
   min-width: 44px;
   min-height: 44px;
+}
+
+#streak-reminder {
+  display: none;
+  margin: 10px 0;
+  padding: 10px;
+  border-radius: 5px;
+  background-color: #e0f7fa;
+  color: #00796b;
 }
 
 #random-term:hover {
@@ -206,7 +214,9 @@ label {
   border-radius: 4px;
   padding: 10px;
   cursor: pointer;
-  transition: background-color 0.2s, color 0.2s;
+  transition:
+    background-color 0.2s,
+    color 0.2s;
   min-width: 44px;
   min-height: 44px;
 }
@@ -324,6 +334,11 @@ body.dark-mode #alpha-nav button:focus {
 body.dark-mode #alpha-nav button.active {
   background-color: #007bff;
   border-color: #007bff;
+}
+
+body.dark-mode #streak-reminder {
+  background-color: #333;
+  color: #fff;
 }
 
 @media (max-width: 480px) {


### PR DESCRIPTION
## Summary
- track visit streak in localStorage and show reminder messages
- add streak reminder container to main page
- style streak reminder including dark mode

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4bb653fdc8328939ddcd8028a3a3b