### PR TITLE
Add feedback widget with GitHub issue reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/assets/js/feedback.js
+++ b/assets/js/feedback.js
@@ -1,0 +1,82 @@
+const owner = 'Alex-Unnippillil';
+const repo = 'CyberSecuirtyDictionary';
+
+async function sendFeedback({ page, comment } = {}) {
+  const token = typeof window !== 'undefined' ? window.GITHUB_TOKEN : process.env.GITHUB_TOKEN;
+  const payload = {
+    title: `Feedback for ${page}`,
+    body: `${comment ? comment + '\n\n' : ''}Page: ${page}`,
+  };
+
+  const response = await fetch(`https://api.github.com/repos/${owner}/${repo}/issues`, {
+    method: 'POST',
+    headers: {
+      'Accept': 'application/vnd.github+json',
+      'Content-Type': 'application/json',
+      ...(token ? { Authorization: `token ${token}` } : {}),
+    },
+    body: JSON.stringify(payload),
+  });
+
+  const remaining = response.headers.get('X-RateLimit-Remaining');
+  if (response.status === 403 || response.status === 429 || remaining === '0') {
+    throw new Error('rate-limit');
+  }
+
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+
+  return response.json();
+}
+
+function createWidget() {
+  const container = document.createElement('div');
+  container.id = 'feedback-widget';
+  container.innerHTML = `
+    <button id="feedback-toggle" type="button" aria-label="Send feedback">Feedback</button>
+    <form id="feedback-form" style="display:none;">
+      <label for="feedback-comment">Comment (optional)</label>
+      <textarea id="feedback-comment" rows="3"></textarea>
+      <button type="submit">Submit</button>
+      <div id="feedback-message" role="alert"></div>
+    </form>`;
+  document.body.appendChild(container);
+
+  const toggle = container.querySelector('#feedback-toggle');
+  const form = container.querySelector('#feedback-form');
+  const comment = container.querySelector('#feedback-comment');
+  const message = container.querySelector('#feedback-message');
+
+  toggle.addEventListener('click', () => {
+    form.style.display = form.style.display === 'none' ? 'block' : 'none';
+  });
+
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    message.textContent = 'Sending...';
+    try {
+      await sendFeedback({ page: window.location.href, comment: comment.value.trim() });
+      message.textContent = 'Thank you for your feedback!';
+      comment.value = '';
+    } catch (err) {
+      if (err.message === 'rate-limit') {
+        message.textContent = 'Rate limit exceeded. Please try again later.';
+      } else {
+        message.textContent = 'Failed to send feedback.';
+      }
+    }
+  });
+}
+
+if (typeof window !== 'undefined') {
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', createWidget);
+  } else {
+    createWidget();
+  }
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { sendFeedback };
+}

--- a/index.html
+++ b/index.html
@@ -11,29 +11,30 @@
 <body>
   <main class="container">
     <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
+    <nav class="site-nav" aria-label="Site navigation"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
     <div id="definition-container" style="display: none;"></div>
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+    <button type="button" id="random-term" aria-label="Show random term">Random Term</button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+    <button type="button" id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 
     <ul id="terms-list"></ul>
   </main>
-  <footer class="container">
+  <footer class="container" aria-label="Primary footer">
     <p><a href="templates/contribute.html">Contribute</a></p>
   </footer>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+  <button type="button" id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
 
-  <footer>
+  <footer aria-label="Secondary footer">
     <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
   </footer>
   <script src="script.js"></script>
   <script src="assets/js/app.js"></script>
+  <script src="assets/js/feedback.js"></script>
 </body>
 </html>
 

--- a/layout.html
+++ b/layout.html
@@ -23,16 +23,17 @@
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+    <button type="button" id="random-term" aria-label="Show random term">Random Term</button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+    <button type="button" id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 
     <ul id="terms-list"></ul>
   </main>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+  <button type="button" id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
 
   <script src="script.js"></script>
+  <script src="assets/js/feedback.js"></script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "script.js",
   "scripts": {
     "build": "node scripts/build.js",
-    "test": "html-validate index.html",
+    "test": "node test/feedback.test.js && html-validate index.html",
     "watch": "chokidar \"**/*.html\" -c \"npm run build\""
   },
   "keywords": [],

--- a/styles.css
+++ b/styles.css
@@ -347,3 +347,28 @@ body.dark-mode #alpha-nav button.active {
     font-size: 14px;
   }
 }
+#feedback-widget {
+  position: fixed;
+  bottom: 80px;
+  right: 20px;
+  z-index: 1000;
+}
+
+#feedback-widget form {
+  margin-top: 5px;
+  background: #f8f8f8;
+  padding: 10px;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+}
+
+#feedback-widget textarea {
+  width: 200px;
+  display: block;
+}
+
+body.dark-mode #feedback-widget form {
+  background-color: #1e1e1e;
+  border-color: #333;
+  color: #fff;
+}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -47,5 +47,6 @@
     </ul>
   </footer>
   <script src="{{ base_url }}/assets/js/app.js"></script>
+  <script src="{{ base_url }}/assets/js/feedback.js"></script>
 </body>
 </html>

--- a/test/feedback.test.js
+++ b/test/feedback.test.js
@@ -1,0 +1,21 @@
+const assert = require('assert').strict;
+const { sendFeedback } = require('../assets/js/feedback.js');
+
+(async () => {
+  const originalFetch = global.fetch;
+  global.fetch = async () => ({
+    status: 403,
+    headers: new Headers({ 'X-RateLimit-Remaining': '0' }),
+    ok: false,
+    text: async () => 'rate limit'
+  });
+  try {
+    await sendFeedback({ page: 'test', comment: '' });
+    assert.fail('Expected rate-limit error');
+  } catch (err) {
+    assert.strictEqual(err.message, 'rate-limit');
+    console.log('Rate limit handled gracefully');
+  } finally {
+    global.fetch = originalFetch;
+  }
+})();


### PR DESCRIPTION
## Summary
- Add per-page feedback widget that files GitHub issues with an optional comment and rate-limit handling
- Style and include the widget across layouts
- Test rate-limit failure handling and update test workflow

## Testing
- `node test/feedback.test.js`
- `npx html-validate index.html && echo 'html-validate passed'`


------
https://chatgpt.com/codex/tasks/task_e_68b4c7f9f71c83289329a17c8e35a6e3