### PR TITLE
docs: add instructions for building glossary

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,15 @@ https://alex-unnippillil.github.io/CyberSecuirtyDictionary/
 
 ## Security
 For information on reporting vulnerabilities, please see our [Security Policy](SECURITY.md).
+
+## Build your own glossary
+
+You can create your own glossary using this project as a starting point.
+
+1. On GitHub, click **Use this template** to generate a new repository.
+2. Clone your new repository locally and install dependencies with `npm install`.
+3. Add or edit terms in `terms.json` or the files under `data/`.
+4. Run `npm run build` to generate the static site, or `npm run watch` to rebuild on changes.
+5. Commit your changes and enable GitHub Pages for your repository to publish your glossary.
+
+This project can be forked as well, but using the template option keeps the commit history focused on your version.


### PR DESCRIPTION
## Summary
- document steps for using the repository as a template and building your own glossary

## Testing
- `npm test` *(fails: unique-landmark, no-implicit-button-type)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c7fc318c8328810c701a9dcac245