### PR TITLE
feat: add security framework metadata and filters

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,25 +11,35 @@
 <body>
   <main class="container">
     <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
+    <nav class="site-nav" aria-label="Primary">
+      <a href="templates/guidelines.html">Definition Guidelines</a>
+    </nav>
     <div id="definition-container" style="display: none;"></div>
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+    <label for="framework-filter">Framework:</label>
+    <select id="framework-filter">
+      <option value="All">All Frameworks</option>
+      <option value="NIST CSF">NIST CSF</option>
+      <option value="ISO 27001">ISO 27001</option>
+      <option value="CIS Controls">CIS Controls</option>
+    </select>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+    <button id="random-term" aria-label="Show random term" type="button">Random Term</button>
+
+    <button id="dark-mode-toggle" aria-label="Toggle dark mode" type="button">Toggle Dark Mode</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 
     <ul id="terms-list"></ul>
   </main>
-  <footer class="container">
+  <footer class="container" aria-label="Contribute">
     <p><a href="templates/contribute.html">Contribute</a></p>
   </footer>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+  <button id="scrollToTopBtn" aria-label="Scroll to top" type="button">↑</button>
 
-  <footer>
+  <footer aria-label="Repository">
     <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
   </footer>
   <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -5,6 +5,7 @@ const randomButton = document.getElementById("random-term");
 const alphaNav = document.getElementById("alpha-nav");
 const darkModeToggle = document.getElementById("dark-mode-toggle");
 const showFavoritesToggle = document.getElementById("show-favorites");
+const frameworkFilter = document.getElementById("framework-filter");
 const favorites = new Set(JSON.parse(localStorage.getItem("favorites") || "[]"));
 const siteUrl = "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/";
 const canonicalLink = document.getElementById("canonical-link");
@@ -130,6 +131,7 @@ function buildAlphaNav() {
 function populateTermsList() {
   termsList.innerHTML = "";
   const searchValue = searchInput.value.trim().toLowerCase();
+  const selectedFramework = frameworkFilter ? frameworkFilter.value : "All";
   termsData.terms
     .sort((a, b) => a.term.localeCompare(b.term))
     .forEach((item) => {
@@ -137,7 +139,10 @@ function populateTermsList() {
       const matchesFavorites = !showFavoritesToggle || !showFavoritesToggle.checked || favorites.has(item.term);
       const matchesLetter =
         currentLetterFilter === "All" || item.term.charAt(0).toUpperCase() === currentLetterFilter;
-      if (matchesSearch && matchesFavorites && matchesLetter) {
+      const matchesFramework =
+        selectedFramework === "All" ||
+        (item.frameworks && item.frameworks[selectedFramework]);
+      if (matchesSearch && matchesFavorites && matchesLetter && matchesFramework) {
         const termDiv = document.createElement("div");
         termDiv.classList.add("dictionary-item");
 
@@ -182,7 +187,17 @@ function populateTermsList() {
 
 function displayDefinition(term) {
   definitionContainer.style.display = "block";
-  definitionContainer.innerHTML = `<h3>${term.term}</h3><p>${term.definition}</p>`;
+  let html = `<h3>${term.term}</h3><p>${term.definition}</p>`;
+  if (term.frameworks) {
+    const fwList = Object.entries(term.frameworks)
+      .filter(([, val]) => val && val.length)
+      .map(([key, val]) => `<strong>${key}:</strong> ${val.join(", ")}`)
+      .join("<br>");
+    if (fwList) {
+      html += `<p>${fwList}</p>`;
+    }
+  }
+  definitionContainer.innerHTML = html;
   window.location.hash = encodeURIComponent(term.term);
   if (canonicalLink) {
     canonicalLink.setAttribute(
@@ -216,6 +231,13 @@ function showRandomTerm() {
 randomButton.addEventListener("click", showRandomTerm);
 if (showFavoritesToggle) {
   showFavoritesToggle.addEventListener("change", () => {
+    clearDefinition();
+    populateTermsList();
+  });
+}
+
+if (frameworkFilter) {
+  frameworkFilter.addEventListener("change", () => {
     clearDefinition();
     populateTermsList();
   });

--- a/terms.json
+++ b/terms.json
@@ -2,7 +2,11 @@
   "terms": [
     {
       "term": "Phishing",
-      "definition": "An attempt to trick individuals into revealing sensitive information through fraudulent emails, websites, or messages."
+      "definition": "An attempt to trick individuals into revealing sensitive information through fraudulent emails, websites, or messages.",
+      "frameworks": {
+        "NIST CSF": ["PR.AT-1"],
+        "CIS Controls": ["14.1"]
+      }
     },
     {
       "term": "Phishing Email",
@@ -14,7 +18,11 @@
     },
     {
       "term": "Advanced Persistent Threat (APT)",
-      "definition": "A prolonged and targeted cyber attack in which attackers gain and maintain unauthorized access to a network."
+      "definition": "A prolonged and targeted cyber attack in which attackers gain and maintain unauthorized access to a network.",
+      "frameworks": {
+        "ISO 27001": ["A.16.1.5"],
+        "CIS Controls": ["20.5"]
+      }
     },
     {
       "term": "Cyber Espionage",
@@ -30,7 +38,12 @@
     },
     {
       "term": "Data Loss Prevention (DLP)",
-      "definition": "A strategy and set of tools to prevent the unauthorized loss or leakage of sensitive data."
+      "definition": "A strategy and set of tools to prevent the unauthorized loss or leakage of sensitive data.",
+      "frameworks": {
+        "NIST CSF": ["PR.DS-1"],
+        "ISO 27001": ["A.8.2.2"],
+        "CIS Controls": ["13.10"]
+      }
     },
     {
       "term": "Endpoint Security",


### PR DESCRIPTION
## Summary
- map several terms to NIST CSF, ISO 27001, and CIS Controls
- add framework filter and display to dictionary UI
- show framework details when viewing definitions

## Testing
- `npm test`
- `node -e "const d=require('./terms.json');const f=['NIST CSF','ISO 27001','CIS Controls'];for(const fw of f){const t=d.terms.filter(x=>x.frameworks&&x.frameworks[fw]);console.log(fw+': '+t.map(x=>x.term).join(', '));}"`


------
https://chatgpt.com/codex/tasks/task_e_68b4c7fe07cc8328a0ea464a6eb44441