### PR TITLE
Add SRI hash validation for external assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Cyber Security Dictionary</title>
   <link rel="stylesheet" href="styles.css">
-  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet" integrity="sha384-QLtLsWkm4K1LJIx85AECMgBdNWyYx3d9pykqVnGenPZjRVss9IMhyxjKBYIGSKHV" crossorigin="anonymous">
   <link rel="canonical" id="canonical-link" href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/">
 </head>
 <body>

--- a/package.json
+++ b/package.json
@@ -5,8 +5,9 @@
   "main": "script.js",
   "scripts": {
     "build": "node scripts/build.js",
-    "test": "html-validate index.html",
-    "watch": "chokidar \"**/*.html\" -c \"npm run build\""
+    "test": "npm run sri && html-validate index.html templates/contribute.html",
+    "watch": "chokidar \"**/*.html\" -c \"npm run build\"",
+    "sri": "node scripts/sri.js"
   },
   "keywords": [],
   "author": "",

--- a/scripts/sri.js
+++ b/scripts/sri.js
@@ -1,0 +1,61 @@
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+const { execSync } = require('child_process');
+
+const htmlFiles = [
+  path.join(__dirname, '..', 'index.html'),
+  path.join(__dirname, '..', 'templates', 'contribute.html')
+];
+
+function fetchHash(url) {
+  let buffer;
+  try {
+    buffer = execSync(`curl -L --ipv4 -s ${JSON.stringify(url)}`);
+  } catch (err) {
+    throw new Error(`Failed to fetch ${url}`);
+  }
+  return crypto.createHash('sha384').update(buffer).digest('base64');
+}
+
+async function processFile(file) {
+  let html = fs.readFileSync(file, 'utf8');
+  let modified = false;
+
+  const linkRegex = /<link(?=[^>]*rel=["']stylesheet["'])(?=[^>]*href=["'](https?:[^"']+)["'])[^>]*>/gi;
+  const scriptRegex = /<script[^>]*src=["'](https?:[^"']+)["'][^>]*><\/script>/gi;
+  const patterns = [linkRegex, scriptRegex];
+
+  for (const regex of patterns) {
+    const matches = [...html.matchAll(regex)];
+    for (const match of matches) {
+      const tag = match[0];
+      const url = match[1];
+      const integrityMatch = tag.match(/integrity=["']([^"']+)["']/i);
+      const hash = fetchHash(url);
+      const integrityValue = `sha384-${hash}`;
+      if (integrityMatch) {
+        if (integrityMatch[1] !== integrityValue) {
+          throw new Error(`Integrity mismatch for ${url} in ${path.basename(file)}`);
+        }
+      } else {
+        const newTag = tag.replace(/\s*>$/, ` integrity="${integrityValue}" crossorigin="anonymous">`);
+        html = html.replace(tag, newTag);
+        modified = true;
+      }
+    }
+  }
+
+  if (modified) {
+    fs.writeFileSync(file, html);
+  }
+}
+
+(async () => {
+  for (const file of htmlFiles) {
+    await processFile(file);
+  }
+})().catch(err => {
+  console.error(err.message);
+  process.exit(1);
+});

--- a/templates/contribute.html
+++ b/templates/contribute.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Contributing - Cyber Security Dictionary</title>
   <link rel="stylesheet" href="../styles.css">
-  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet" integrity="sha384-QLtLsWkm4K1LJIx85AECMgBdNWyYx3d9pykqVnGenPZjRVss9IMhyxjKBYIGSKHV" crossorigin="anonymous">
 </head>
 <body>
   <main class="container">


### PR DESCRIPTION
## Summary
- generate and verify SRI hashes for external scripts and styles
- run SRI validation in test workflow
- ignore node_modules in git

## Testing
- `npm run sri`
- `npm test` *(fails: unique-landmark, no-implicit-button-type)*
- `npm run sri` with tampered hash *(fails: Integrity mismatch for https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap in index.html)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c7dad0748328b72b9ee3c6d85e31