### PR TITLE
Add contributors page generated from Git history

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -12,3 +12,6 @@ Contact: mailto:security@example.com
 TXT
 
 echo "Generated .well-known/security.txt"
+
+# Update contributors page
+node scripts/contributors.js

--- a/contributors.html
+++ b/contributors.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Contributors</title>
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<main class="container">
+<h1>Contributors</h1>
+<ul>
+<li><img src="https://www.gravatar.com/avatar/8f622a2fab0aabc70b7005b563a086f0?s=64&d=identicon" alt="Alex Unnippillil" width="64" height="64"> Alex Unnippillil - 152 commits</li>
+<li><img src="https://www.gravatar.com/avatar/725c74c80350e1517ab0396bc12f2a40?s=64&d=identicon" alt="Codex" width="64" height="64"> Codex - 1 commits</li>
+</ul>
+</main>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -11,26 +11,27 @@
 <body>
   <main class="container">
     <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
+    <nav class="site-nav" aria-label="Site navigation"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
     <div id="definition-container" style="display: none;"></div>
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+    <button id="random-term" aria-label="Show random term" type="button">Random Term</button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+    <button id="dark-mode-toggle" aria-label="Toggle dark mode" type="button">Toggle Dark Mode</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 
     <ul id="terms-list"></ul>
   </main>
-  <footer class="container">
+  <footer class="container" aria-label="Contribution footer">
     <p><a href="templates/contribute.html">Contribute</a></p>
   </footer>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+  <button id="scrollToTopBtn" aria-label="Scroll to top" type="button">↑</button>
 
-  <footer>
+  <footer aria-label="Project footer">
     <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
+    <p><a href="contributors.html">Contributors</a></p>
   </footer>
   <script src="script.js"></script>
   <script src="assets/js/app.js"></script>

--- a/scripts/contributors.js
+++ b/scripts/contributors.js
@@ -1,0 +1,49 @@
+const { execSync } = require('child_process');
+const fs = require('fs');
+const crypto = require('crypto');
+
+function avatarUrl(email) {
+  const ghMatch = email.match(/^.+?\+?([A-Za-z0-9-]+)@users\.noreply\.github\.com$/);
+  if (ghMatch) {
+    const username = ghMatch[1];
+    return `https://github.com/${username}.png?size=64`;
+  }
+  const hash = crypto.createHash('md5').update(email.trim().toLowerCase()).digest('hex');
+  return `https://www.gravatar.com/avatar/${hash}?s=64&d=identicon`;
+}
+
+const lines = execSync('git log --format="%aN;%aE"').toString().trim().split('\n');
+const map = new Map();
+for (const line of lines) {
+  if (!line) continue;
+  const [name, email] = line.split(';');
+  const key = email.toLowerCase();
+  const info = map.get(key) || { name, email, commits: 0 };
+  info.commits++;
+  map.set(key, info);
+}
+
+const contributors = Array.from(map.values()).sort((a, b) => b.commits - a.commits);
+const items = contributors
+  .map(c => `<li><img src="${avatarUrl(c.email)}" alt="${c.name}" width="64" height="64"> ${c.name} - ${c.commits} commits</li>`)
+  .join('\n');
+
+const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Contributors</title>
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<main class="container">
+<h1>Contributors</h1>
+<ul>
+${items}
+</ul>
+</main>
+</body>
+</html>`;
+
+fs.writeFileSync('contributors.html', html);
+console.log('Generated contributors.html');


### PR DESCRIPTION
## Summary
- generate contributors.html from Git history with avatars and commit counts
- hook contributor generation into build script and add link from index page

## Testing
- `npm test`
- `sh build.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b4c7f95318832891ead02b90a00ec4