### PR TITLE
feat: serve hashed assets with long-term caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/asset-manifest.json
+++ b/asset-manifest.json
@@ -1,0 +1,6 @@
+{
+  "styles.css": "styles.7fa2bea0.css",
+  "script.js": "script.c167e777.js",
+  "assets/js/app.js": "assets/js/app.a59bc1d0.js",
+  "assets/js/search.js": "assets/js/search.dbc888ee.js"
+}

--- a/assets/js/app.a59bc1d0.js
+++ b/assets/js/app.a59bc1d0.js
@@ -1,0 +1,5 @@
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/sw.js');
+  });
+}

--- a/assets/js/search.dbc888ee.js
+++ b/assets/js/search.dbc888ee.js
@@ -1,0 +1,77 @@
+(function(){
+  const resultsContainer = document.getElementById('results');
+  const searchInput = document.getElementById('search-box');
+  let terms = [];
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const baseUrl = window.__BASE_URL__ || '';
+    fetch(`${baseUrl}/terms.json`)
+      .then(r => r.ok ? r.json() : Promise.reject(r.statusText))
+      .then(data => {
+        // terms.json may either be an array or object with terms property
+        terms = Array.isArray(data) ? data : (data.terms || []);
+      })
+      .catch(err => {
+        console.error('Failed to load terms.json', err);
+      });
+
+    searchInput.addEventListener('input', handleSearch);
+  });
+
+  function handleSearch(){
+    const query = searchInput.value.trim().toLowerCase();
+    resultsContainer.innerHTML = '';
+    if(!query){
+      return;
+    }
+    const matches = terms
+      .map(term => ({ term, score: score(term, query) }))
+      .filter(item => item.score > 0)
+      .sort((a,b) => b.score - a.score);
+
+    matches.forEach(({ term }) => {
+      resultsContainer.appendChild(renderCard(term));
+    });
+  }
+
+  function score(term, query){
+    let s = 0;
+    const name = (term.name || term.term || '').toLowerCase();
+    const def = (term.definition || '').toLowerCase();
+    const category = (term.category || '').toLowerCase();
+    const syns = (term.synonyms || []).map(s=>s.toLowerCase());
+    if(name.includes(query)) s += 3;
+    if(def.includes(query)) s += 1;
+    if(category.includes(query)) s += 1;
+    if(syns.some(syn => syn.includes(query))) s += 2;
+    return s;
+  }
+
+  function renderCard(term){
+    const card = document.createElement('div');
+    card.className = 'result-card';
+
+    const title = document.createElement('h3');
+    title.textContent = term.name || term.term || '';
+    card.appendChild(title);
+
+    if(term.category){
+      const cat = document.createElement('p');
+      cat.className = 'category';
+      cat.textContent = term.category;
+      card.appendChild(cat);
+    }
+
+    const def = document.createElement('p');
+    def.textContent = term.definition || '';
+    card.appendChild(def);
+
+    if(term.synonyms && term.synonyms.length){
+      const syn = document.createElement('p');
+      syn.className = 'synonyms';
+      syn.textContent = `Synonyms: ${term.synonyms.join(', ')}`;
+      card.appendChild(syn);
+    }
+    return card;
+  }
+})();

--- a/hash-assets.js
+++ b/hash-assets.js
@@ -1,0 +1,39 @@
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+const assets = [
+  'styles.css',
+  'script.js',
+  path.join('assets','js','app.js'),
+  path.join('assets','js','search.js')
+];
+
+const manifest = {};
+
+for (const asset of assets) {
+  const filePath = path.join(__dirname, asset);
+  const content = fs.readFileSync(filePath);
+  const hash = crypto.createHash('sha256').update(content).digest('hex').slice(0,8);
+  const ext = path.extname(asset);
+  const base = path.basename(asset, ext);
+  const dir = path.dirname(asset);
+  const hashedFile = path.join(dir, `${base}.${hash}${ext}`);
+  fs.writeFileSync(path.join(__dirname, hashedFile), content);
+  manifest[asset] = hashedFile.replace(/\\/g, '/');
+}
+
+fs.writeFileSync(path.join(__dirname, 'asset-manifest.json'), JSON.stringify(manifest, null, 2));
+
+const filesToUpdate = ['index.html', 'search.html', 'layout.html', 'sw.js'];
+for (const file of filesToUpdate) {
+  const filePath = path.join(__dirname, file);
+  let data = fs.readFileSync(filePath, 'utf8');
+  for (const [original, hashed] of Object.entries(manifest)) {
+    const regex = new RegExp(original.replace(/[.*+?^${}()|[\\]\\]/g, '\\$&'), 'g');
+    data = data.replace(regex, hashed);
+  }
+  fs.writeFileSync(filePath, data);
+}
+
+console.log('Hashed assets generated:', manifest);

--- a/index.html
+++ b/index.html
@@ -4,36 +4,36 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Cyber Security Dictionary</title>
-  <link rel="stylesheet" href="styles.css">
+  <link rel="stylesheet" href="styles.7fa2bea0.css">
   <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet">
   <link rel="canonical" id="canonical-link" href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/">
 </head>
 <body>
   <main class="container">
     <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
+      <nav class="site-nav" aria-label="Site navigation"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
     <div id="definition-container" style="display: none;"></div>
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+      <button id="random-term" type="button" aria-label="Show random term">Random Term</button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+      <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">Toggle Dark Mode</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 
     <ul id="terms-list"></ul>
   </main>
-  <footer class="container">
+    <footer class="container" aria-label="Contribution links">
     <p><a href="templates/contribute.html">Contribute</a></p>
   </footer>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+    <button id="scrollToTopBtn" type="button" aria-label="Scroll to top">↑</button>
 
-  <footer>
+    <footer aria-label="Project footer">
     <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
   </footer>
-  <script src="script.js"></script>
-  <script src="assets/js/app.js"></script>
+  <script src="script.c167e777.js"></script>
+  <script src="assets/js/app.a59bc1d0.js"></script>
 </body>
 </html>
 

--- a/layout.html
+++ b/layout.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Cyber Security Dictionary</title>
-  <link rel="stylesheet" href="styles.css">
+  <link rel="stylesheet" href="styles.7fa2bea0.css">
   <meta property="og:title" content="Cyber Security Dictionary">
   <meta property="og:description" content="An interactive dictionary for cyber security terms.">
   <meta property="og:type" content="website">
@@ -23,16 +23,16 @@
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+      <button id="random-term" type="button" aria-label="Show random term">Random Term</button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+      <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">Toggle Dark Mode</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 
     <ul id="terms-list"></ul>
   </main>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+    <button id="scrollToTopBtn" type="button" aria-label="Scroll to top">↑</button>
 
-  <script src="script.js"></script>
+  <script src="script.c167e777.js"></script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "build": "node scripts/build.js",
     "test": "html-validate index.html",
-    "watch": "chokidar \"**/*.html\" -c \"npm run build\""
+    "watch": "chokidar \"**/*.html\" -c \"npm run build\"",
+    "hash": "node hash-assets.js",
+    "start": "node server.js"
   },
   "keywords": [],
   "author": "",

--- a/script.c167e777.js
+++ b/script.c167e777.js
@@ -1,0 +1,256 @@
+const termsList = document.getElementById("terms-list");
+const definitionContainer = document.getElementById("definition-container");
+const searchInput = document.getElementById("search");
+const randomButton = document.getElementById("random-term");
+const alphaNav = document.getElementById("alpha-nav");
+const darkModeToggle = document.getElementById("dark-mode-toggle");
+const showFavoritesToggle = document.getElementById("show-favorites");
+const favorites = new Set(JSON.parse(localStorage.getItem("favorites") || "[]"));
+const siteUrl = "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/";
+const canonicalLink = document.getElementById("canonical-link");
+
+let currentLetterFilter = "All";
+let termsData = { terms: [] };
+
+if (localStorage.getItem("darkMode") === "true") {
+  document.body.classList.add("dark-mode");
+}
+
+if (darkModeToggle) {
+  darkModeToggle.addEventListener("click", () => {
+    document.body.classList.toggle("dark-mode");
+    localStorage.setItem("darkMode", document.body.classList.contains("dark-mode"));
+  });
+}
+
+window.addEventListener("DOMContentLoaded", () => {
+  loadTerms();
+});
+
+function loadTerms() {
+  fetch("terms.json")
+    .then((response) => {
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+      return response.json();
+    })
+    .then((data) => {
+      termsData = data;
+      removeDuplicateTermsAndDefinitions();
+      termsData.terms.sort((a, b) => a.term.localeCompare(b.term));
+      buildAlphaNav();
+      populateTermsList();
+
+      if (window.location.hash) {
+        const termFromHash = decodeURIComponent(window.location.hash.substring(1));
+        const matchedTerm = termsData.terms.find(
+          (t) => t.term.toLowerCase() === termFromHash.toLowerCase()
+        );
+        if (matchedTerm) {
+          displayDefinition(matchedTerm);
+        }
+      }
+    })
+    .catch((error) => {
+      console.error("Detailed error fetching data:", error);
+      definitionContainer.style.display = "block";
+      definitionContainer.innerHTML =
+        '<p>Unable to load dictionary data. Please check your connection and try again.</p>' +
+        '<button id="retry-fetch">Retry</button>';
+      const retryBtn = document.getElementById("retry-fetch");
+      if (retryBtn) {
+        retryBtn.addEventListener("click", (e) => {
+          e.stopPropagation();
+          loadTerms();
+        });
+      }
+    });
+}
+
+function removeDuplicateTermsAndDefinitions() {
+  const uniqueTerms = new Set();
+  const uniqueTermsData = [];
+
+  termsData.terms.forEach((item) => {
+    const lowerCaseTerm = item.term.toLowerCase();
+    if (!uniqueTerms.has(lowerCaseTerm)) {
+      uniqueTerms.add(lowerCaseTerm);
+      uniqueTermsData.push(item);
+    }
+  });
+
+  termsData.terms = uniqueTermsData;
+}
+
+function toggleFavorite(term) {
+  if (favorites.has(term)) {
+    favorites.delete(term);
+  } else {
+    favorites.add(term);
+  }
+  try {
+    localStorage.setItem("favorites", JSON.stringify(Array.from(favorites)));
+  } catch (e) {
+    // Ignore storage errors
+  }
+}
+
+function highlightActiveButton(button) {
+  alphaNav.querySelectorAll("button").forEach((btn) => btn.classList.remove("active"));
+  button.classList.add("active");
+}
+
+function buildAlphaNav() {
+  const letters = Array.from(new Set(termsData.terms.map((t) => t.term.charAt(0).toUpperCase()))).sort();
+
+  const allButton = document.createElement("button");
+  allButton.textContent = "All";
+  allButton.addEventListener("click", () => {
+    currentLetterFilter = "All";
+    highlightActiveButton(allButton);
+    populateTermsList();
+  });
+  alphaNav.appendChild(allButton);
+
+  letters.forEach((letter) => {
+    const btn = document.createElement("button");
+    btn.textContent = letter;
+    btn.addEventListener("click", () => {
+      currentLetterFilter = letter;
+      highlightActiveButton(btn);
+      populateTermsList();
+    });
+    alphaNav.appendChild(btn);
+  });
+
+  highlightActiveButton(allButton);
+}
+
+function populateTermsList() {
+  termsList.innerHTML = "";
+  const searchValue = searchInput.value.trim().toLowerCase();
+  termsData.terms
+    .sort((a, b) => a.term.localeCompare(b.term))
+    .forEach((item) => {
+      const matchesSearch = item.term.toLowerCase().includes(searchValue);
+      const matchesFavorites = !showFavoritesToggle || !showFavoritesToggle.checked || favorites.has(item.term);
+      const matchesLetter =
+        currentLetterFilter === "All" || item.term.charAt(0).toUpperCase() === currentLetterFilter;
+      if (matchesSearch && matchesFavorites && matchesLetter) {
+        const termDiv = document.createElement("div");
+        termDiv.classList.add("dictionary-item");
+
+        const termHeader = document.createElement("h3");
+        if (searchValue) {
+          const escaped = searchValue.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+          const regex = new RegExp(`(${escaped})`, "gi");
+          termHeader.innerHTML = item.term.replace(regex, "<mark>$1</mark>");
+        } else {
+          termHeader.textContent = item.term;
+        }
+
+        const star = document.createElement("span");
+        star.classList.add("favorite-star");
+        star.textContent = "★";
+        if (favorites.has(item.term)) {
+          star.classList.add("favorited");
+        }
+        star.addEventListener("click", (e) => {
+          e.stopPropagation();
+          toggleFavorite(item.term);
+          star.classList.toggle("favorited");
+          if (showFavoritesToggle && showFavoritesToggle.checked) {
+            populateTermsList();
+          }
+        });
+        termHeader.appendChild(star);
+        termDiv.appendChild(termHeader);
+
+        const definitionPara = document.createElement("p");
+        definitionPara.textContent = item.definition;
+        termDiv.appendChild(definitionPara);
+
+        termDiv.addEventListener("click", () => {
+          displayDefinition(item);
+        });
+
+        termsList.appendChild(termDiv);
+      }
+    });
+}
+
+function displayDefinition(term) {
+  definitionContainer.style.display = "block";
+  definitionContainer.innerHTML = `<h3>${term.term}</h3><p>${term.definition}</p>`;
+  window.location.hash = encodeURIComponent(term.term);
+  if (canonicalLink) {
+    canonicalLink.setAttribute(
+      "href",
+      `${siteUrl}#${encodeURIComponent(term.term)}`
+    );
+  }
+}
+
+function clearDefinition() {
+  definitionContainer.style.display = "none";
+  definitionContainer.innerHTML = "";
+  history.replaceState(null, "", window.location.pathname + window.location.search);
+  if (canonicalLink) {
+    canonicalLink.setAttribute("href", siteUrl);
+  }
+}
+
+function showRandomTerm() {
+  const randomTerm = termsData.terms[Math.floor(Math.random() * termsData.terms.length)];
+  displayDefinition(randomTerm);
+
+  const today = new Date().toDateString();
+  try {
+    localStorage.setItem("lastRandomTerm", JSON.stringify({ date: today, term: randomTerm }));
+  } catch (e) {
+    // Ignore storage errors
+  }
+}
+
+randomButton.addEventListener("click", showRandomTerm);
+if (showFavoritesToggle) {
+  showFavoritesToggle.addEventListener("change", () => {
+    clearDefinition();
+    populateTermsList();
+  });
+}
+
+(function initializeDailyTerm() {
+  const today = new Date().toDateString();
+  try {
+    const stored = localStorage.getItem("lastRandomTerm");
+    if (stored) {
+      const parsed = JSON.parse(stored);
+      if (parsed.date === today && parsed.term) {
+        displayDefinition(parsed.term);
+        return;
+      }
+    }
+  } catch (e) {
+    // Ignore parse errors and fall back to showing a random term
+  }
+
+  showRandomTerm();
+})();
+
+searchInput.addEventListener("input", () => {
+  clearDefinition();
+  populateTermsList();
+});
+
+const scrollBtn = document.getElementById("scrollToTopBtn");
+window.addEventListener("scroll", () => {
+  scrollBtn.style.display = window.scrollY > 200 ? "block" : "none";
+});
+scrollBtn.addEventListener("click", () =>
+  window.scrollTo({ top: 0, behavior: "smooth" })
+);
+
+definitionContainer.addEventListener("click", clearDefinition);
+

--- a/search.html
+++ b/search.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Search</title>
-  <link rel="stylesheet" href="styles.css">
+  <link rel="stylesheet" href="styles.7fa2bea0.css">
 </head>
 <body>
   <main class="container">
@@ -15,6 +15,6 @@
   <script>
     window.__BASE_URL__ = window.__BASE_URL__ || '';
   </script>
-  <script src="assets/js/search.js"></script>
+  <script src="assets/js/search.dbc888ee.js"></script>
 </body>
 </html>

--- a/server.js
+++ b/server.js
@@ -1,0 +1,47 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const mimeTypes = {
+  '.html': 'text/html',
+  '.css': 'text/css',
+  '.js': 'application/javascript',
+  '.json': 'application/json'
+};
+
+const server = http.createServer((req, res) => {
+  let reqPath = req.url.split('?')[0];
+  if (reqPath === '/' || reqPath === '') {
+    reqPath = '/index.html';
+  }
+  const filePath = path.join(__dirname, reqPath);
+  fs.stat(filePath, (err, stats) => {
+    if (err || !stats.isFile()) {
+      res.statusCode = 404;
+      res.end('Not found');
+      return;
+    }
+    const ext = path.extname(filePath);
+    res.setHeader('Content-Type', mimeTypes[ext] || 'application/octet-stream');
+    const name = path.basename(filePath);
+    const hashMatch = name.match(/\.([0-9a-f]{8})\./);
+    if (hashMatch) {
+      const etag = hashMatch[1];
+      res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
+      res.setHeader('ETag', etag);
+      if (req.headers['if-none-match'] === etag) {
+        res.statusCode = 304;
+        res.end();
+        return;
+      }
+    } else {
+      res.setHeader('Cache-Control', 'public, max-age=0, must-revalidate');
+    }
+    fs.createReadStream(filePath).pipe(res);
+  });
+});
+
+const port = process.env.PORT || 8080;
+server.listen(port, () => {
+  console.log(`Server running on http://localhost:${port}`);
+});

--- a/styles.7fa2bea0.css
+++ b/styles.7fa2bea0.css
@@ -1,0 +1,349 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: Arial, sans-serif;
+  line-height: 1.6;
+  background-color: #f8f8f8;
+  margin: 0;
+  padding: 0;
+  overflow-x: hidden;
+}
+
+.container {
+  max-width: 800px;
+  width: 100%;
+  margin: 0 auto;
+  padding: 20px;
+  background-color: #fff;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+  border-radius: 8px;
+}
+
+h1 {
+  text-align: center;
+  font-family: 'Cinzel', serif;
+  font-weight: 700;
+  font-size: 48px;
+  margin-bottom: 20px;
+  color: #333;
+  text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.1);
+}
+
+ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+li {
+  padding: 12px 20px;
+  background-color: #fff;
+  border-bottom: 1px solid #e0e0e0;
+  cursor: pointer;
+  transition: background-color 0.2s;
+  min-height: 44px;
+}
+
+li:last-child {
+  border-bottom: none;
+}
+
+li:hover {
+  background-color: #f5f5f5;
+}
+
+mark {
+  background-color: yellow;
+  color: inherit;
+}
+
+body.dark-mode mark {
+  background-color: #ffeb3b;
+  color: #000;
+}
+
+.dictionary-item {
+  margin-bottom: 20px;
+  padding: 12px;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  cursor: pointer;
+  transition: transform 0.2s;
+  min-height: 44px;
+}
+
+.dictionary-item h3 {
+  font-size: 24px;
+  margin: 0;
+  padding-bottom: 10px;
+  border-bottom: 1px solid #ccc;
+  color: #333;
+}
+
+.dictionary-item p {
+  font-size: 16px;
+  color: #666;
+}
+
+.dictionary-item:hover {
+  transform: scale(1.02);
+}
+
+#definition-container {
+  padding: 20px;
+  background-color: #f2f2f2;
+  border-radius: 5px;
+  box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
+  margin-bottom: 20px;
+}
+
+#search {
+  width: 100%;
+  padding: 10px;
+  font-size: 16px;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
+  min-height: 44px;
+}
+
+
+/* Controls styling */
+#random-term {
+  margin-top: 10px;
+  padding: 10px;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  background-color: #007bff;
+  color: #fff;
+  cursor: pointer;
+  min-width: 44px;
+  min-height: 44px;
+}
+
+#random-term:hover {
+  background-color: #0056b3;
+}
+
+#dark-mode-toggle {
+  margin-top: 10px;
+  padding: 10px;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  background-color: #007bff;
+  color: #fff;
+  cursor: pointer;
+  min-width: 44px;
+  min-height: 44px;
+}
+
+#dark-mode-toggle:hover {
+  background-color: #0056b3;
+}
+
+label {
+  margin-left: 10px;
+  margin-top: 10px;
+  display: inline-block;
+  line-height: 44px;
+}
+
+#show-favorites {
+  width: 44px;
+  height: 44px;
+  margin-right: 5px;
+}
+
+/* Favorite star styles */
+.favorite-star {
+  font-size: 20px;
+  color: #ccc;
+  cursor: pointer;
+  margin-left: 5px;
+  transition: color 0.2s;
+  width: 44px;
+  height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.favorite-star:hover,
+.favorite-star:focus {
+  color: #999;
+}
+
+.favorited {
+  color: #ffd700;
+}
+
+/* Category badge styles */
+.badge {
+  display: inline-block;
+  padding: 2px 8px;
+  font-size: 0.75em;
+  border-radius: 12px;
+  background-color: #0056b3;
+  color: #fff;
+}
+
+/* Alphabet navigation styles */
+#alpha-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  justify-content: center;
+  margin-bottom: 15px;
+}
+
+#alpha-nav button {
+  background-color: #eee;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  padding: 10px;
+  cursor: pointer;
+  transition: background-color 0.2s, color 0.2s;
+  min-width: 44px;
+  min-height: 44px;
+}
+
+#alpha-nav button:hover,
+#alpha-nav button:focus {
+  background-color: #ddd;
+}
+
+#alpha-nav button.active {
+  background-color: #007bff;
+  border-color: #007bff;
+  color: #fff;
+}
+
+/* Scroll to Top button styles */
+#scrollToTopBtn {
+  display: none;
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  font-size: 20px;
+  border: none;
+  background-color: #007bff;
+  color: #fff;
+  cursor: pointer;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+}
+
+#scrollToTopBtn:hover {
+  background-color: #0056b3;
+}
+
+/* Dark Mode styles */
+body.dark-mode {
+  background-color: #121212;
+  color: #fff;
+}
+
+body.dark-mode .container {
+  background-color: #1e1e1e;
+}
+
+body.dark-mode #search {
+  background-color: #1e1e1e;
+  color: #fff;
+  border-color: #333;
+}
+
+body.dark-mode #dark-mode-toggle {
+  background-color: #333;
+  color: #fff;
+  border-color: #555;
+}
+
+body.dark-mode li {
+  background-color: #1e1e1e;
+  border-bottom: 1px solid #333;
+}
+
+body.dark-mode li:hover {
+  background-color: #333;
+}
+
+body.dark-mode .dictionary-item {
+  background-color: #1e1e1e;
+  border-color: #333;
+}
+
+body.dark-mode .dictionary-item h3 {
+  color: #fff;
+  border-bottom-color: #333;
+}
+
+body.dark-mode .dictionary-item p {
+  color: #ccc;
+}
+
+body.dark-mode #definition-container {
+  background-color: #1e1e1e;
+  box-shadow: 0 0 5px rgba(255, 255, 255, 0.1);
+}
+
+body.dark-mode .favorite-star {
+  color: #888;
+}
+
+body.dark-mode .favorite-star:hover,
+body.dark-mode .favorite-star:focus {
+  color: #bbb;
+}
+
+body.dark-mode .favorited {
+  color: #ffd700;
+}
+
+body.dark-mode .badge {
+  background-color: #1e90ff;
+  color: #000;
+}
+
+body.dark-mode #alpha-nav button {
+  background-color: #333;
+  border-color: #555;
+  color: #fff;
+}
+
+body.dark-mode #alpha-nav button:hover,
+body.dark-mode #alpha-nav button:focus {
+  background-color: #555;
+}
+
+body.dark-mode #alpha-nav button.active {
+  background-color: #007bff;
+  border-color: #007bff;
+}
+
+@media (max-width: 480px) {
+  h1 {
+    font-size: 32px;
+  }
+
+  .container {
+    padding: 10px;
+  }
+
+  .dictionary-item h3 {
+    font-size: 20px;
+  }
+
+  .dictionary-item p {
+    font-size: 14px;
+  }
+
+  #alpha-nav button {
+    font-size: 14px;
+  }
+}

--- a/sw.js
+++ b/sw.js
@@ -2,8 +2,8 @@ const CACHE_NAME = 'csd-cache-v1';
 const URLS_TO_CACHE = [
   '/',
   '/index.html',
-  '/styles.css',
-  '/script.js',
+  '/styles.7fa2bea0.css',
+  '/script.c167e777.js',
   '/data.json'
 ];
 


### PR DESCRIPTION
## Summary
- add hash-assets script to fingerprint CSS and JS, updating references automatically
- serve hashed assets with express-less HTTP server using `Cache-Control: max-age=31536000, immutable`
- add start/hash npm scripts and minor accessibility fixes for buttons and landmarks

## Testing
- `npm test`
- `curl -sI http://localhost:8080/styles.7fa2bea0.css`
- `curl -s -w '%{time_total}\n' -o /tmp/first.css http://localhost:8080/styles.7fa2bea0.css`
- `curl -s -H 'If-None-Match: 7fa2bea0' -w '%{time_total}\n' -o /tmp/second.css http://localhost:8080/styles.7fa2bea0.css`


------
https://chatgpt.com/codex/tasks/task_e_68b4c7e796848328afbb426cfa9935dc