### PR TITLE
chore: add devcontainer for Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,19 @@
+{
+  "name": "CyberSecuirtyDictionary",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "20"
+    },
+    "ghcr.io/devcontainers/features/playwright:1": {}
+  },
+  "postCreateCommand": "pnpm install",
+  "postStartCommand": "pnpm exec http-server -p 8080 .",
+  "forwardPorts": [8080],
+  "portsAttributes": {
+    "8080": {
+      "label": "Dev server",
+      "onAutoForward": "openBrowser"
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,19 @@
 # CyberSecuirtyDictionary
+
 https://alex-unnippillil.github.io/CyberSecuirtyDictionary/
 ![image](https://github.com/Alex-Unnippillil/CyberSecuirtyDictionary/assets/24538548/c5a54c56-babb-485d-b01c-4fdfb186325b)
 
+## Development
+
+This project includes a [development container](.devcontainer/devcontainer.json) for use with [GitHub Codespaces](https://github.com/features/codespaces) or the VS Code Dev Containers extension.
+
+- **Node.js 20** with `pnpm` is provided via devcontainer features.
+- **Playwright** browser dependencies are preinstalled for running end-to-end tests.
+- When the container starts, it runs `pnpm exec http-server -p 8080 .` so the site is served on <http://localhost:8080/>.
+- Codespaces automatically forwards this port and opens a browser preview.
+
+Opening the repository in Codespaces will install dependencies and launch the dev server automatically, letting you start developing right away.
+
 ## Security
+
 For information on reporting vulnerabilities, please see our [Security Policy](SECURITY.md).


### PR DESCRIPTION
## Summary
- add devcontainer with Node.js 20, pnpm and Playwright dependencies
- start http-server automatically in Codespaces
- document dev container usage in README

## Testing
- `npm test` *(fails: Landmarks must have a non-empty and unique accessible name)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c7f3180c83288d2ece24fc5bad0c