### PR TITLE
Add simplified summary toggle with device persistence

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,25 +11,27 @@
 <body>
   <main class="container">
     <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
+    <nav class="site-nav" aria-label="Site links"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
     <div id="definition-container" style="display: none;"></div>
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+    <button id="random-term" type="button" aria-label="Show random term">Random Term</button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+    <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+    <input type="checkbox" id="simplified-toggle" aria-label="Enable simplified summaries">
+    <label for="simplified-toggle">Simplified Summaries</label>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 
     <ul id="terms-list"></ul>
   </main>
-  <footer class="container">
+  <footer class="container" aria-label="Content footer">
     <p><a href="templates/contribute.html">Contribute</a></p>
   </footer>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+  <button id="scrollToTopBtn" type="button" aria-label="Scroll to top">↑</button>
 
-  <footer>
+  <footer aria-label="Project footer">
     <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
   </footer>
   <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -5,6 +5,7 @@ const randomButton = document.getElementById("random-term");
 const alphaNav = document.getElementById("alpha-nav");
 const darkModeToggle = document.getElementById("dark-mode-toggle");
 const showFavoritesToggle = document.getElementById("show-favorites");
+const simplifiedToggle = document.getElementById("simplified-toggle");
 const favorites = new Set(JSON.parse(localStorage.getItem("favorites") || "[]"));
 const siteUrl = "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/";
 const canonicalLink = document.getElementById("canonical-link");
@@ -20,6 +21,20 @@ if (darkModeToggle) {
   darkModeToggle.addEventListener("click", () => {
     document.body.classList.toggle("dark-mode");
     localStorage.setItem("darkMode", document.body.classList.contains("dark-mode"));
+  });
+}
+
+if (localStorage.getItem("simplified") === "true") {
+  if (simplifiedToggle) {
+    simplifiedToggle.checked = true;
+  }
+}
+
+if (simplifiedToggle) {
+  simplifiedToggle.addEventListener("change", () => {
+    localStorage.setItem("simplified", simplifiedToggle.checked);
+    clearDefinition();
+    populateTermsList();
   });
 }
 
@@ -81,6 +96,15 @@ function removeDuplicateTermsAndDefinitions() {
   });
 
   termsData.terms = uniqueTermsData;
+}
+
+function getSimplifiedDefinition(text) {
+  const match = text.match(/[^.!?]+[.!?]/);
+  if (match) {
+    return match[0].trim();
+  }
+  const words = text.split(/\s+/);
+  return words.slice(0, 10).join(" ") + (words.length > 10 ? "..." : "");
 }
 
 function toggleFavorite(term) {
@@ -168,7 +192,11 @@ function populateTermsList() {
         termDiv.appendChild(termHeader);
 
         const definitionPara = document.createElement("p");
-        definitionPara.textContent = item.definition;
+        const definitionText =
+          simplifiedToggle && simplifiedToggle.checked
+            ? getSimplifiedDefinition(item.definition)
+            : item.definition;
+        definitionPara.textContent = definitionText;
         termDiv.appendChild(definitionPara);
 
         termDiv.addEventListener("click", () => {
@@ -182,7 +210,11 @@ function populateTermsList() {
 
 function displayDefinition(term) {
   definitionContainer.style.display = "block";
-  definitionContainer.innerHTML = `<h3>${term.term}</h3><p>${term.definition}</p>`;
+  const definitionText =
+    simplifiedToggle && simplifiedToggle.checked
+      ? getSimplifiedDefinition(term.definition)
+      : term.definition;
+  definitionContainer.innerHTML = `<h3>${term.term}</h3><p>${definitionText}</p>`;
   window.location.hash = encodeURIComponent(term.term);
   if (canonicalLink) {
     canonicalLink.setAttribute(

--- a/tests/simplified-toggle.test.js
+++ b/tests/simplified-toggle.test.js
@@ -1,0 +1,51 @@
+const { JSDOM } = require('jsdom');
+const fs = require('fs');
+const vm = require('vm');
+
+const html = `<!DOCTYPE html><body>
+<ul id="terms-list"></ul>
+<div id="definition-container"></div>
+<input id="search" />
+<button id="random-term"></button>
+<nav id="alpha-nav"></nav>
+<button id="dark-mode-toggle"></button>
+<input type="checkbox" id="show-favorites" />
+<input type="checkbox" id="simplified-toggle" />
+<button id="scrollToTopBtn"></button>
+</body>`;
+
+const dom = new JSDOM(html, { url: 'https://example.org' });
+const { window } = dom;
+
+global.window = window;
+window.addEventListener = () => {};
+
+global.document = window.document;
+global.localStorage = window.localStorage;
+
+global.fetch = () => Promise.resolve({ ok: true, json: () => Promise.resolve({ terms: [] }) });
+
+const today = new Date().toDateString();
+window.localStorage.setItem(
+  'lastRandomTerm',
+  JSON.stringify({ date: today, term: { term: 'Dummy', definition: 'Dummy.' } })
+);
+
+const scriptContent = fs.readFileSync('./script.js', 'utf8');
+vm.runInThisContext(scriptContent);
+
+termsData = { terms: [{ term: 'Example', definition: 'A long definition. Second sentence explains more.' }] };
+populateTermsList();
+let def = document.querySelector('#terms-list p').textContent;
+if (def !== 'A long definition. Second sentence explains more.') {
+  throw new Error('Expected full definition');
+}
+
+document.getElementById('simplified-toggle').checked = true;
+populateTermsList();
+def = document.querySelector('#terms-list p').textContent;
+if (def !== 'A long definition.') {
+  throw new Error('Simplified definition not displayed');
+}
+
+console.log('Simplified toggle test passed');


### PR DESCRIPTION
## Summary
- add UI toggle to display simplified term summaries
- persist simplified-summary preference in localStorage
- cover simplified mode with JSDOM test

## Testing
- `npm test`
- `node tests/simplified-toggle.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b4bb67d5c88328aa20d92fc30f4735