### PR TITLE
feat: add daily term automation

### DIFF
--- a/.github/workflows/daily-term.yml
+++ b/.github/workflows/daily-term.yml
@@ -1,0 +1,28 @@
+name: Update daily term
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Generate daily term
+        run: node scripts/update-daily-term.js
+      - name: Commit daily term
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add daily-term.json
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore: update daily term"
+            git push
+          fi

--- a/daily-term.json
+++ b/daily-term.json
@@ -1,0 +1,5 @@
+{
+  "date": "2025-08-31",
+  "term": "Public Key Infrastructure (PKI)",
+  "definition": "A system for managing digital certificates and public-private key pairs used in asymmetric encryption."
+}

--- a/index.html
+++ b/index.html
@@ -11,25 +11,26 @@
 <body>
   <main class="container">
     <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
+    <nav class="site-nav" aria-label="Site navigation"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
+    <section id="daily-term"></section>
     <div id="definition-container" style="display: none;"></div>
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+    <button id="random-term" type="button" aria-label="Show random term">Random Term</button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+    <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">Toggle Dark Mode</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 
     <ul id="terms-list"></ul>
   </main>
-  <footer class="container">
+    <footer class="container" aria-label="Contribution footer">
     <p><a href="templates/contribute.html">Contribute</a></p>
   </footer>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+    <button id="scrollToTopBtn" type="button" aria-label="Scroll to top">↑</button>
 
-  <footer>
+    <footer aria-label="Project links">
     <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
   </footer>
   <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -5,6 +5,7 @@ const randomButton = document.getElementById("random-term");
 const alphaNav = document.getElementById("alpha-nav");
 const darkModeToggle = document.getElementById("dark-mode-toggle");
 const showFavoritesToggle = document.getElementById("show-favorites");
+const dailyTermContainer = document.getElementById("daily-term");
 const favorites = new Set(JSON.parse(localStorage.getItem("favorites") || "[]"));
 const siteUrl = "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/";
 const canonicalLink = document.getElementById("canonical-link");
@@ -25,6 +26,7 @@ if (darkModeToggle) {
 
 window.addEventListener("DOMContentLoaded", () => {
   loadTerms();
+  loadDailyTerm();
 });
 
 function loadTerms() {
@@ -65,6 +67,24 @@ function loadTerms() {
           loadTerms();
         });
       }
+    });
+}
+
+function loadDailyTerm() {
+  fetch("daily-term.json")
+    .then((response) => {
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+      return response.json();
+    })
+    .then((data) => {
+      if (dailyTermContainer) {
+        dailyTermContainer.innerHTML = `<h2>Daily Term</h2><p><strong>${data.term}</strong>: ${data.definition}</p>`;
+      }
+    })
+    .catch((error) => {
+      console.error("Error fetching daily term:", error);
     });
 }
 

--- a/scripts/update-daily-term.js
+++ b/scripts/update-daily-term.js
@@ -1,0 +1,27 @@
+const fs = require('fs');
+const path = require('path');
+
+const termsPath = path.join(__dirname, '..', 'terms.json');
+const outputPath = path.join(__dirname, '..', 'daily-term.json');
+
+const termsData = JSON.parse(fs.readFileSync(termsPath, 'utf8'));
+const today = new Date().toISOString().split('T')[0];
+
+let current;
+if (fs.existsSync(outputPath)) {
+  try {
+    current = JSON.parse(fs.readFileSync(outputPath, 'utf8'));
+  } catch (err) {
+    current = null;
+  }
+}
+
+if (!current || current.date !== today) {
+  const term = termsData.terms[Math.floor(Math.random() * termsData.terms.length)];
+  const daily = {
+    date: today,
+    term: term.term,
+    definition: term.definition,
+  };
+  fs.writeFileSync(outputPath, JSON.stringify(daily, null, 2) + '\n');
+}


### PR DESCRIPTION
## Summary
- add workflow that picks a random term daily and commits it
- display chosen term on the home page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4c7ed27848328b6c5ddbc9d6d2ddb