### PR TITLE
Add MIT license and footer credits

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Cyber Security Dictionary contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/index.html
+++ b/index.html
@@ -1,39 +1,67 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Cyber Security Dictionary</title>
-  <link rel="stylesheet" href="styles.css">
-  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet">
-  <link rel="canonical" id="canonical-link" href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/">
-</head>
-<body>
-  <main class="container">
-    <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
-    <div id="definition-container" style="display: none;"></div>
-    <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
-    <input type="text" id="search" placeholder="Search...">
+  <head>
+      <meta charset="UTF-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <title>Cyber Security Dictionary</title>
+      <link rel="stylesheet" href="styles.css">
+      <link
+        href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap"
+        rel="stylesheet"
+      >
+      <link
+        rel="canonical"
+        id="canonical-link"
+        href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/"
+      >
+    </head>
+  <body>
+    <main class="container">
+      <h1>Cyber Security Dictionary</h1>
+      <nav class="site-nav" aria-label="Site navigation">
+        <a href="templates/guidelines.html">Definition Guidelines</a>
+      </nav>
+      <div id="definition-container" style="display: none"></div>
+      <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
+        <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+        <button id="random-term" type="button" aria-label="Show random term">
+          Random Term
+        </button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
-    <input type="checkbox" id="show-favorites" aria-label="Show favorites">
-    <label for="show-favorites">Show Favorites</label>
+        <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">
+          Toggle Dark Mode
+        </button>
+        <input type="checkbox" id="show-favorites" aria-label="Show favorites">
+      <label for="show-favorites">Show Favorites</label>
 
-    <ul id="terms-list"></ul>
-  </main>
-  <footer class="container">
-    <p><a href="templates/contribute.html">Contribute</a></p>
-  </footer>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+      <ul id="terms-list"></ul>
+    </main>
+    <footer class="container" aria-label="Site footer">
+      <p><a href="templates/contribute.html">Contribute</a></p>
+        <p>
+          <a href="LICENSE"
+            ><img
+              src="https://img.shields.io/badge/Code%20License-MIT-blue.svg"
+              alt="Code License: MIT"
+          ></a>
+          <a href="https://creativecommons.org/licenses/by/4.0/"
+            ><img
+              src="https://img.shields.io/badge/Content%20License-CC%20BY%204.0-lightgrey.svg"
+              alt="Content License: CC BY 4.0"
+          ></a>
+        </p>
+      <p>
+        Hero image by
+        <a href="https://pixabay.com/users/geralt-9301/">Gerd Altmann</a> from
+        <a href="https://pixabay.com/">Pixabay</a>.
+      </p>
+    </footer>
+      <button id="scrollToTopBtn" type="button" aria-label="Scroll to top">
+        ↑
+      </button>
 
-  <footer>
-    <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
-  </footer>
-  <script src="script.js"></script>
-  <script src="assets/js/app.js"></script>
-</body>
+      <script src="script.js"></script>
+      <script src="assets/js/app.js"></script>
+  </body>
 </html>
-

--- a/layout.html
+++ b/layout.html
@@ -1,38 +1,81 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Cyber Security Dictionary</title>
-  <link rel="stylesheet" href="styles.css">
-  <meta property="og:title" content="Cyber Security Dictionary">
-  <meta property="og:description" content="An interactive dictionary for cyber security terms.">
-  <meta property="og:type" content="website">
-  <meta property="og:url" content="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/">
-  <meta property="og:image" content="https://github.com/Alex-Unnippillil/CyberSecuirtyDictionary/assets/24538548/c5a54c56-babb-485d-b01c-4fdfb186325b">
-  <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Cyber Security Dictionary">
-  <meta name="twitter:description" content="An interactive dictionary for cyber security terms.">
-  <meta name="twitter:url" content="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/">
-  <meta name="twitter:image" content="https://github.com/Alex-Unnippillil/CyberSecuirtyDictionary/assets/24538548/c5a54c56-babb-485d-b01c-4fdfb186325b">
-</head>
-<body>
-  <main class="container">
-    <h1>Cyber Security Dictionary</h1>
-    <div id="definition-container" style="display: none;"></div>
-    <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
-    <input type="text" id="search" placeholder="Search...">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cyber Security Dictionary</title>
+    <link rel="stylesheet" href="styles.css">
+    <meta property="og:title" content="Cyber Security Dictionary">
+    <meta
+      property="og:description"
+      content="An interactive dictionary for cyber security terms."
+    >
+    <meta property="og:type" content="website">
+    <meta
+      property="og:url"
+      content="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/"
+    >
+    <meta
+      property="og:image"
+      content="https://github.com/Alex-Unnippillil/CyberSecuirtyDictionary/assets/24538548/c5a54c56-babb-485d-b01c-4fdfb186325b"
+    >
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Cyber Security Dictionary">
+    <meta
+      name="twitter:description"
+      content="An interactive dictionary for cyber security terms."
+    >
+    <meta
+      name="twitter:url"
+      content="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/"
+    >
+    <meta
+      name="twitter:image"
+      content="https://github.com/Alex-Unnippillil/CyberSecuirtyDictionary/assets/24538548/c5a54c56-babb-485d-b01c-4fdfb186325b"
+    >
+  </head>
+  <body>
+    <main class="container">
+      <h1>Cyber Security Dictionary</h1>
+      <div id="definition-container" style="display: none"></div>
+      <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
+        <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+        <button id="random-term" type="button" aria-label="Show random term">
+          Random Term
+        </button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
-    <input type="checkbox" id="show-favorites" aria-label="Show favorites">
-    <label for="show-favorites">Show Favorites</label>
+        <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">
+          Toggle Dark Mode
+        </button>
+        <input type="checkbox" id="show-favorites" aria-label="Show favorites">
+      <label for="show-favorites">Show Favorites</label>
 
-    <ul id="terms-list"></ul>
-  </main>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+      <ul id="terms-list"></ul>
+    </main>
+    <footer class="container" aria-label="Site footer">
+        <p>
+          <a href="LICENSE"
+            ><img
+              src="https://img.shields.io/badge/Code%20License-MIT-blue.svg"
+              alt="Code License: MIT"
+          ></a>
+          <a href="https://creativecommons.org/licenses/by/4.0/"
+            ><img
+              src="https://img.shields.io/badge/Content%20License-CC%20BY%204.0-lightgrey.svg"
+              alt="Content License: CC BY 4.0"
+          ></a>
+        </p>
+      <p>
+        Hero image by
+        <a href="https://pixabay.com/users/geralt-9301/">Gerd Altmann</a> from
+        <a href="https://pixabay.com/">Pixabay</a>.
+      </p>
+    </footer>
+    <button id="scrollToTopBtn" type="button" aria-label="Scroll to top">
+      ↑
+    </button>
 
-  <script src="script.js"></script>
-</body>
+    <script src="script.js"></script>
+  </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "devDependencies": {
     "chokidar-cli": "^3.0.0",
     "html-validate": "^10.0.0",

--- a/search.html
+++ b/search.html
@@ -1,20 +1,39 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Search</title>
-  <link rel="stylesheet" href="styles.css">
-</head>
-<body>
-  <main class="container">
-    <h1>Search</h1>
-    <input id="search-box" type="text" placeholder="Search terms..." />
-    <div id="results"></div>
-  </main>
-  <script>
-    window.__BASE_URL__ = window.__BASE_URL__ || '';
-  </script>
-  <script src="assets/js/search.js"></script>
-</body>
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Search</title>
+    <link rel="stylesheet" href="styles.css">
+  </head>
+  <body>
+    <main class="container">
+      <h1>Search</h1>
+        <input id="search-box" type="text" placeholder="Search terms...">
+      <div id="results"></div>
+    </main>
+    <footer class="container" aria-label="Site footer">
+        <p>
+          <a href="LICENSE"
+            ><img
+              src="https://img.shields.io/badge/Code%20License-MIT-blue.svg"
+              alt="Code License: MIT"
+          ></a>
+          <a href="https://creativecommons.org/licenses/by/4.0/"
+            ><img
+              src="https://img.shields.io/badge/Content%20License-CC%20BY%204.0-lightgrey.svg"
+              alt="Content License: CC BY 4.0"
+          ></a>
+        </p>
+      <p>
+        Hero image by
+        <a href="https://pixabay.com/users/geralt-9301/">Gerd Altmann</a> from
+        <a href="https://pixabay.com/">Pixabay</a>.
+      </p>
+    </footer>
+    <script>
+      window.__BASE_URL__ = window.__BASE_URL__ || "";
+    </script>
+    <script src="assets/js/search.js"></script>
+  </body>
 </html>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -1,51 +1,64 @@
 <!DOCTYPE html>
 <html lang="{{ lang }}">
-<head>
-  <meta charset="utf-8" />
-  <title>{{ title }}</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <head>
+    <meta charset="utf-8">
+    <title>{{ title }}</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <meta property="og:title" content="{{ og_title }}" />
-  <meta property="og:description" content="{{ og_description }}" />
-  <meta property="og:type" content="{{ og_type }}" />
-  <meta property="og:url" content="{{ canonical_url }}" />
-  <meta property="og:image" content="{{ og_image }}" />
+    <meta property="og:title" content="{{ og_title }}">
+    <meta property="og:description" content="{{ og_description }}">
+    <meta property="og:type" content="{{ og_type }}">
+    <meta property="og:url" content="{{ canonical_url }}">
+    <meta property="og:image" content="{{ og_image }}">
 
-  <meta name="twitter:card" content="{{ twitter_card }}" />
-  <meta name="twitter:site" content="{{ twitter_site }}" />
-  <meta name="twitter:title" content="{{ twitter_title }}" />
-  <meta name="twitter:description" content="{{ twitter_description }}" />
-  <meta name="twitter:image" content="{{ twitter_image }}" />
+    <meta name="twitter:card" content="{{ twitter_card }}">
+    <meta name="twitter:site" content="{{ twitter_site }}">
+    <meta name="twitter:title" content="{{ twitter_title }}">
+    <meta name="twitter:description" content="{{ twitter_description }}">
+    <meta name="twitter:image" content="{{ twitter_image }}">
 
-  <link rel="canonical" href="{{ canonical_url }}" />
-  <link rel="manifest" href="{{ manifest_url }}" />
-  <link rel="icon" href="{{ favicon_url }}" />
-  <link rel="stylesheet" href="{{ stylesheet_url }}" />
+    <link rel="canonical" href="{{ canonical_url }}">
+    <link rel="manifest" href="{{ manifest_url }}">
+    <link rel="icon" href="{{ favicon_url }}">
+    <link rel="stylesheet" href="{{ stylesheet_url }}">
 
-  <script>
-    const BASE_URL = "{{ base_url }}";
-  </script>
+    <script>
+      const BASE_URL = "{{ base_url }}";
+    </script>
 
-  <script type="application/ld+json">
-    {{ json_ld }}
-  </script>
-</head>
-<body>
-  <a href="#main" class="skip-link">Skip to content</a>
-  <header role="banner">
-    <nav role="navigation" aria-label="Primary">
-      {{ navigation }}
-    </nav>
-  </header>
-  <main id="main" role="main">
-    {{ content }}
-  </main>
-  <footer role="contentinfo">
-    <ul>
-      <li><a href="{{ privacy_url }}">{{ privacy_label }}</a></li>
-      <li><a href="{{ contact_url }}">{{ contact_label }}</a></li>
-    </ul>
-  </footer>
-  <script src="{{ base_url }}/assets/js/app.js"></script>
-</body>
+    <script type="application/ld+json">
+      {{ json_ld }}
+    </script>
+  </head>
+  <body>
+    <a href="#main" class="skip-link">Skip to content</a>
+      <header>
+        <nav aria-label="Primary">{{ navigation }}</nav>
+      </header>
+      <main id="main">{{ content }}</main>
+      <footer aria-label="Site footer">
+      <ul>
+        <li><a href="{{ privacy_url }}">{{ privacy_label }}</a></li>
+        <li><a href="{{ contact_url }}">{{ contact_label }}</a></li>
+      </ul>
+        <p>
+          <a href="{{ base_url }}/LICENSE"
+            ><img
+              src="https://img.shields.io/badge/Code%20License-MIT-blue.svg"
+              alt="Code License: MIT"
+          ></a>
+          <a href="https://creativecommons.org/licenses/by/4.0/"
+            ><img
+              src="https://img.shields.io/badge/Content%20License-CC%20BY%204.0-lightgrey.svg"
+              alt="Content License: CC BY 4.0"
+          ></a>
+        </p>
+      <p>
+        Hero image by
+        <a href="https://pixabay.com/users/geralt-9301/">Gerd Altmann</a> from
+        <a href="https://pixabay.com/">Pixabay</a>.
+      </p>
+    </footer>
+    <script src="{{ base_url }}/assets/js/app.js"></script>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- add MIT license for project and update package metadata
- show license badges and image credits in site footers
- normalize HTML markup for validation

## Testing
- `npm test`
- `npx html-validate search.html layout.html templates/layout.html`


------
https://chatgpt.com/codex/tasks/task_e_68b4c7db9138832881aff9af028cdb24