### PR TITLE
feat: add local read-later queue

### DIFF
--- a/assets/js/queue.js
+++ b/assets/js/queue.js
@@ -1,0 +1,61 @@
+const queueList = document.getElementById("queue-list");
+let queue = [];
+
+function loadQueue() {
+  try {
+    queue = JSON.parse(localStorage.getItem("readLaterQueue")) || [];
+  } catch (e) {
+    queue = [];
+  }
+}
+
+function saveQueue() {
+  try {
+    localStorage.setItem("readLaterQueue", JSON.stringify(queue));
+  } catch (e) {
+    // Ignore storage errors
+  }
+}
+
+function renderQueue() {
+  queueList.innerHTML = "";
+  queue.forEach((term, index) => {
+    const li = document.createElement("li");
+    li.draggable = true;
+    li.dataset.index = index;
+    const link = document.createElement("a");
+    link.href = `index.html#${encodeURIComponent(term)}`;
+    link.textContent = term;
+    li.appendChild(link);
+    queueList.appendChild(li);
+  });
+}
+
+function handleDragStart(e) {
+  if (e.target.tagName === "LI") {
+    e.dataTransfer.setData("text/plain", e.target.dataset.index);
+  }
+}
+
+function handleDrop(e) {
+  e.preventDefault();
+  const fromIndex = e.dataTransfer.getData("text/plain");
+  const targetLi = e.target.closest("li");
+  if (fromIndex === "" || !targetLi) return;
+  const toIndex = targetLi.dataset.index;
+  const [moved] = queue.splice(fromIndex, 1);
+  queue.splice(toIndex, 0, moved);
+  saveQueue();
+  renderQueue();
+}
+
+function handleDragOver(e) {
+  e.preventDefault();
+}
+
+loadQueue();
+renderQueue();
+
+queueList.addEventListener("dragstart", handleDragStart);
+queueList.addEventListener("dragover", handleDragOver);
+queueList.addEventListener("drop", handleDrop);

--- a/index.html
+++ b/index.html
@@ -11,25 +11,25 @@
 <body>
   <main class="container">
     <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
+    <nav class="site-nav" aria-label="Site navigation"><a href="templates/guidelines.html">Definition Guidelines</a> | <a href="queue.html">Read Later Queue</a></nav>
     <div id="definition-container" style="display: none;"></div>
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+    <button id="random-term" aria-label="Show random term" type="button">Random Term</button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+    <button id="dark-mode-toggle" aria-label="Toggle dark mode" type="button">Toggle Dark Mode</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 
     <ul id="terms-list"></ul>
   </main>
-  <footer class="container">
+    <footer class="container" aria-label="Contributor links">
     <p><a href="templates/contribute.html">Contribute</a></p>
   </footer>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+    <button id="scrollToTopBtn" aria-label="Scroll to top" type="button">↑</button>
 
-  <footer>
+    <footer aria-label="Project contribution">
     <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
   </footer>
   <script src="script.js"></script>

--- a/queue.html
+++ b/queue.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Read Later Queue</title>
+  <link rel="stylesheet" href="styles.css">
+  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet">
+</head>
+<body>
+  <main class="container">
+    <h1>Read Later Queue</h1>
+    <nav class="site-nav"><a href="index.html">Back to Dictionary</a></nav>
+    <ul id="queue-list"></ul>
+  </main>
+  <script src="assets/js/queue.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -8,6 +8,27 @@ const showFavoritesToggle = document.getElementById("show-favorites");
 const favorites = new Set(JSON.parse(localStorage.getItem("favorites") || "[]"));
 const siteUrl = "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/";
 const canonicalLink = document.getElementById("canonical-link");
+const readLaterKey = "readLaterQueue";
+
+function getReadLaterQueue() {
+  try {
+    return JSON.parse(localStorage.getItem(readLaterKey)) || [];
+  } catch (e) {
+    return [];
+  }
+}
+
+function addToReadLater(term) {
+  const queue = getReadLaterQueue();
+  if (!queue.includes(term)) {
+    queue.push(term);
+    try {
+      localStorage.setItem(readLaterKey, JSON.stringify(queue));
+    } catch (e) {
+      // Ignore storage errors
+    }
+  }
+}
 
 let currentLetterFilter = "All";
 let termsData = { terms: [] };
@@ -182,7 +203,21 @@ function populateTermsList() {
 
 function displayDefinition(term) {
   definitionContainer.style.display = "block";
-  definitionContainer.innerHTML = `<h3>${term.term}</h3><p>${term.definition}</p>`;
+  definitionContainer.innerHTML = `<h3>${term.term}</h3><p>${term.definition}</p><button id="read-later-btn">Read later</button>`;
+  const readLaterBtn = document.getElementById("read-later-btn");
+  if (readLaterBtn) {
+    const queue = getReadLaterQueue();
+    if (queue.includes(term.term)) {
+      readLaterBtn.textContent = "In queue";
+      readLaterBtn.disabled = true;
+    }
+    readLaterBtn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      addToReadLater(term.term);
+      readLaterBtn.textContent = "Added!";
+      readLaterBtn.disabled = true;
+    });
+  }
   window.location.hash = encodeURIComponent(term.term);
   if (canonicalLink) {
     canonicalLink.setAttribute(


### PR DESCRIPTION
## Summary
- add read-later queue page with drag-and-drop ordering
- allow adding terms to queue from definitions
- annotate buttons and landmarks for accessibility

## Testing
- `npm test`
- `npx html-validate queue.html`


------
https://chatgpt.com/codex/tasks/task_e_68b4bb6708f48328ab443f04015d6865