### PR TITLE
Defer heavy scripts and monitor performance metrics

### DIFF
--- a/assets/js/analytics.js
+++ b/assets/js/analytics.js
@@ -1,0 +1,4 @@
+(function(){
+  console.log("Analytics module loaded");
+  // Placeholder for analytics initialization.
+})();

--- a/assets/js/perf-monitor.js
+++ b/assets/js/perf-monitor.js
@@ -1,0 +1,29 @@
+(function(){
+  if (!("PerformanceObserver" in window)) {
+    return;
+  }
+  let tbt = 0;
+  const observer = new PerformanceObserver((list) => {
+    for (const entry of list.getEntries()) {
+      const blocking = entry.duration - 50;
+      if (blocking > 0) {
+        tbt += blocking;
+      }
+    }
+  });
+  observer.observe({ type: "longtask", buffered: true });
+
+  function report() {
+    try {
+      navigator.sendBeacon("/analytics", JSON.stringify({ tbt }));
+    } catch (e) {
+      console.log("TBT", tbt);
+    }
+  }
+
+  window.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "hidden") {
+      report();
+    }
+  });
+})();

--- a/assets/js/quiz.js
+++ b/assets/js/quiz.js
@@ -1,0 +1,4 @@
+(function(){
+  console.log("Quiz module loaded");
+  // Placeholder for quiz initialization.
+})();

--- a/index.html
+++ b/index.html
@@ -9,31 +9,32 @@
   <link rel="canonical" id="canonical-link" href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/">
 </head>
 <body>
-  <main class="container">
-    <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
+    <main class="container">
+      <h1>Cyber Security Dictionary</h1>
+      <nav class="site-nav" aria-label="Site navigation"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
     <div id="definition-container" style="display: none;"></div>
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+      <button id="random-term" aria-label="Show random term" type="button">Random Term</button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+      <button id="dark-mode-toggle" aria-label="Toggle dark mode" type="button">Toggle Dark Mode</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 
     <ul id="terms-list"></ul>
   </main>
-  <footer class="container">
-    <p><a href="templates/contribute.html">Contribute</a></p>
-  </footer>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+    <footer class="container" aria-label="Primary footer">
+      <p><a href="templates/contribute.html">Contribute</a></p>
+    </footer>
+    <button id="scrollToTopBtn" aria-label="Scroll to top" type="button">↑</button>
 
-  <footer>
-    <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
-  </footer>
-  <script src="script.js"></script>
-  <script src="assets/js/app.js"></script>
+    <footer aria-label="Secondary footer">
+      <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
+    </footer>
+  <script src="script.js" defer></script>
+  <script src="assets/js/app.js" defer></script>
+  <script src="assets/js/perf-monitor.js" defer></script>
 </body>
 </html>
 

--- a/layout.html
+++ b/layout.html
@@ -23,16 +23,17 @@
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+      <button id="random-term" aria-label="Show random term" type="button">Random Term</button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+      <button id="dark-mode-toggle" aria-label="Toggle dark mode" type="button">Toggle Dark Mode</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 
     <ul id="terms-list"></ul>
   </main>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+    <button id="scrollToTopBtn" aria-label="Scroll to top" type="button">↑</button>
 
-  <script src="script.js"></script>
+  <script src="script.js" defer></script>
+  <script src="assets/js/perf-monitor.js" defer></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -254,3 +254,20 @@ scrollBtn.addEventListener("click", () =>
 
 definitionContainer.addEventListener("click", clearDefinition);
 
+function loadDeferredScripts() {
+  const analytics = document.createElement("script");
+  analytics.src = "assets/js/analytics.js";
+  analytics.defer = true;
+  document.body.appendChild(analytics);
+
+  const quiz = document.createElement("script");
+  quiz.src = "assets/js/quiz.js";
+  quiz.defer = true;
+  document.body.appendChild(quiz);
+}
+
+if ("requestIdleCallback" in window) {
+  requestIdleCallback(loadDeferredScripts);
+} else {
+  window.addEventListener("load", loadDeferredScripts);
+}

--- a/search.html
+++ b/search.html
@@ -7,14 +7,15 @@
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-  <main class="container">
-    <h1>Search</h1>
-    <input id="search-box" type="text" placeholder="Search terms..." />
-    <div id="results"></div>
-  </main>
+    <main class="container">
+      <h1>Search</h1>
+      <input id="search-box" type="text" placeholder="Search terms...">
+      <div id="results"></div>
+    </main>
   <script>
     window.__BASE_URL__ = window.__BASE_URL__ || '';
   </script>
-  <script src="assets/js/search.js"></script>
+  <script src="assets/js/search.js" defer></script>
+  <script src="assets/js/perf-monitor.js" defer></script>
 </body>
 </html>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -1,26 +1,26 @@
 <!DOCTYPE html>
 <html lang="{{ lang }}">
-<head>
-  <meta charset="utf-8" />
-  <title>{{ title }}</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <head>
+    <meta charset="utf-8">
+    <title>{{ title }}</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <meta property="og:title" content="{{ og_title }}" />
-  <meta property="og:description" content="{{ og_description }}" />
-  <meta property="og:type" content="{{ og_type }}" />
-  <meta property="og:url" content="{{ canonical_url }}" />
-  <meta property="og:image" content="{{ og_image }}" />
+    <meta property="og:title" content="{{ og_title }}">
+    <meta property="og:description" content="{{ og_description }}">
+    <meta property="og:type" content="{{ og_type }}">
+    <meta property="og:url" content="{{ canonical_url }}">
+    <meta property="og:image" content="{{ og_image }}">
 
-  <meta name="twitter:card" content="{{ twitter_card }}" />
-  <meta name="twitter:site" content="{{ twitter_site }}" />
-  <meta name="twitter:title" content="{{ twitter_title }}" />
-  <meta name="twitter:description" content="{{ twitter_description }}" />
-  <meta name="twitter:image" content="{{ twitter_image }}" />
+    <meta name="twitter:card" content="{{ twitter_card }}">
+    <meta name="twitter:site" content="{{ twitter_site }}">
+    <meta name="twitter:title" content="{{ twitter_title }}">
+    <meta name="twitter:description" content="{{ twitter_description }}">
+    <meta name="twitter:image" content="{{ twitter_image }}">
 
-  <link rel="canonical" href="{{ canonical_url }}" />
-  <link rel="manifest" href="{{ manifest_url }}" />
-  <link rel="icon" href="{{ favicon_url }}" />
-  <link rel="stylesheet" href="{{ stylesheet_url }}" />
+    <link rel="canonical" href="{{ canonical_url }}">
+    <link rel="manifest" href="{{ manifest_url }}">
+    <link rel="icon" href="{{ favicon_url }}">
+    <link rel="stylesheet" href="{{ stylesheet_url }}">
 
   <script>
     const BASE_URL = "{{ base_url }}";
@@ -30,22 +30,23 @@
     {{ json_ld }}
   </script>
 </head>
-<body>
-  <a href="#main" class="skip-link">Skip to content</a>
-  <header role="banner">
-    <nav role="navigation" aria-label="Primary">
-      {{ navigation }}
-    </nav>
-  </header>
-  <main id="main" role="main">
-    {{ content }}
-  </main>
-  <footer role="contentinfo">
-    <ul>
-      <li><a href="{{ privacy_url }}">{{ privacy_label }}</a></li>
-      <li><a href="{{ contact_url }}">{{ contact_label }}</a></li>
-    </ul>
-  </footer>
-  <script src="{{ base_url }}/assets/js/app.js"></script>
+  <body>
+    <a href="#main" class="skip-link">Skip to content</a>
+    <header>
+      <nav aria-label="Primary">
+        {{ navigation }}
+      </nav>
+    </header>
+    <main id="main">
+      {{ content }}
+    </main>
+    <footer>
+      <ul>
+        <li><a href="{{ privacy_url }}">{{ privacy_label }}</a></li>
+        <li><a href="{{ contact_url }}">{{ contact_label }}</a></li>
+      </ul>
+    </footer>
+  <script src="{{ base_url }}/assets/js/app.js" defer></script>
+  <script src="{{ base_url }}/assets/js/perf-monitor.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load analytics and quiz modules during idle time
- defer all non-critical scripts across pages
- add performance observer to send total blocking time metrics
- fix accessibility issues and button types flagged by html-validate

## Testing
- `npm test`
- `npx --yes html-validate index.html layout.html search.html templates/layout.html`
- `CHROME_PATH=$(which chromium-browser) npx lighthouse index.html --chrome-flags="--headless" --output=json --output-path=./lighthouse-after.json` *(fails: waiting for Chrome due to missing snap Chromium)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c7e717c0832894f98dbc9c8dc805