### PR TITLE
Add daily content backup workflow

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -1,0 +1,33 @@
+name: Content Backup
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  backup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create archive
+        run: |
+          ZIP_FILE="content-$(date +%Y-%m-%d).zip"
+          zip -r "$ZIP_FILE" content
+          echo "ZIP_FILE=$ZIP_FILE" >> $GITHUB_ENV
+
+      - name: Commit to backup branch
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin backup || true
+          git checkout backup || git checkout --orphan backup
+          mv "$ZIP_FILE" .
+          ls -1tr *.zip 2>/dev/null | head -n -7 | xargs -r rm --
+          git add *.zip
+          git add -u
+          git commit -m "Backup for $(date +%Y-%m-%d)"
+          git push origin backup

--- a/content/sample.txt
+++ b/content/sample.txt
@@ -1,0 +1,1 @@
+Example content for backup.

--- a/index.html
+++ b/index.html
@@ -11,25 +11,25 @@
 <body>
   <main class="container">
     <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
+    <nav class="site-nav" aria-label="Site navigation"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
     <div id="definition-container" style="display: none;"></div>
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+    <button id="random-term" aria-label="Show random term" type="button">Random Term</button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+    <button id="dark-mode-toggle" aria-label="Toggle dark mode" type="button">Toggle Dark Mode</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 
     <ul id="terms-list"></ul>
   </main>
-  <footer class="container">
+  <footer class="container" aria-label="Primary footer">
     <p><a href="templates/contribute.html">Contribute</a></p>
   </footer>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+  <button id="scrollToTopBtn" aria-label="Scroll to top" type="button">↑</button>
 
-  <footer>
+  <footer aria-label="Secondary footer">
     <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
   </footer>
   <script src="script.js"></script>


### PR DESCRIPTION
## Summary
- automate daily zipping of `content/` and pushing to `backup` branch while retaining only the latest seven archives
- add sample content directory so backups have data
- fix `index.html` landmark labels and button types for passing HTML validation

## Testing
- `npm test`
- simulated eight backup runs to confirm only seven archives kept


------
https://chatgpt.com/codex/tasks/task_e_68b4c7f8a6d483289221d9265be5a07e