### PR TITLE
Validate sitemap URLs in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,10 @@ jobs:
         run: npx stylelint styles.css
       - name: cSpell
         run: npx cspell README.md terms.json
+      - name: Generate sitemap
+        run: node build.js
+      - name: Validate sitemap URLs
+        run: node check-sitemap.js
       - name: Link checker
         uses: lycheeverse/lychee-action@v2
         with:

--- a/build.js
+++ b/build.js
@@ -1,8 +1,8 @@
 const fs = require('fs');
 const path = require('path');
 
-const dataPath = path.join(__dirname, 'data.json');
-const data = JSON.parse(fs.readFileSync(dataPath, 'utf8'));
+const termsPath = path.join(__dirname, 'terms.json');
+const data = JSON.parse(fs.readFileSync(termsPath, 'utf8'));
 
 const termsDir = path.join(__dirname, 'terms');
 fs.mkdirSync(termsDir, { recursive: true });

--- a/check-sitemap.js
+++ b/check-sitemap.js
@@ -1,0 +1,27 @@
+const fs = require('fs');
+
+async function main() {
+  const xml = fs.readFileSync('sitemap.xml', 'utf8');
+  const urls = [...xml.matchAll(/<loc>(.*?)<\/loc>/g)].map(m => m[1]);
+  const failures = [];
+  for (const url of urls) {
+    try {
+      const res = await fetch(url, { method: 'HEAD' });
+      if (res.status !== 200) {
+        console.error(`${url} -> ${res.status}`);
+        failures.push(url);
+      } else {
+        console.log(`${url} -> ${res.status}`);
+      }
+    } catch (err) {
+      console.error(`${url} -> ${err.message}`);
+      failures.push(url);
+    }
+  }
+  if (failures.length) {
+    console.error(`Found ${failures.length} failing URLs`);
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- Update build script to read terms.json
- Add check-sitemap script to verify sitemap URLs return 200
- Run sitemap check during CI

## Testing
- `node build.js`
- `node check-sitemap.js` *(fails: fetch failed for all URLs)*
- `npm test` *(fails: unique-landmark, no-implicit-button-type)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c7e433c4832884002cf7307e8337