### PR TITLE
ci: add commitlint and changelog automation

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -1,0 +1,19 @@
+name: Verify Changelog
+
+on:
+  pull_request:
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check changelog
+        run: |
+          git fetch origin ${{ github.base_ref }}:base
+          if ! git diff --name-only base...HEAD | grep -q '^CHANGELOG.md$'; then
+            echo "::error::CHANGELOG.md must be updated"
+            exit 1
+          fi

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,23 @@
+name: Changelog
+
+on:
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: write
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Conventional Changelog
+        uses: TriPSs/conventional-changelog-action@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          skip-version-file: true
+          output-file: CHANGELOG.md
+          git-message: "chore: update changelog"

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,13 @@
+name: Commitlint
+
+on:
+  pull_request:
+  merge_group:
+    types: [checks_requested]
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: wagoid/commitlint-github-action@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## Unreleased
+
+### Added
+- enforce conventional commits and automated changelog generation.


### PR DESCRIPTION
## Summary
- enforce conventional commit messages
- auto-update CHANGELOG on main
- check PRs include changelog

## Testing
- `npm test` *(fails: Landmarks must have a non-empty and unique accessible name; `<button>` missing recommended `type` attribute)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c7f5194c8328a1135204f310c36b