### PR TITLE
docs: add custom domain security guidance

### DIFF
--- a/.well-known/security.txt
+++ b/.well-known/security.txt
@@ -1,3 +1,7 @@
 # Security contact for CyberSecuirtyDictionary
 # See https://www.rfc-editor.org/rfc/rfc9116.html for format details
 Contact: mailto:security@example.com
+Policy: https://github.com/Alex-Unnippillil/CyberSecuirtyDictionary/SECURITY.md
+Preferred-Languages: en
+Expires: 2025-01-01T00:00:00Z
+

--- a/README.md
+++ b/README.md
@@ -4,3 +4,8 @@ https://alex-unnippillil.github.io/CyberSecuirtyDictionary/
 
 ## Security
 For information on reporting vulnerabilities, please see our [Security Policy](SECURITY.md).
+Security contact details are also published in [`security.txt`](.well-known/security.txt).
+
+## Custom Domains
+When serving this project from your own domain, follow the [custom domain security guide](docs/custom-domain-security.md) for CSP, SRI and Referrer-Policy recommendations.
+

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,4 +8,7 @@ If you believe you've found a security vulnerability in this project, please ema
 
 We will acknowledge your report within 48 hours, investigate, and take appropriate action. Please avoid public disclosure until we've addressed the issue.
 
+See our [`security.txt`](.well-known/security.txt) for additional contact information.
+
 Thanks for helping keep our project secure.
+

--- a/docs/custom-domain-security.md
+++ b/docs/custom-domain-security.md
@@ -1,0 +1,26 @@
+# Custom Domain Security
+
+When hosting this project on a custom domain you should serve appropriate security headers and integrity metadata to protect visitors.
+
+## Content Security Policy (CSP)
+Define a strict [Content Security Policy](https://developer.mozilla.org/docs/Web/HTTP/CSP) header to limit where scripts, styles, images and other resources can be loaded from.  A simple example for a site that only loads local resources is:
+
+```
+Content-Security-Policy: default-src 'self'; base-uri 'self'; form-action 'self'
+```
+
+Adjust the policy if you load assets from additional origins.
+
+## Subresource Integrity (SRI)
+If you include third party scripts or styles, add [Subresource Integrity](https://developer.mozilla.org/docs/Web/Security/Subresource_Integrity) hashes to the `integrity` attribute so the browser can verify the resource has not been modified.
+
+## Referrer Policy
+Set a [Referrer-Policy](https://developer.mozilla.org/docs/Web/HTTP/Headers/Referrer-Policy) header to control how much referrer information is shared with external sites.  A privacy‑respecting option is:
+
+```
+Referrer-Policy: no-referrer
+```
+
+## Security.txt
+Publish contact details for security reports at [`/.well-known/security.txt`](../.well-known/security.txt).
+

--- a/index.html
+++ b/index.html
@@ -11,25 +11,25 @@
 <body>
   <main class="container">
     <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
+      <nav class="site-nav" aria-label="Site navigation"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
     <div id="definition-container" style="display: none;"></div>
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+      <button id="random-term" aria-label="Show random term" type="button">Random Term</button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+      <button id="dark-mode-toggle" aria-label="Toggle dark mode" type="button">Toggle Dark Mode</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 
     <ul id="terms-list"></ul>
   </main>
-  <footer class="container">
+    <footer class="container" aria-label="Primary footer">
     <p><a href="templates/contribute.html">Contribute</a></p>
   </footer>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+    <button id="scrollToTopBtn" aria-label="Scroll to top" type="button">↑</button>
 
-  <footer>
+    <footer aria-label="Project footer">
     <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
   </footer>
   <script src="script.js"></script>


### PR DESCRIPTION
## Summary
- document CSP, SRI and Referrer-Policy for custom domains
- publish example `security.txt` and link from security policy
- expose security info in README and fix HTML validation warnings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4c7d9df7083288347cfdac4fd0501