### PR TITLE
Add accessibility tests using axe and pa11y

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/index.html
+++ b/index.html
@@ -11,25 +11,25 @@
 <body>
   <main class="container">
     <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
+    <nav class="site-nav" aria-label="Site navigation"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
     <div id="definition-container" style="display: none;"></div>
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+      <button id="random-term" type="button" aria-label="Show random term">Random Term</button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+      <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">Toggle Dark Mode</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 
     <ul id="terms-list"></ul>
   </main>
-  <footer class="container">
+    <footer class="container" aria-label="Primary footer">
     <p><a href="templates/contribute.html">Contribute</a></p>
   </footer>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+    <button id="scrollToTopBtn" type="button" aria-label="Scroll to top">↑</button>
 
-  <footer>
+    <footer aria-label="Project footer">
     <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
   </footer>
   <script src="script.js"></script>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "script.js",
   "scripts": {
     "build": "node scripts/build.js",
-    "test": "html-validate index.html",
+    "test": "html-validate index.html && npm run test:a11y",
+    "test:a11y": "node tests/a11y.js",
     "watch": "chokidar \"**/*.html\" -c \"npm run build\""
   },
   "keywords": [],
@@ -16,6 +17,9 @@
     "html-validate": "^10.0.0",
     "http-server": "^14.1.1",
     "js-yaml": "^4.1.0",
-    "prettier": "^3.6.2"
+    "prettier": "^3.6.2",
+    "@axe-core/puppeteer": "^4.10.2",
+    "pa11y": "^9.0.0",
+    "puppeteer": "^24.17.1"
   }
 }

--- a/tests/a11y.js
+++ b/tests/a11y.js
@@ -1,0 +1,60 @@
+const httpServer = require('http-server');
+const pa11y = require('pa11y');
+const puppeteer = require('puppeteer');
+const { AxePuppeteer } = require('@axe-core/puppeteer');
+
+(async () => {
+  const server = httpServer.createServer({ root: '.' });
+  const PORT = 8080;
+  await new Promise(resolve => server.listen(PORT, resolve));
+
+  const pages = ['index.html', 'search.html'];
+  let hasErrors = false;
+
+  for (const page of pages) {
+    const url = `http://localhost:${PORT}/${page}`;
+    console.log(`\nTesting ${url}`);
+
+    const pa11yResults = await pa11y(url, {
+      chromeLaunchConfig: {
+        args: ['--no-sandbox', '--disable-setuid-sandbox']
+      }
+    });
+    if (pa11yResults.issues.length) {
+      hasErrors = true;
+      console.log('pa11y violations:');
+      pa11yResults.issues.forEach(issue => {
+        console.log(`- ${issue.message} (${issue.selector})`);
+      });
+    }
+
+    const browser = await puppeteer.launch({
+      args: ['--no-sandbox', '--disable-setuid-sandbox']
+    });
+    const pageObj = await browser.newPage();
+    await pageObj.goto(url);
+    const axeResults = await new AxePuppeteer(pageObj).analyze();
+    if (axeResults.violations.length) {
+      hasErrors = true;
+      console.log('axe violations:');
+      axeResults.violations.forEach(v => {
+        v.nodes.forEach(node => {
+          console.log(`- ${v.id}: ${node.target.join(' ')}`);
+        });
+      });
+    }
+    await browser.close();
+  }
+
+  server.close();
+
+  if (hasErrors) {
+    console.error('Accessibility violations found');
+    process.exit(1);
+  } else {
+    console.log('No accessibility violations found');
+  }
+})().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add npm script to run axe and pa11y against critical pages
- include test script that starts a local server, runs pa11y and axe, and fails on violations
- tweak index.html landmarks and buttons to satisfy html-validate

## Testing
- `npm test` *(fails: Accessibility violations found)*


------
https://chatgpt.com/codex/tasks/task_e_68b4c7e152ac832883d65bd5501124d0