### PR TITLE
Add bundle size budget check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+bundle-report.json

--- a/README.md
+++ b/README.md
@@ -4,3 +4,6 @@ https://alex-unnippillil.github.io/CyberSecuirtyDictionary/
 
 ## Security
 For information on reporting vulnerabilities, please see our [Security Policy](SECURITY.md).
+
+## Bundle Size
+Each HTML route is limited to a 30 kB budget during the build. The bundle size check reports the size of every route and fails the build if any exceed the limit. The largest route at present is `layout.html` at roughly 1.85 kB, well under the budget.

--- a/index.html
+++ b/index.html
@@ -11,25 +11,25 @@
 <body>
   <main class="container">
     <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
+    <nav class="site-nav" aria-label="Site navigation"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
     <div id="definition-container" style="display: none;"></div>
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+    <button id="random-term" type="button" aria-label="Show random term">Random Term</button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+    <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">Toggle Dark Mode</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 
     <ul id="terms-list"></ul>
   </main>
-  <footer class="container">
+  <footer class="container" aria-label="Contribution link">
     <p><a href="templates/contribute.html">Contribute</a></p>
   </footer>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+  <button id="scrollToTopBtn" type="button" aria-label="Scroll to top">↑</button>
 
-  <footer>
+  <footer aria-label="Project links">
     <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
   </footer>
   <script src="script.js"></script>

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "description": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/",
   "main": "script.js",
   "scripts": {
-    "build": "node scripts/build.js",
+    "build": "sh build.sh && node scripts/size-check.js",
     "test": "html-validate index.html",
-    "watch": "chokidar \"**/*.html\" -c \"npm run build\""
+    "watch": "chokidar \"**/*.html\" -c \"npm run build\"",
+    "size": "node scripts/size-check.js"
   },
   "keywords": [],
   "author": "",

--- a/scripts/size-check.js
+++ b/scripts/size-check.js
@@ -1,0 +1,46 @@
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const BUDGET_BYTES = 30 * 1024; // 30 KB per route
+const IGNORE_DIRS = new Set(['node_modules', 'templates', '.git']);
+
+function walk(dir) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    if (IGNORE_DIRS.has(entry.name)) continue;
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...walk(fullPath));
+    } else if (entry.isFile() && entry.name.endsWith('.html')) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+const routes = walk(ROOT).map((file) => {
+  const size = fs.statSync(file).size;
+  return { route: path.relative(ROOT, file), size };
+});
+
+routes.forEach((r) => {
+  console.log(`${r.route}: ${(r.size / 1024).toFixed(2)} kB`);
+});
+
+let largest = { route: '', size: 0 };
+for (const r of routes) {
+  if (r.size > largest.size) largest = r;
+}
+
+console.log(`Largest route: ${largest.route} at ${(largest.size / 1024).toFixed(2)} kB`);
+
+const exceeded = routes.filter((r) => r.size > BUDGET_BYTES);
+if (exceeded.length > 0) {
+  console.error(`\nBundle size budget of ${BUDGET_BYTES} bytes exceeded:`);
+  exceeded.forEach((r) => {
+    console.error(`  ${r.route} at ${r.size} bytes`);
+  });
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add script to report bundle size per HTML route and enforce 30 kB budget
- integrate size check into build process and ignore node_modules
- document bundle size budget and update index page for test compliance

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b4c7e476888328b1cab5721406fba8