### PR TITLE
chore: enforce checks on commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npm run typecheck && npx lint-staged

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,25 @@ Thank you for taking the time to contribute to the Cyber Security Dictionary!
 ## Pull request checklist
 
 - Make sure your changes pass tests (`npm test` if available).
+- Pre-commit hooks run type checking, linting, and content linting.
 - Follow the [pull request template](.github/PULL_REQUEST_TEMPLATE.md).
 - Keep descriptions concise and clear.
+
+## Development setup
+
+Install dependencies to enable the Git hooks:
+
+```bash
+npm install
+```
+
+The `pre-commit` hook runs `npm run typecheck` and then `lint-staged` to
+format code and spell-check markdown. Commits are rejected when these checks
+fail. You can run the checks manually with:
+
+```bash
+npm run typecheck
+npx lint-staged --no-stash
+```
 
 If you have questions, feel free to open an issue.

--- a/package.json
+++ b/package.json
@@ -6,16 +6,31 @@
   "scripts": {
     "build": "node scripts/build.js",
     "test": "html-validate index.html",
-    "watch": "chokidar \"**/*.html\" -c \"npm run build\""
+    "watch": "chokidar \"**/*.html\" -c \"npm run build\"",
+    "prepare": "husky install",
+    "typecheck": "tsc --noEmit",
+    "lint": "prettier --check",
+    "lint:content": "cspell --no-summary"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "@types/node": "^24.3.0",
     "chokidar-cli": "^3.0.0",
+    "cspell": "^9.2.1",
     "html-validate": "^10.0.0",
     "http-server": "^14.1.1",
+    "husky": "^9.1.7",
     "js-yaml": "^4.1.0",
-    "prettier": "^3.6.2"
+    "lint-staged": "^16.1.5",
+    "prettier": "^3.6.2",
+    "stylelint": "^16.23.1",
+    "typescript": "^5.9.2"
+  },
+  "lint-staged": {
+    "*.{js,css,html,json,md}": "prettier --check",
+    "*.css": "stylelint",
+    "*.md": "cspell --no-summary"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "noEmit": true
+  },
+  "files": ["types.d.ts"]
+}


### PR DESCRIPTION
## Summary
- add Husky pre-commit hook running typecheck and lint-staged
- lint-staged checks formatting with Prettier and spelling with cspell
- document hook setup in CONTRIBUTING

## Testing
- `npm run typecheck`
- `npm run lint:content -- CONTRIBUTING.md`
- `npx lint-staged --no-stash` *(no staged files)*
- `npm test` *(fails: unique-landmark, no-implicit-button-type)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c7f484d48328a16f1cbc04a623b2