### PR TITLE
Add embeddable dictionary widget

### DIFF
--- a/widget-demo.html
+++ b/widget-demo.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Widget Demo</title>
+</head>
+<body>
+  <p>
+    Learn about <span data-csd-term="Phishing"></span> and other security concepts.
+  </p>
+  <script src="widget.js" data-endpoint="terms.json"></script>
+</body>
+</html>

--- a/widget.js
+++ b/widget.js
@@ -1,0 +1,53 @@
+(function () {
+  const script = document.currentScript;
+  const endpoint = script.getAttribute('data-endpoint') || 'terms.json';
+
+  function init() {
+    fetch(endpoint)
+      .then((res) => res.json())
+      .then((data) => {
+        const map = new Map(
+          data.terms.map((t) => [t.term.toLowerCase(), t.definition])
+        );
+        document.querySelectorAll('[data-csd-term]').forEach((el) => {
+          const term = el.getAttribute('data-csd-term');
+          const definition = map.get(term.toLowerCase());
+          if (!definition) return;
+
+          const shadow = el.attachShadow({ mode: 'open' });
+
+          const style = document.createElement('style');
+          style.textContent = `
+            .csd-widget { font-family: sans-serif; background:#f9f9f9; border:1px solid #ddd; padding:2px 4px; border-radius:3px; font-size:0.875em; }
+            .csd-term { font-weight:bold; }
+            .csd-definition { margin-left:4px; }
+          `;
+
+          const container = document.createElement('span');
+          container.className = 'csd-widget';
+
+          const termSpan = document.createElement('span');
+          termSpan.className = 'csd-term';
+          termSpan.textContent = term;
+
+          const defSpan = document.createElement('span');
+          defSpan.className = 'csd-definition';
+          defSpan.textContent = definition;
+
+          container.appendChild(termSpan);
+          container.appendChild(document.createTextNode(': '));
+          container.appendChild(defSpan);
+
+          shadow.appendChild(style);
+          shadow.appendChild(container);
+        });
+      })
+      .catch((err) => console.error('Dictionary widget error:', err));
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();


### PR DESCRIPTION
## Summary
- add JS widget that fetches terms and injects inline definitions with isolated styling
- add demo page showing one-line `<script>` usage for the widget

## Testing
- `npm test` (fails: unique-landmark, no-implicit-button-type)
- `npx html-validate widget-demo.html`


------
https://chatgpt.com/codex/tasks/task_e_68b4c7ebbff8832884ab4acbcb6e5f2f