### PR TITLE
Add incident response pack and print styles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/index.html
+++ b/index.html
@@ -1,39 +1,54 @@
-<!DOCTYPE html>
+<!DOCTYPE HTML>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Cyber Security Dictionary</title>
-  <link rel="stylesheet" href="styles.css">
-  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet">
-  <link rel="canonical" id="canonical-link" href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/">
-</head>
-<body>
-  <main class="container">
-    <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
-    <div id="definition-container" style="display: none;"></div>
-    <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
-    <input type="text" id="search" placeholder="Search...">
+  <head>
+    <meta charset="UTF-8" >
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" >
+    <title>Cyber Security Dictionary</title>
+    <link rel="stylesheet" href="styles.css" >
+    <link
+      href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap"
+      rel="stylesheet"
+    >
+    <link
+      rel="canonical"
+      id="canonical-link"
+      href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/"
+    >
+  </head>
+  <body>
+    <main class="container">
+      <h1>Cyber Security Dictionary</h1>
+      <nav class="site-nav" aria-label="Site navigation">
+        <a href="templates/guidelines.html">Definition Guidelines</a> |
+        <a href="templates/incident-response-pack.html"
+          >Incident Response Pack</a
+        >
+      </nav>
+      <div id="definition-container" style="display: none"></div>
+      <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
+      <input type="text" id="search" placeholder="Search..." >
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+      <button type="button" id="random-term" aria-label="Show random term">
+        Random Term
+      </button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
-    <input type="checkbox" id="show-favorites" aria-label="Show favorites">
-    <label for="show-favorites">Show Favorites</label>
+      <button type="button" id="dark-mode-toggle" aria-label="Toggle dark mode">
+        Toggle Dark Mode
+      </button>
+      <input type="checkbox" id="show-favorites" aria-label="Show favorites" >
+      <label for="show-favorites">Show Favorites</label>
 
-    <ul id="terms-list"></ul>
-  </main>
-  <footer class="container">
-    <p><a href="templates/contribute.html">Contribute</a></p>
-  </footer>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+      <ul id="terms-list"></ul>
+    </main>
+    <footer class="container" aria-label="Primary footer">
+      <p><a href="templates/contribute.html">Contribute</a></p>
+    </footer>
+    <button type="button" id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
 
-  <footer>
-    <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
-  </footer>
-  <script src="script.js"></script>
-  <script src="assets/js/app.js"></script>
-</body>
+    <footer aria-label="Project footer">
+      <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
+    </footer>
+    <script src="script.js"></script>
+    <script src="assets/js/app.js"></script>
+  </body>
 </html>
-

--- a/styles.css
+++ b/styles.css
@@ -25,7 +25,7 @@ body {
 
 h1 {
   text-align: center;
-  font-family: 'Cinzel', serif;
+  font-family: "Cinzel", serif;
   font-weight: 700;
   font-size: 48px;
   margin-bottom: 20px;
@@ -110,7 +110,6 @@ body.dark-mode mark {
   box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
   min-height: 44px;
 }
-
 
 /* Controls styling */
 #random-term {
@@ -206,7 +205,9 @@ label {
   border-radius: 4px;
   padding: 10px;
   cursor: pointer;
-  transition: background-color 0.2s, color 0.2s;
+  transition:
+    background-color 0.2s,
+    color 0.2s;
   min-width: 44px;
   min-height: 44px;
 }
@@ -345,5 +346,27 @@ body.dark-mode #alpha-nav button.active {
 
   #alpha-nav button {
     font-size: 14px;
+  }
+}
+@media print {
+  nav,
+  #random-term,
+  #dark-mode-toggle,
+  #scrollToTopBtn,
+  #alpha-nav,
+  #show-favorites,
+  label[for="show-favorites"],
+  #search,
+  #print-pack {
+    display: none;
+  }
+
+  body {
+    background: #fff;
+    color: #000;
+  }
+
+  .container {
+    box-shadow: none;
   }
 }

--- a/templates/incident-response-pack.html
+++ b/templates/incident-response-pack.html
@@ -1,0 +1,75 @@
+<!DOCTYPE HTML>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" >
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" >
+    <title>Incident Response Pack</title>
+    <link rel="stylesheet" href="../styles.css" >
+  </head>
+  <body>
+    <a href="#main" class="skip-link">Skip to content</a>
+    <main id="main" class="container">
+      <h1>Incident Response Pack</h1>
+      <button
+        type="button"
+        id="print-pack"
+        onclick="window.print()"
+        aria-label="Print this pack"
+      >
+        Print Pack
+      </button>
+
+      <section aria-labelledby="glossary-heading">
+        <h2 id="glossary-heading">Mini Glossary</h2>
+        <dl>
+          <dt>Incident Response</dt>
+          <dd>
+            Coordinated steps for addressing and managing the aftermath of a
+            security breach or attack.
+          </dd>
+          <dt>Containment</dt>
+          <dd>
+            Actions taken to limit the scope and impact of a security incident.
+          </dd>
+          <dt>Eradication</dt>
+          <dd>
+            Steps to remove the cause of the incident and ensure it does not
+            recur.
+          </dd>
+          <dt>Recovery</dt>
+          <dd>
+            Process of restoring systems to normal operation and verifying they
+            are functioning correctly.
+          </dd>
+        </dl>
+      </section>
+
+      <section aria-labelledby="runbooks-heading">
+        <h2 id="runbooks-heading">Runbooks</h2>
+
+        <article aria-labelledby="phishing-heading">
+          <h3 id="phishing-heading">Phishing Email Response</h3>
+          <ol>
+            <li>Report suspicious email to security team.</li>
+            <li>Isolate affected user account and device.</li>
+            <li>Analyze email headers and payload.</li>
+            <li>Remove malicious content and reset credentials.</li>
+            <li>Inform users and update phishing filters.</li>
+          </ol>
+        </article>
+
+        <article aria-labelledby="ransomware-heading">
+          <h3 id="ransomware-heading">Ransomware Outbreak</h3>
+          <ol>
+            <li>Disconnect infected systems from the network.</li>
+            <li>Notify incident response team and relevant stakeholders.</li>
+            <li>Identify strain and determine scope of encryption.</li>
+            <li>Restore systems from clean backups.</li>
+            <li>Conduct lessons learned and strengthen defenses.</li>
+          </ol>
+        </article>
+      </section>
+    </main>
+    <script src="../assets/js/app.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Add incident-response pack page with mini glossary and runbooks
- Link pack from homepage and improve button accessibility
- Introduce print-focused styles and ignore node modules

## Testing
- `npm test`
- `npx html-validate templates/incident-response-pack.html && echo "HTML Validate OK" >/tmp/validate.log && cat /tmp/validate.log`

------
https://chatgpt.com/codex/tasks/task_e_68b4c7fee01483289a6f1d39a219a4d6