### PR TITLE
feat: add oEmbed support for term previews

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -4,3 +4,18 @@ https://alex-unnippillil.github.io/CyberSecuirtyDictionary/
 
 ## Security
 For information on reporting vulnerabilities, please see our [Security Policy](SECURITY.md).
+
+## oEmbed
+Static oEmbed responses are available for each term. These files live under the
+`oembed/` directory and can be used by platforms that support oEmbed to preview
+dictionary entries.
+
+For example, the term **Phishing** exposes an oEmbed response at:
+
+```
+https://alex-unnippillil.github.io/CyberSecuirtyDictionary/oembed/phishing.json
+```
+
+To embed a term, link to `#Term` on the main site (e.g.
+`https://alex-unnippillil.github.io/CyberSecuirtyDictionary/#Phishing`). The
+page automatically advertises the corresponding oEmbed URL for unfurling.

--- a/build.sh
+++ b/build.sh
@@ -1,9 +1,12 @@
 #!/bin/sh
 set -e
-
 # Build script for CyberSecuirtyDictionary
-# Generates .well-known/security.txt following RFC 9116
+# Generates static assets required for the site
 
+# Generate oEmbed responses for each term
+node scripts/generate-oembed.js
+
+# Generate .well-known/security.txt following RFC 9116
 mkdir -p .well-known
 cat <<'TXT' > .well-known/security.txt
 # Security contact for CyberSecuirtyDictionary

--- a/index.html
+++ b/index.html
@@ -7,29 +7,30 @@
   <link rel="stylesheet" href="styles.css">
   <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet">
   <link rel="canonical" id="canonical-link" href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/">
+  <link rel="alternate" type="application/json+oembed" href="oembed/index.json" id="oembed-link">
 </head>
 <body>
   <main class="container">
     <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
+    <nav class="site-nav" aria-label="Site navigation"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
     <div id="definition-container" style="display: none;"></div>
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+    <button id="random-term" type="button" aria-label="Show random term">Random Term</button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+    <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">Toggle Dark Mode</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 
     <ul id="terms-list"></ul>
   </main>
-  <footer class="container">
+    <footer class="container" aria-label="Contributor links">
     <p><a href="templates/contribute.html">Contribute</a></p>
   </footer>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+    <button id="scrollToTopBtn" type="button" aria-label="Scroll to top">↑</button>
 
-  <footer>
+    <footer aria-label="Project links">
     <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
   </footer>
   <script src="script.js"></script>

--- a/oembed/advanced-encryption-standard-aes.json
+++ b/oembed/advanced-encryption-standard-aes.json
@@ -1,0 +1,8 @@
+{
+  "version": "1.0",
+  "type": "rich",
+  "provider_name": "Cyber Security Dictionary",
+  "provider_url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary",
+  "title": "Advanced Encryption Standard (AES)",
+  "html": "<div><strong>Advanced Encryption Standard (AES):</strong> A widely used symmetric key encryption algorithm known for its security and efficiency. <a href=\"https://alex-unnippillil.github.io/CyberSecuirtyDictionary#Advanced%20Encryption%20Standard%20(AES)\">Read more</a></div>"
+}

--- a/oembed/advanced-persistent-threat-apt.json
+++ b/oembed/advanced-persistent-threat-apt.json
@@ -1,0 +1,8 @@
+{
+  "version": "1.0",
+  "type": "rich",
+  "provider_name": "Cyber Security Dictionary",
+  "provider_url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary",
+  "title": "Advanced Persistent Threat (APT)",
+  "html": "<div><strong>Advanced Persistent Threat (APT):</strong> A prolonged and targeted cyber attack in which attackers gain and maintain unauthorized access to a network. <a href=\"https://alex-unnippillil.github.io/CyberSecuirtyDictionary#Advanced%20Persistent%20Threat%20(APT)\">Read more</a></div>"
+}

--- a/oembed/certificate-authority-ca.json
+++ b/oembed/certificate-authority-ca.json
@@ -1,0 +1,8 @@
+{
+  "version": "1.0",
+  "type": "rich",
+  "provider_name": "Cyber Security Dictionary",
+  "provider_url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary",
+  "title": "Certificate Authority (CA)",
+  "html": "<div><strong>Certificate Authority (CA):</strong> An entity responsible for issuing and managing digital certificates used in PKI. <a href=\"https://alex-unnippillil.github.io/CyberSecuirtyDictionary#Certificate%20Authority%20(CA)\">Read more</a></div>"
+}

--- a/oembed/cross-site-request-forgery-csrf.json
+++ b/oembed/cross-site-request-forgery-csrf.json
@@ -1,0 +1,8 @@
+{
+  "version": "1.0",
+  "type": "rich",
+  "provider_name": "Cyber Security Dictionary",
+  "provider_url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary",
+  "title": "Cross-Site Request Forgery (CSRF)",
+  "html": "<div><strong>Cross-Site Request Forgery (CSRF):</strong> An attack that tricks a user into unknowingly submitting a malicious request on a trusted website. <a href=\"https://alex-unnippillil.github.io/CyberSecuirtyDictionary#Cross-Site%20Request%20Forgery%20(CSRF)\">Read more</a></div>"
+}

--- a/oembed/cross-site-scripting-xss.json
+++ b/oembed/cross-site-scripting-xss.json
@@ -1,0 +1,8 @@
+{
+  "version": "1.0",
+  "type": "rich",
+  "provider_name": "Cyber Security Dictionary",
+  "provider_url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary",
+  "title": "Cross-Site Scripting (XSS)",
+  "html": "<div><strong>Cross-Site Scripting (XSS):</strong> A type of web vulnerability where attackers inject malicious scripts into web pages viewed by other users. <a href=\"https://alex-unnippillil.github.io/CyberSecuirtyDictionary#Cross-Site%20Scripting%20(XSS)\">Read more</a></div>"
+}

--- a/oembed/cryptography.json
+++ b/oembed/cryptography.json
@@ -1,0 +1,8 @@
+{
+  "version": "1.0",
+  "type": "rich",
+  "provider_name": "Cyber Security Dictionary",
+  "provider_url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary",
+  "title": "Cryptography",
+  "html": "<div><strong>Cryptography:</strong> The practice of secure communication by converting plaintext into ciphertext and vice versa. <a href=\"https://alex-unnippillil.github.io/CyberSecuirtyDictionary#Cryptography\">Read more</a></div>"
+}

--- a/oembed/cyber-espionage.json
+++ b/oembed/cyber-espionage.json
@@ -1,0 +1,8 @@
+{
+  "version": "1.0",
+  "type": "rich",
+  "provider_name": "Cyber Security Dictionary",
+  "provider_url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary",
+  "title": "Cyber Espionage",
+  "html": "<div><strong>Cyber Espionage:</strong> The use of cyber techniques to steal sensitive information from governments, organizations, or individuals. <a href=\"https://alex-unnippillil.github.io/CyberSecuirtyDictionary#Cyber%20Espionage\">Read more</a></div>"
+}

--- a/oembed/data-encryption-standard-des.json
+++ b/oembed/data-encryption-standard-des.json
@@ -1,0 +1,8 @@
+{
+  "version": "1.0",
+  "type": "rich",
+  "provider_name": "Cyber Security Dictionary",
+  "provider_url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary",
+  "title": "Data Encryption Standard (DES)",
+  "html": "<div><strong>Data Encryption Standard (DES):</strong> An early symmetric key encryption algorithm used to secure electronic data. <a href=\"https://alex-unnippillil.github.io/CyberSecuirtyDictionary#Data%20Encryption%20Standard%20(DES)\">Read more</a></div>"
+}

--- a/oembed/data-loss-prevention-dlp.json
+++ b/oembed/data-loss-prevention-dlp.json
@@ -1,0 +1,8 @@
+{
+  "version": "1.0",
+  "type": "rich",
+  "provider_name": "Cyber Security Dictionary",
+  "provider_url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary",
+  "title": "Data Loss Prevention (DLP)",
+  "html": "<div><strong>Data Loss Prevention (DLP):</strong> A strategy and set of tools to prevent the unauthorized loss or leakage of sensitive data. <a href=\"https://alex-unnippillil.github.io/CyberSecuirtyDictionary#Data%20Loss%20Prevention%20(DLP)\">Read more</a></div>"
+}

--- a/oembed/eavesdropping.json
+++ b/oembed/eavesdropping.json
@@ -1,0 +1,8 @@
+{
+  "version": "1.0",
+  "type": "rich",
+  "provider_name": "Cyber Security Dictionary",
+  "provider_url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary",
+  "title": "Eavesdropping",
+  "html": "<div><strong>Eavesdropping:</strong> Unauthorized interception and monitoring of private communications, often done surreptitiously. <a href=\"https://alex-unnippillil.github.io/CyberSecuirtyDictionary#Eavesdropping\">Read more</a></div>"
+}

--- a/oembed/endpoint-security.json
+++ b/oembed/endpoint-security.json
@@ -1,0 +1,8 @@
+{
+  "version": "1.0",
+  "type": "rich",
+  "provider_name": "Cyber Security Dictionary",
+  "provider_url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary",
+  "title": "Endpoint Security",
+  "html": "<div><strong>Endpoint Security:</strong> The protection of devices like laptops, desktops, and smartphones from various security threats. <a href=\"https://alex-unnippillil.github.io/CyberSecuirtyDictionary#Endpoint%20Security\">Read more</a></div>"
+}

--- a/oembed/identity-theft.json
+++ b/oembed/identity-theft.json
@@ -1,0 +1,8 @@
+{
+  "version": "1.0",
+  "type": "rich",
+  "provider_name": "Cyber Security Dictionary",
+  "provider_url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary",
+  "title": "Identity Theft",
+  "html": "<div><strong>Identity Theft:</strong> The fraudulent acquisition and use of an individual's personal information to impersonate them for malicious purposes. <a href=\"https://alex-unnippillil.github.io/CyberSecuirtyDictionary#Identity%20Theft\">Read more</a></div>"
+}

--- a/oembed/incident-response.json
+++ b/oembed/incident-response.json
@@ -1,0 +1,8 @@
+{
+  "version": "1.0",
+  "type": "rich",
+  "provider_name": "Cyber Security Dictionary",
+  "provider_url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary",
+  "title": "Incident Response",
+  "html": "<div><strong>Incident Response:</strong> The process of managing and mitigating the impact of a cybersecurity incident or breach. <a href=\"https://alex-unnippillil.github.io/CyberSecuirtyDictionary#Incident%20Response\">Read more</a></div>"
+}

--- a/oembed/index.json
+++ b/oembed/index.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0",
+  "type": "link",
+  "provider_name": "Cyber Security Dictionary",
+  "provider_url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary",
+  "title": "Cyber Security Dictionary"
+}

--- a/oembed/key-exchange.json
+++ b/oembed/key-exchange.json
@@ -1,0 +1,8 @@
+{
+  "version": "1.0",
+  "type": "rich",
+  "provider_name": "Cyber Security Dictionary",
+  "provider_url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary",
+  "title": "Key Exchange",
+  "html": "<div><strong>Key Exchange:</strong> The process of securely sharing encryption keys between parties to establish a secure communication channel. <a href=\"https://alex-unnippillil.github.io/CyberSecuirtyDictionary#Key%20Exchange\">Read more</a></div>"
+}

--- a/oembed/malvertising.json
+++ b/oembed/malvertising.json
@@ -1,0 +1,8 @@
+{
+  "version": "1.0",
+  "type": "rich",
+  "provider_name": "Cyber Security Dictionary",
+  "provider_url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary",
+  "title": "Malvertising",
+  "html": "<div><strong>Malvertising:</strong> Malicious online advertisements that deliver malware or lead to malicious websites. <a href=\"https://alex-unnippillil.github.io/CyberSecuirtyDictionary#Malvertising\">Read more</a></div>"
+}

--- a/oembed/network-security.json
+++ b/oembed/network-security.json
@@ -1,0 +1,8 @@
+{
+  "version": "1.0",
+  "type": "rich",
+  "provider_name": "Cyber Security Dictionary",
+  "provider_url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary",
+  "title": "Network Security",
+  "html": "<div><strong>Network Security:</strong> The protection of network infrastructure and data from unauthorized access or attacks. <a href=\"https://alex-unnippillil.github.io/CyberSecuirtyDictionary#Network%20Security\">Read more</a></div>"
+}

--- a/oembed/payload.json
+++ b/oembed/payload.json
@@ -1,0 +1,8 @@
+{
+  "version": "1.0",
+  "type": "rich",
+  "provider_name": "Cyber Security Dictionary",
+  "provider_url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary",
+  "title": "Payload",
+  "html": "<div><strong>Payload:</strong> The part of a malware or exploit that performs malicious actions on a victim's system. <a href=\"https://alex-unnippillil.github.io/CyberSecuirtyDictionary#Payload\">Read more</a></div>"
+}

--- a/oembed/phishing-email.json
+++ b/oembed/phishing-email.json
@@ -1,0 +1,8 @@
+{
+  "version": "1.0",
+  "type": "rich",
+  "provider_name": "Cyber Security Dictionary",
+  "provider_url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary",
+  "title": "Phishing Email",
+  "html": "<div><strong>Phishing Email:</strong> An email sent by attackers that appears legitimate but aims to trick recipients into revealing sensitive information or performing actions. <a href=\"https://alex-unnippillil.github.io/CyberSecuirtyDictionary#Phishing%20Email\">Read more</a></div>"
+}

--- a/oembed/phishing.json
+++ b/oembed/phishing.json
@@ -1,0 +1,8 @@
+{
+  "version": "1.0",
+  "type": "rich",
+  "provider_name": "Cyber Security Dictionary",
+  "provider_url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary",
+  "title": "Phishing",
+  "html": "<div><strong>Phishing:</strong> An attempt to trick individuals into revealing sensitive information through fraudulent emails, websites, or messages. <a href=\"https://alex-unnippillil.github.io/CyberSecuirtyDictionary#Phishing\">Read more</a></div>"
+}

--- a/oembed/privilege-escalation.json
+++ b/oembed/privilege-escalation.json
@@ -1,0 +1,8 @@
+{
+  "version": "1.0",
+  "type": "rich",
+  "provider_name": "Cyber Security Dictionary",
+  "provider_url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary",
+  "title": "Privilege Escalation",
+  "html": "<div><strong>Privilege Escalation:</strong> The act of gaining higher levels of access or permissions in a system or network than originally granted. <a href=\"https://alex-unnippillil.github.io/CyberSecuirtyDictionary#Privilege%20Escalation\">Read more</a></div>"
+}

--- a/oembed/public-key-infrastructure-pki.json
+++ b/oembed/public-key-infrastructure-pki.json
@@ -1,0 +1,8 @@
+{
+  "version": "1.0",
+  "type": "rich",
+  "provider_name": "Cyber Security Dictionary",
+  "provider_url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary",
+  "title": "Public Key Infrastructure (PKI)",
+  "html": "<div><strong>Public Key Infrastructure (PKI):</strong> A system for managing digital certificates and public-private key pairs used in asymmetric encryption. <a href=\"https://alex-unnippillil.github.io/CyberSecuirtyDictionary#Public%20Key%20Infrastructure%20(PKI)\">Read more</a></div>"
+}

--- a/oembed/secure-sockets-layer-ssl.json
+++ b/oembed/secure-sockets-layer-ssl.json
@@ -1,0 +1,8 @@
+{
+  "version": "1.0",
+  "type": "rich",
+  "provider_name": "Cyber Security Dictionary",
+  "provider_url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary",
+  "title": "Secure Sockets Layer (SSL)",
+  "html": "<div><strong>Secure Sockets Layer (SSL):</strong> An older cryptographic protocol that provides secure communication over a computer network. <a href=\"https://alex-unnippillil.github.io/CyberSecuirtyDictionary#Secure%20Sockets%20Layer%20(SSL)\">Read more</a></div>"
+}

--- a/oembed/security-assessment.json
+++ b/oembed/security-assessment.json
@@ -1,0 +1,8 @@
+{
+  "version": "1.0",
+  "type": "rich",
+  "provider_name": "Cyber Security Dictionary",
+  "provider_url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary",
+  "title": "Security Assessment",
+  "html": "<div><strong>Security Assessment:</strong> A systematic evaluation of an organization's security measures to identify vulnerabilities and weaknesses. <a href=\"https://alex-unnippillil.github.io/CyberSecuirtyDictionary#Security%20Assessment\">Read more</a></div>"
+}

--- a/oembed/security-operations-center-soc.json
+++ b/oembed/security-operations-center-soc.json
@@ -1,0 +1,8 @@
+{
+  "version": "1.0",
+  "type": "rich",
+  "provider_name": "Cyber Security Dictionary",
+  "provider_url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary",
+  "title": "Security Operations Center (SOC)",
+  "html": "<div><strong>Security Operations Center (SOC):</strong> A centralized unit that monitors, detects, and responds to cybersecurity incidents and threats in real-time. <a href=\"https://alex-unnippillil.github.io/CyberSecuirtyDictionary#Security%20Operations%20Center%20(SOC)\">Read more</a></div>"
+}

--- a/oembed/security-patch.json
+++ b/oembed/security-patch.json
@@ -1,0 +1,8 @@
+{
+  "version": "1.0",
+  "type": "rich",
+  "provider_name": "Cyber Security Dictionary",
+  "provider_url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary",
+  "title": "Security Patch",
+  "html": "<div><strong>Security Patch:</strong> An update released by software vendors to fix security vulnerabilities in their products. <a href=\"https://alex-unnippillil.github.io/CyberSecuirtyDictionary#Security%20Patch\">Read more</a></div>"
+}

--- a/oembed/security-token.json
+++ b/oembed/security-token.json
@@ -1,0 +1,8 @@
+{
+  "version": "1.0",
+  "type": "rich",
+  "provider_name": "Cyber Security Dictionary",
+  "provider_url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary",
+  "title": "Security Token",
+  "html": "<div><strong>Security Token:</strong> A physical or digital device used to authenticate users or provide one-time passwords for secure access. <a href=\"https://alex-unnippillil.github.io/CyberSecuirtyDictionary#Security%20Token\">Read more</a></div>"
+}

--- a/oembed/social-engineering-attack-vectors.json
+++ b/oembed/social-engineering-attack-vectors.json
@@ -1,0 +1,8 @@
+{
+  "version": "1.0",
+  "type": "rich",
+  "provider_name": "Cyber Security Dictionary",
+  "provider_url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary",
+  "title": "Social Engineering Attack Vectors",
+  "html": "<div><strong>Social Engineering Attack Vectors:</strong> Different methods and techniques used in social engineering attacks to manipulate victims. <a href=\"https://alex-unnippillil.github.io/CyberSecuirtyDictionary#Social%20Engineering%20Attack%20Vectors\">Read more</a></div>"
+}

--- a/oembed/social-engineering-toolkit-set.json
+++ b/oembed/social-engineering-toolkit-set.json
@@ -1,0 +1,8 @@
+{
+  "version": "1.0",
+  "type": "rich",
+  "provider_name": "Cyber Security Dictionary",
+  "provider_url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary",
+  "title": "Social Engineering Toolkit (SET)",
+  "html": "<div><strong>Social Engineering Toolkit (SET):</strong> A framework for simulating social engineering attacks, helping organizations test their security awareness. <a href=\"https://alex-unnippillil.github.io/CyberSecuirtyDictionary#Social%20Engineering%20Toolkit%20(SET)\">Read more</a></div>"
+}

--- a/oembed/threat-hunting.json
+++ b/oembed/threat-hunting.json
@@ -1,0 +1,8 @@
+{
+  "version": "1.0",
+  "type": "rich",
+  "provider_name": "Cyber Security Dictionary",
+  "provider_url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary",
+  "title": "Threat Hunting",
+  "html": "<div><strong>Threat Hunting:</strong> Proactively searching for and identifying cyber threats that have evaded traditional security measures. <a href=\"https://alex-unnippillil.github.io/CyberSecuirtyDictionary#Threat%20Hunting\">Read more</a></div>"
+}

--- a/oembed/transport-layer-security-tls.json
+++ b/oembed/transport-layer-security-tls.json
@@ -1,0 +1,8 @@
+{
+  "version": "1.0",
+  "type": "rich",
+  "provider_name": "Cyber Security Dictionary",
+  "provider_url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary",
+  "title": "Transport Layer Security (TLS)",
+  "html": "<div><strong>Transport Layer Security (TLS):</strong> A more secure successor to SSL, providing encryption and authentication for secure communication. <a href=\"https://alex-unnippillil.github.io/CyberSecuirtyDictionary#Transport%20Layer%20Security%20(TLS)\">Read more</a></div>"
+}

--- a/oembed/zero-day-vulnerability.json
+++ b/oembed/zero-day-vulnerability.json
@@ -1,0 +1,8 @@
+{
+  "version": "1.0",
+  "type": "rich",
+  "provider_name": "Cyber Security Dictionary",
+  "provider_url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary",
+  "title": "Zero-Day Vulnerability",
+  "html": "<div><strong>Zero-Day Vulnerability:</strong> A software vulnerability that is not yet known to the vendor or the public, making it highly valuable to attackers. <a href=\"https://alex-unnippillil.github.io/CyberSecuirtyDictionary#Zero-Day%20Vulnerability\">Read more</a></div>"
+}

--- a/oembed/zero-knowledge-proof.json
+++ b/oembed/zero-knowledge-proof.json
@@ -1,0 +1,8 @@
+{
+  "version": "1.0",
+  "type": "rich",
+  "provider_name": "Cyber Security Dictionary",
+  "provider_url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary",
+  "title": "Zero-Knowledge Proof",
+  "html": "<div><strong>Zero-Knowledge Proof:</strong> A cryptographic method that allows a party to prove knowledge of a secret without revealing the secret itself. <a href=\"https://alex-unnippillil.github.io/CyberSecuirtyDictionary#Zero-Knowledge%20Proof\">Read more</a></div>"
+}

--- a/script.js
+++ b/script.js
@@ -8,6 +8,14 @@ const showFavoritesToggle = document.getElementById("show-favorites");
 const favorites = new Set(JSON.parse(localStorage.getItem("favorites") || "[]"));
 const siteUrl = "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/";
 const canonicalLink = document.getElementById("canonical-link");
+const oembedLink = document.getElementById("oembed-link");
+
+function slugify(term) {
+  return term
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
 
 let currentLetterFilter = "All";
 let termsData = { terms: [] };
@@ -190,6 +198,12 @@ function displayDefinition(term) {
       `${siteUrl}#${encodeURIComponent(term.term)}`
     );
   }
+  if (oembedLink) {
+    oembedLink.setAttribute(
+      "href",
+      `oembed/${slugify(term.term)}.json`
+    );
+  }
 }
 
 function clearDefinition() {
@@ -198,6 +212,9 @@ function clearDefinition() {
   history.replaceState(null, "", window.location.pathname + window.location.search);
   if (canonicalLink) {
     canonicalLink.setAttribute("href", siteUrl);
+  }
+  if (oembedLink) {
+    oembedLink.setAttribute("href", "oembed/index.json");
   }
 }
 

--- a/scripts/generate-oembed.js
+++ b/scripts/generate-oembed.js
@@ -1,0 +1,44 @@
+const fs = require('fs');
+const path = require('path');
+
+const dataPath = path.join(__dirname, '..', 'terms.json');
+const data = JSON.parse(fs.readFileSync(dataPath, 'utf8'));
+
+const oembedDir = path.join(__dirname, '..', 'oembed');
+fs.mkdirSync(oembedDir, { recursive: true });
+
+const providerName = 'Cyber Security Dictionary';
+const providerUrl = 'https://alex-unnippillil.github.io/CyberSecuirtyDictionary';
+
+function slugify(term) {
+  return term
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+for (const entry of data.terms) {
+  const slug = slugify(entry.term);
+  const url = `${providerUrl}#${encodeURIComponent(entry.term)}`;
+  const oembed = {
+    version: '1.0',
+    type: 'rich',
+    provider_name: providerName,
+    provider_url: providerUrl,
+    title: entry.term,
+    html: `<div><strong>${entry.term}:</strong> ${entry.definition} <a href="${url}">Read more</a></div>`
+  };
+  fs.writeFileSync(path.join(oembedDir, `${slug}.json`), JSON.stringify(oembed, null, 2));
+}
+
+console.log(`Generated ${data.terms.length} oEmbed responses.`);
+
+// Generate a generic oEmbed for the homepage
+const home = {
+  version: '1.0',
+  type: 'link',
+  provider_name: providerName,
+  provider_url: providerUrl,
+  title: providerName,
+};
+fs.writeFileSync(path.join(oembedDir, 'index.json'), JSON.stringify(home, null, 2));


### PR DESCRIPTION
## Summary
- generate static oEmbed JSON for each term
- advertise oEmbed links on term display
- document oEmbed endpoints and include build script

## Testing
- `./build.sh`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4c7eb1c208328bd077c4209538893