### PR TITLE
Add cookie-free analytics with custom event hooks

### DIFF
--- a/assets/js/analytics.js
+++ b/assets/js/analytics.js
@@ -1,0 +1,30 @@
+(function(){
+  const domain = 'alex-unnippillil.github.io';
+
+  function track(eventName, props = {}) {
+    if (typeof window.plausible === 'function') {
+      window.plausible(eventName, { props });
+    } else {
+      window.plausible = window.plausible || function(){ (window.plausible.q = window.plausible.q || []).push(arguments); };
+      window.plausible(eventName, { props });
+    }
+  }
+
+  window.analytics = {
+    trackEvent: track,
+    trackSearch(query) {
+      if (query) {
+        track('Search', { query });
+      }
+    },
+    trackQuizStart(quizId) {
+      track('QuizStart', { quizId });
+    },
+    trackQuizAnswer(quizId, questionId, correct) {
+      track('QuizAnswer', { quizId, questionId, correct });
+    },
+    trackQuizComplete(quizId, score) {
+      track('QuizComplete', { quizId, score });
+    }
+  };
+})();

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -24,6 +24,9 @@
     if(!query){
       return;
     }
+    if(window.analytics){
+      window.analytics.trackSearch(query);
+    }
     const matches = terms
       .map(term => ({ term, score: score(term, query) }))
       .filter(item => item.score > 0)

--- a/index.html
+++ b/index.html
@@ -11,29 +11,31 @@
 <body>
   <main class="container">
     <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
+    <nav class="site-nav" aria-label="Site links"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
     <div id="definition-container" style="display: none;"></div>
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+    <button id="random-term" type="button" aria-label="Show random term">Random Term</button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+    <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">Toggle Dark Mode</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 
     <ul id="terms-list"></ul>
   </main>
-  <footer class="container">
+  <footer class="container" aria-label="Contributor info">
     <p><a href="templates/contribute.html">Contribute</a></p>
   </footer>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+  <button id="scrollToTopBtn" type="button" aria-label="Scroll to top">↑</button>
 
-  <footer>
+  <footer aria-label="Project info">
     <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
   </footer>
   <script src="script.js"></script>
   <script src="assets/js/app.js"></script>
+  <script defer data-domain="alex-unnippillil.github.io" src="https://plausible.io/js/script.js"></script>
+  <script src="assets/js/analytics.js"></script>
 </body>
 </html>
 

--- a/layout.html
+++ b/layout.html
@@ -23,16 +23,18 @@
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+    <button id="random-term" type="button" aria-label="Show random term">Random Term</button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+    <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">Toggle Dark Mode</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 
     <ul id="terms-list"></ul>
   </main>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+  <button id="scrollToTopBtn" type="button" aria-label="Scroll to top">↑</button>
 
   <script src="script.js"></script>
+  <script defer data-domain="alex-unnippillil.github.io" src="https://plausible.io/js/script.js"></script>
+  <script src="assets/js/analytics.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -242,6 +242,12 @@ if (showFavoritesToggle) {
 searchInput.addEventListener("input", () => {
   clearDefinition();
   populateTermsList();
+  if (window.analytics) {
+    const query = searchInput.value.trim();
+    if (query) {
+      window.analytics.trackSearch(query);
+    }
+  }
 });
 
 const scrollBtn = document.getElementById("scrollToTopBtn");

--- a/search.html
+++ b/search.html
@@ -9,12 +9,14 @@
 <body>
   <main class="container">
     <h1>Search</h1>
-    <input id="search-box" type="text" placeholder="Search terms..." />
+    <input id="search-box" type="text" placeholder="Search terms...">
     <div id="results"></div>
   </main>
   <script>
     window.__BASE_URL__ = window.__BASE_URL__ || '';
   </script>
+  <script defer data-domain="alex-unnippillil.github.io" src="https://plausible.io/js/script.js"></script>
+  <script src="assets/js/analytics.js"></script>
   <script src="assets/js/search.js"></script>
 </body>
 </html>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -47,5 +47,7 @@
     </ul>
   </footer>
   <script src="{{ base_url }}/assets/js/app.js"></script>
+  <script defer data-domain="alex-unnippillil.github.io" src="https://plausible.io/js/script.js"></script>
+  <script src="{{ base_url }}/assets/js/analytics.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Integrate Plausible analytics without cookies and expose global hooks for custom events and quizzes
- Track search queries and hook site scripts into analytics
- Include analytics scripts and accessibility fixes across site layouts

## Testing
- `npm test`
- `npx html-validate search.html`
- `npx html-validate layout.html`
- `npx html-validate templates/layout.html` *(fails: void-style & no-redundant-role)*
- `curl -i https://plausible.io/api/event -H 'User-Agent: Mozilla/5.0' -H 'Content-Type: application/json' -d '{"name":"Search","url":"https://alex-unnippillil.github.io/CyberSecuirtyDictionary/","domain":"alex-unnippillil.github.io","props":{"query":"test"}}'`
- `curl -i https://plausible.io/api/event -H 'User-Agent: Mozilla/5.0' -H 'Content-Type: application/json' -d '{"name":"QuizStart","url":"https://alex-unnippillil.github.io/CyberSecuirtyDictionary/quiz","domain":"alex-unnippillil.github.io","props":{"quizId":"sample"}}'`


------
https://chatgpt.com/codex/tasks/task_e_68b4c7e99f908328b01571126648bdea