### PR TITLE
Add contact form with Formspree and mailto fallback

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,25 +11,25 @@
 <body>
   <main class="container">
     <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
+    <nav class="site-nav" aria-label="Site links"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
     <div id="definition-container" style="display: none;"></div>
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+      <button id="random-term" type="button" aria-label="Show random term">Random Term</button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+      <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">Toggle Dark Mode</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 
     <ul id="terms-list"></ul>
   </main>
-  <footer class="container">
-    <p><a href="templates/contribute.html">Contribute</a></p>
+  <footer class="container" aria-label="Site footer">
+    <p><a href="templates/contribute.html">Contribute</a> | <a href="templates/contact.html">Contact</a></p>
   </footer>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+  <button id="scrollToTopBtn" type="button" aria-label="Scroll to top">↑</button>
 
-  <footer>
+  <footer aria-label="Project information">
     <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
   </footer>
   <script src="script.js"></script>

--- a/templates/contact.html
+++ b/templates/contact.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Contact - Cyber Security Dictionary</title>
+  <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+  <main class="container">
+    <h1>Contact Us</h1>
+    <form id="contact-form" action="https://formspree.io/f/YOUR_FORM_ID" method="POST">
+      <label for="name">Name</label>
+      <input type="text" id="name" name="name" required>
+
+      <label for="email">Email</label>
+      <input type="email" id="email" name="email" required>
+
+      <label for="message">Message</label>
+      <textarea id="message" name="message" required></textarea>
+
+      <input type="text" id="company" name="company" style="display:none" tabindex="-1" autocomplete="off">
+
+      <button type="submit">Send</button>
+    </form>
+    <noscript>
+      <p>If the form is not working, please email <a href="mailto:contact@example.com">contact@example.com</a>.</p>
+    </noscript>
+  </main>
+  <script>
+    const form = document.getElementById('contact-form');
+    form.addEventListener('submit', async (event) => {
+      const honeypot = document.getElementById('company');
+      if (honeypot.value) {
+        event.preventDefault();
+        return;
+      }
+      event.preventDefault();
+      const formData = new FormData(form);
+      try {
+        const response = await fetch(form.action, {
+          method: 'POST',
+          body: formData,
+          headers: { 'Accept': 'application/json' }
+        });
+        if (response.ok) {
+          form.innerHTML = '<p>Thank you for your message!</p>';
+        } else {
+          window.location.href = 'mailto:contact@example.com';
+        }
+      } catch (err) {
+        window.location.href = 'mailto:contact@example.com';
+      }
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a static contact form powered by Formspree with a honeypot field
- fall back to a mailto link if the Formspree submission fails
- link to the new contact page and tidy accessibility on the home page

## Testing
- `npm test`
- `npx html-validate templates/contact.html`
- `curl -i -X POST https://formspree.io/f/YOUR_FORM_ID -d "email=test@example.com" -d "message=Hello"`
- `curl mailto:contact@example.com` *(fails: fetches example.com placeholder)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c7ee965c8328a90dd69b81f0fbfd