### PR TITLE
Add Code of Conduct and reference in docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,3 +8,4 @@
 - [ ] Added/updated terms in `data.json`
 - [ ] Ran tests (`npm test`)
 - [ ] Updated documentation if needed
+- [ ] I agree to follow this project's [Code of Conduct](../CODE_OF_CONDUCT.md)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,28 @@
+# Code of Conduct
+
+We are dedicated to providing a welcoming and harassment-free experience for everyone.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+- Using inclusive and welcoming language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+
+Unacceptable behavior includes:
+- Harassment, intimidation, or discrimination in any form
+- Public or private harassment
+- Publishing others' private information without permission
+
+## Reporting
+
+If you experience or witness unacceptable behavior, please report it to us at [conduct@example.com](mailto:conduct@example.com).
+
+All reports will be reviewed and handled confidentially. Project maintainers will take appropriate action in response to any behavior they deem inappropriate.
+
+## Enforcement
+
+Project maintainers who do not follow or enforce the Code of Conduct may be removed from the project team.
+
+Thank you for helping us maintain a welcoming community.
+

--- a/README.md
+++ b/README.md
@@ -4,3 +4,6 @@ https://alex-unnippillil.github.io/CyberSecuirtyDictionary/
 
 ## Security
 For information on reporting vulnerabilities, please see our [Security Policy](SECURITY.md).
+
+## Code of Conduct
+Please read our [Code of Conduct](CODE_OF_CONDUCT.md) to understand the expectations for participation.


### PR DESCRIPTION
## Summary
- add community Code of Conduct with reporting contact
- link Code of Conduct from README and PR template

## Testing
- `npm test` *(fails: 6 html-validate errors in index.html)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c7fb461c8328ad135105a56dbf7a