### PR TITLE
chore: retain build artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,13 @@ jobs:
         uses: lycheeverse/lychee-action@v2
         with:
           args: --no-cache terms.json
+      - name: Install dependencies
+        run: npm ci
+      - name: Build site
+        run: npm run build
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: out
+          path: out
+          retention-days: 30

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,8 @@ jobs:
           SITE_URL: ${{ vars.SITE_URL }}
       - uses: actions/upload-pages-artifact@v2
         with:
-          path: dist
+          path: out
+          retention-days: 30
   deploy:
     needs: build
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -4,3 +4,7 @@ https://alex-unnippillil.github.io/CyberSecuirtyDictionary/
 
 ## Security
 For information on reporting vulnerabilities, please see our [Security Policy](SECURITY.md).
+
+## Artifact retention
+
+Continuous integration runs upload the contents of the `out/` directory as downloadable artifacts. These builds are retained for 30 days so old versions can be accessed during that period.


### PR DESCRIPTION
## Summary
- upload build output and keep artifacts for 30 days
- document artifact retention policy in README

## Testing
- `npm test` *(fails: unique-landmark, no-implicit-button-type)*
- `npm run build` *(fails: Cannot find module 'scripts/build.js')*


------
https://chatgpt.com/codex/tasks/task_e_68b4c7f7b758832886044a1882cd6a36