### PR TITLE
Add educator kit page with lesson outlines

### DIFF
--- a/educator-kit/index.html
+++ b/educator-kit/index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Educator Kit</title>
+  <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+  <main class="container">
+    <h1>Educator Kit</h1>
+    <p>This dictionary can support cybersecurity courses. Instructors can print term sets for flashcards, quizzes, or reference sheets to bring concepts into the classroom.</p>
+    <h2>Sample Lesson Outlines</h2>
+    <ol>
+      <li>
+        <h3>Lesson 1: Getting Started with Cybersecurity</h3>
+        <p>Introduce core terminology and have students paraphrase each definition from the site.</p>
+      </li>
+      <li>
+        <h3>Lesson 2: Securing a Network</h3>
+        <p>Distribute printable term sets and assign groups to research and present how each concept protects network assets.</p>
+      </li>
+      <li>
+        <h3>Lesson 3: Incident Response Drill</h3>
+        <p>Use printed attack and defense cards to run a simulated breach and discuss the appropriate response steps.</p>
+      </li>
+    </ol>
+  </main>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -11,27 +11,30 @@
 <body>
   <main class="container">
     <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
+    <nav class="site-nav" aria-label="Site navigation">
+      <a href="templates/guidelines.html">Definition Guidelines</a>
+      <a href="educator-kit/">Educator Kit</a>
+    </nav>
     <div id="definition-container" style="display: none;"></div>
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+      <button id="random-term" type="button" aria-label="Show random term">Random Term</button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+      <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">Toggle Dark Mode</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 
     <ul id="terms-list"></ul>
   </main>
-  <footer class="container">
-    <p><a href="templates/contribute.html">Contribute</a></p>
-  </footer>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+    <footer class="container" aria-label="Contributor resources">
+      <p><a href="templates/contribute.html">Contribute</a></p>
+    </footer>
+    <button id="scrollToTopBtn" type="button" aria-label="Scroll to top">↑</button>
 
-  <footer>
-    <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
-  </footer>
+    <footer aria-label="Project information">
+      <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
+    </footer>
   <script src="script.js"></script>
   <script src="assets/js/app.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- add new Educator Kit page under `/educator-kit` explaining how to use the dictionary in courses with printable term sets
- include three sample lesson outlines for classroom activities
- link the new page from the home page and add button types/aria labels to satisfy html validation

## Testing
- `npm test`
- `npx html-validate educator-kit/index.html`


------
https://chatgpt.com/codex/tasks/task_e_68b4c7edcc488328aae5b0a9e21887cc