### PR TITLE
feat: add pnpm help script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,8 @@ Thank you for taking the time to contribute to the Cyber Security Dictionary!
 
 ## Pull request checklist
 
-- Make sure your changes pass tests (`npm test` if available).
+- Make sure your changes pass tests (`pnpm test`).
+- Run `pnpm run help` to see available development scripts.
 - Follow the [pull request template](.github/PULL_REQUEST_TEMPLATE.md).
 - Keep descriptions concise and clear.
 

--- a/README.md
+++ b/README.md
@@ -2,5 +2,9 @@
 https://alex-unnippillil.github.io/CyberSecuirtyDictionary/
 ![image](https://github.com/Alex-Unnippillil/CyberSecuirtyDictionary/assets/24538548/c5a54c56-babb-485d-b01c-4fdfb186325b)
 
+## Development
+
+Run `pnpm run help` to see available scripts and their descriptions.
+
 ## Security
 For information on reporting vulnerabilities, please see our [Security Policy](SECURITY.md).

--- a/package.json
+++ b/package.json
@@ -6,7 +6,14 @@
   "scripts": {
     "build": "node scripts/build.js",
     "test": "html-validate index.html",
-    "watch": "chokidar \"**/*.html\" -c \"npm run build\""
+    "watch": "chokidar \"**/*.html\" -c \"npm run build\"",
+    "help": "node scripts/help.js"
+  },
+  "scripts-info": {
+    "build": "Generate static site files",
+    "test": "Validate HTML",
+    "watch": "Rebuild on file changes",
+    "help": "List available scripts"
   },
   "keywords": [],
   "author": "",

--- a/scripts/help.js
+++ b/scripts/help.js
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const pkgPath = path.join(__dirname, '..', 'package.json');
+const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+
+const scripts = pkg.scripts || {};
+const info = pkg['scripts-info'] || {};
+
+console.log('Usage: pnpm run <script>');
+console.log('\nAvailable scripts:\n');
+
+for (const name of Object.keys(scripts)) {
+  const description = info[name] || '';
+  const spacing = description ? ' - ' : '';
+  console.log(`${name}${spacing}${description}`);
+}


### PR DESCRIPTION
## Summary
- add `pnpm run help` script that reads package.json and lists scripts with descriptions
- document help usage for contributors

## Testing
- `pnpm run help`
- `pnpm test` *(fails: unique-landmark, no-implicit-button-type)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c7f3fa588328acb3e9e7751aca2e