### PR TITLE
Add Playwright end-to-end tests and CI integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,17 @@ jobs:
         uses: lycheeverse/lychee-action@v2
         with:
           args: --no-cache terms.json
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm install
+      - run: npm test
+      - name: Install Playwright
+        run: npx playwright install --with-deps
+      - name: Playwright tests
+        run: npx playwright test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+package-lock.json
+playwright-report/
+test-results/
+trace.zip

--- a/package.json
+++ b/package.json
@@ -6,12 +6,14 @@
   "scripts": {
     "build": "node scripts/build.js",
     "test": "html-validate index.html",
-    "watch": "chokidar \"**/*.html\" -c \"npm run build\""
+    "watch": "chokidar \"**/*.html\" -c \"npm run build\"",
+    "test:e2e": "playwright test"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "@playwright/test": "^1.55.0",
     "chokidar-cli": "^3.0.0",
     "html-validate": "^10.0.0",
     "http-server": "^14.1.1",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,15 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  webServer: {
+    command: 'npx http-server -p 3000',
+    url: 'http://localhost:3000',
+    timeout: 120 * 1000,
+    reuseExistingServer: !process.env.CI,
+  },
+  use: {
+    baseURL: 'http://localhost:3000',
+    headless: true,
+  },
+});

--- a/tests/e2e.spec.js
+++ b/tests/e2e.spec.js
@@ -1,0 +1,42 @@
+import { test, expect } from '@playwright/test';
+
+// Test 1: Home page
+test('home page shows dictionary title and terms', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.getByRole('heading', { name: 'Cyber Security Dictionary' })).toBeVisible();
+  await page.waitForSelector('#terms-list .dictionary-item');
+});
+
+// Test 2: Search page
+test('search returns expected term', async ({ page }) => {
+  await page.goto('/search.html');
+  await page.fill('#search-box', 'phishing');
+  await expect(page.locator('.result-card').first()).toContainText('Phishing');
+});
+
+// Test 3: Term page via click
+test('clicking a term shows its definition', async ({ page }) => {
+  await page.goto('/');
+  await page.waitForSelector('#terms-list .dictionary-item');
+  const first = page.locator('#terms-list .dictionary-item').first();
+  const term = await first.locator('h3').evaluate(el => el.childNodes[0].textContent.trim());
+  await first.click();
+  await expect(page.locator('#definition-container')).toBeVisible();
+  await expect(page.locator('#definition-container')).toContainText(term);
+});
+
+// Test 4: Favorites filter
+test('favorites filter shows only favorited items', async ({ page }) => {
+  await page.goto('/');
+  await page.waitForSelector('#terms-list .dictionary-item');
+  const first = page.locator('#terms-list .dictionary-item').first();
+  await first.locator('.favorite-star').click();
+  await page.check('#show-favorites');
+  await expect(page.locator('#terms-list .dictionary-item')).toHaveCount(1);
+});
+
+// Test 5: Compare view (currently missing)
+test('compare view is not found', async ({ request }) => {
+  const response = await request.get('/compare.html');
+  expect(response.status()).toBe(404);
+});


### PR DESCRIPTION
## Summary
- add Playwright-based tests for home page, search, term display, favorites filter, and compare view placeholder
- configure Playwright to run against a local http-server in headless mode
- run Playwright tests in CI alongside existing checks

## Testing
- `npx playwright test`
- `npm test` *(fails: Landmarks must have a non-empty and unique accessible name, no-implicit-button-type)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c7df582c8328b5bb11b0b8ed59ee