### PR TITLE
Add dynamic roadmap page

### DIFF
--- a/assets/js/roadmap.js
+++ b/assets/js/roadmap.js
@@ -1,0 +1,56 @@
+async function fetchRoadmap() {
+  const container = document.getElementById('roadmap');
+  const repo = 'alex-unnippillil/CyberSecuirtyDictionary';
+
+  try {
+    const milestonesResponse = await fetch(`https://api.github.com/repos/${repo}/milestones?state=open`);
+    const milestones = await milestonesResponse.json();
+
+    if (!Array.isArray(milestones) || milestones.length === 0) {
+      container.textContent = 'No roadmap items found.';
+      return;
+    }
+
+    const fragment = document.createDocumentFragment();
+
+    for (const milestone of milestones) {
+      const section = document.createElement('section');
+      const header = document.createElement('h2');
+      const link = document.createElement('a');
+      link.href = milestone.html_url;
+      link.textContent = milestone.title;
+      header.appendChild(link);
+      section.appendChild(header);
+
+      const issuesResponse = await fetch(`https://api.github.com/repos/${repo}/issues?state=open&milestone=${milestone.number}`);
+      const issues = await issuesResponse.json();
+
+      if (Array.isArray(issues) && issues.length > 0) {
+        const list = document.createElement('ul');
+        for (const issue of issues) {
+          const item = document.createElement('li');
+          const issueLink = document.createElement('a');
+          issueLink.href = issue.html_url;
+          issueLink.textContent = issue.title;
+          item.appendChild(issueLink);
+          list.appendChild(item);
+        }
+        section.appendChild(list);
+      } else {
+        const p = document.createElement('p');
+        p.textContent = 'No open items.';
+        section.appendChild(p);
+      }
+
+      fragment.appendChild(section);
+    }
+
+    container.textContent = '';
+    container.appendChild(fragment);
+  } catch (error) {
+    container.textContent = 'Failed to load roadmap.';
+    console.error(error);
+  }
+}
+
+document.addEventListener('DOMContentLoaded', fetchRoadmap);

--- a/index.html
+++ b/index.html
@@ -11,25 +11,28 @@
 <body>
   <main class="container">
     <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
+    <nav class="site-nav" aria-label="Site navigation">
+      <a href="templates/guidelines.html">Definition Guidelines</a>
+      <a href="templates/roadmap.html">Roadmap</a>
+    </nav>
     <div id="definition-container" style="display: none;"></div>
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+    <button id="random-term" aria-label="Show random term" type="button">Random Term</button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+    <button id="dark-mode-toggle" aria-label="Toggle dark mode" type="button">Toggle Dark Mode</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 
     <ul id="terms-list"></ul>
   </main>
-  <footer class="container">
+  <footer class="container" aria-label="Contribute section">
     <p><a href="templates/contribute.html">Contribute</a></p>
   </footer>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+  <button id="scrollToTopBtn" aria-label="Scroll to top" type="button">↑</button>
 
-  <footer>
+  <footer aria-label="Project information">
     <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
   </footer>
   <script src="script.js"></script>

--- a/templates/roadmap.html
+++ b/templates/roadmap.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Project Roadmap</title>
+  <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+  <main class="container">
+    <h1>Project Roadmap</h1>
+    <div id="roadmap">Loading...</div>
+  </main>
+  <script src="../assets/js/roadmap.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Link roadmap page from the home navigation and resolve HTML validation errors
- Add roadmap template and script that groups GitHub milestones and their issues

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4c7f9d5b0832895a8a02c69e132a9