### PR TITLE
Add i18n infrastructure with strict key checking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -4,3 +4,13 @@ https://alex-unnippillil.github.io/CyberSecuirtyDictionary/
 
 ## Security
 For information on reporting vulnerabilities, please see our [Security Policy](SECURITY.md).
+
+## Localization
+
+UI text is stored in JSON files under `locales/` and accessed through type-safe helpers.
+
+### Adding a new language
+
+1. Copy `locales/en.json` to `locales/<language>.json` and translate the values.
+2. Ensure all keys are present; missing keys will fail CI.
+3. Run `npm test` to validate locale files and HTML.

--- a/index.html
+++ b/index.html
@@ -3,36 +3,36 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Cyber Security Dictionary</title>
+  <title data-i18n="title">Cyber Security Dictionary</title>
   <link rel="stylesheet" href="styles.css">
   <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet">
   <link rel="canonical" id="canonical-link" href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/">
 </head>
 <body>
   <main class="container">
-    <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
+    <h1 data-i18n="title">Cyber Security Dictionary</h1>
+    <nav class="site-nav" aria-label="Site navigation" data-i18n-aria-label="site_navigation"><a data-i18n="definition_guidelines" href="templates/guidelines.html">Definition Guidelines</a></nav>
     <div id="definition-container" style="display: none;"></div>
-    <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
-    <input type="text" id="search" placeholder="Search...">
+    <nav id="alpha-nav" aria-label="Alphabet navigation" data-i18n-aria-label="alphabet_navigation"></nav>
+    <input type="text" id="search" placeholder="Search..." data-i18n-placeholder="search_placeholder">
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+    <button id="random-term" aria-label="Show random term" data-i18n="random_term" data-i18n-aria-label="random_term" type="button">Random Term</button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
-    <input type="checkbox" id="show-favorites" aria-label="Show favorites">
-    <label for="show-favorites">Show Favorites</label>
+    <button id="dark-mode-toggle" aria-label="Toggle dark mode" data-i18n="toggle_dark_mode" data-i18n-aria-label="toggle_dark_mode" type="button">Toggle Dark Mode</button>
+    <input type="checkbox" id="show-favorites" aria-label="Show favorites" data-i18n-aria-label="show_favorites">
+    <label for="show-favorites" data-i18n="show_favorites">Show Favorites</label>
 
     <ul id="terms-list"></ul>
   </main>
-  <footer class="container">
-    <p><a href="templates/contribute.html">Contribute</a></p>
+  <footer class="container" aria-label="Main footer" data-i18n-aria-label="main_footer">
+    <p><a href="templates/contribute.html" data-i18n="contribute">Contribute</a></p>
   </footer>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+  <button id="scrollToTopBtn" aria-label="Scroll to top" data-i18n-aria-label="scroll_to_top" type="button">↑</button>
 
-  <footer>
-    <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
+  <footer aria-label="Repository footer" data-i18n-aria-label="repo_footer">
+    <p><a href="CONTRIBUTING.md" data-i18n="contribute_project">Contribute to this project</a></p>
   </footer>
-  <script src="script.js"></script>
+  <script type="module" src="script.js"></script>
   <script src="assets/js/app.js"></script>
 </body>
 </html>

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,0 +1,18 @@
+{
+  "title": "Cyber Security Dictionary",
+  "definition_guidelines": "Definition Guidelines",
+  "search_placeholder": "Search...",
+  "random_term": "Random Term",
+  "toggle_dark_mode": "Toggle Dark Mode",
+  "show_favorites": "Show Favorites",
+  "contribute": "Contribute",
+  "contribute_project": "Contribute to this project",
+  "scroll_to_top": "Scroll to top",
+  "all": "All",
+  "error_loading": "Unable to load dictionary data. Please check your connection and try again.",
+  "retry": "Retry",
+  "site_navigation": "Site navigation",
+  "alphabet_navigation": "Alphabet navigation",
+  "main_footer": "Main footer",
+  "repo_footer": "Repository footer"
+}

--- a/locales/i18n.js
+++ b/locales/i18n.js
@@ -1,0 +1,37 @@
+// @ts-check
+
+/** @typedef {typeof import('./en.json')} LocaleStrings */
+/** @typedef {keyof LocaleStrings} LocaleKey */
+
+let messages = /** @type {LocaleStrings} */ ({})
+let strictMode = false
+
+/**
+ * Load locale data.
+ * @param {string} locale
+ * @param {{strict?: boolean}} [options]
+ */
+export async function loadLocale(locale, options = {}) {
+  strictMode = options.strict ?? false
+  const res = await fetch(`locales/${locale}.json`)
+  if (!res.ok) {
+    throw new Error(`Failed to load locale: ${locale}`)
+  }
+  messages = await res.json()
+}
+
+/**
+ * Get a localized string by key.
+ * @param {LocaleKey} key
+ * @returns {string}
+ */
+export function t(key) {
+  const value = messages[key]
+  if (value === undefined) {
+    if (strictMode) {
+      throw new Error(`Missing translation for key: ${key}`)
+    }
+    return key
+  }
+  return value
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "script.js",
   "scripts": {
     "build": "node scripts/build.js",
-    "test": "html-validate index.html",
+    "i18n:check": "node scripts/i18n-check.js",
+    "test": "npm run i18n:check && html-validate index.html",
     "watch": "chokidar \"**/*.html\" -c \"npm run build\""
   },
   "keywords": [],

--- a/script.js
+++ b/script.js
@@ -1,3 +1,7 @@
+// @ts-check
+
+import { loadLocale, t } from "./locales/i18n.js";
+
 const termsList = document.getElementById("terms-list");
 const definitionContainer = document.getElementById("definition-container");
 const searchInput = document.getElementById("search");
@@ -12,6 +16,28 @@ const canonicalLink = document.getElementById("canonical-link");
 let currentLetterFilter = "All";
 let termsData = { terms: [] };
 
+function applyTranslations() {
+  document.title = t("title");
+  document.querySelectorAll("[data-i18n]").forEach((el) => {
+    const key = el.getAttribute("data-i18n");
+    if (key) {
+      el.textContent = t(key);
+    }
+  });
+  document.querySelectorAll("[data-i18n-placeholder]").forEach((el) => {
+    const key = el.getAttribute("data-i18n-placeholder");
+    if (key) {
+      el.setAttribute("placeholder", t(key));
+    }
+  });
+  document.querySelectorAll("[data-i18n-aria-label]").forEach((el) => {
+    const key = el.getAttribute("data-i18n-aria-label");
+    if (key) {
+      el.setAttribute("aria-label", t(key));
+    }
+  });
+}
+
 if (localStorage.getItem("darkMode") === "true") {
   document.body.classList.add("dark-mode");
 }
@@ -23,7 +49,9 @@ if (darkModeToggle) {
   });
 }
 
-window.addEventListener("DOMContentLoaded", () => {
+window.addEventListener("DOMContentLoaded", async () => {
+  await loadLocale("en", { strict: true });
+  applyTranslations();
   loadTerms();
 });
 
@@ -56,8 +84,8 @@ function loadTerms() {
       console.error("Detailed error fetching data:", error);
       definitionContainer.style.display = "block";
       definitionContainer.innerHTML =
-        '<p>Unable to load dictionary data. Please check your connection and try again.</p>' +
-        '<button id="retry-fetch">Retry</button>';
+        `<p>${t("error_loading")}</p>` +
+        `<button id="retry-fetch">${t("retry")}</button>`;
       const retryBtn = document.getElementById("retry-fetch");
       if (retryBtn) {
         retryBtn.addEventListener("click", (e) => {
@@ -105,7 +133,7 @@ function buildAlphaNav() {
   const letters = Array.from(new Set(termsData.terms.map((t) => t.term.charAt(0).toUpperCase()))).sort();
 
   const allButton = document.createElement("button");
-  allButton.textContent = "All";
+  allButton.textContent = t("all");
   allButton.addEventListener("click", () => {
     currentLetterFilter = "All";
     highlightActiveButton(allButton);

--- a/scripts/i18n-check.js
+++ b/scripts/i18n-check.js
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const localesDir = path.join(__dirname, '..', 'locales');
+const files = fs.readdirSync(localesDir).filter((f) => f.endsWith('.json'));
+if (files.length === 0) {
+  console.error('No locale files found');
+  process.exit(1);
+}
+
+const baseName = files[0];
+const base = JSON.parse(fs.readFileSync(path.join(localesDir, baseName), 'utf8'));
+const baseKeys = Object.keys(base).sort();
+let missing = false;
+
+for (const file of files.slice(1)) {
+  const data = JSON.parse(fs.readFileSync(path.join(localesDir, file), 'utf8'));
+  const keys = Object.keys(data);
+  const missingKeys = baseKeys.filter((k) => !keys.includes(k));
+  if (missingKeys.length > 0) {
+    console.error(`Locale ${file} missing keys: ${missingKeys.join(', ')}`);
+    missing = true;
+  }
+}
+
+if (missing) {
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- extract UI strings to `locales/en.json`
- provide type-safe accessors and runtime loading of locale strings
- add CI check for missing translation keys

## Testing
- `npm test`
- `npx html-validate index.html`


------
https://chatgpt.com/codex/tasks/task_e_68b4c7efca94832892a824b05f8c40c8