### PR TITLE
Add IAM tag filtering and terms

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,25 +11,31 @@
 <body>
   <main class="container">
     <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
+      <nav class="site-nav" aria-label="Site navigation"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
     <div id="definition-container" style="display: none;"></div>
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+    <label for="tag-filter">Filter by topic:</label>
+    <select id="tag-filter">
+      <option value="All">All Topics</option>
+      <option value="IAM">IAM</option>
+    </select>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+      <button id="random-term" aria-label="Show random term" type="button">Random Term</button>
+
+      <button id="dark-mode-toggle" aria-label="Toggle dark mode" type="button">Toggle Dark Mode</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 
     <ul id="terms-list"></ul>
   </main>
-  <footer class="container">
+    <footer class="container" aria-label="Primary footer">
     <p><a href="templates/contribute.html">Contribute</a></p>
   </footer>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+    <button id="scrollToTopBtn" aria-label="Scroll to top" type="button">↑</button>
 
-  <footer>
+    <footer aria-label="Secondary footer">
     <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
   </footer>
   <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -5,11 +5,13 @@ const randomButton = document.getElementById("random-term");
 const alphaNav = document.getElementById("alpha-nav");
 const darkModeToggle = document.getElementById("dark-mode-toggle");
 const showFavoritesToggle = document.getElementById("show-favorites");
+const tagFilter = document.getElementById("tag-filter");
 const favorites = new Set(JSON.parse(localStorage.getItem("favorites") || "[]"));
 const siteUrl = "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/";
 const canonicalLink = document.getElementById("canonical-link");
 
 let currentLetterFilter = "All";
+let currentTagFilter = "All";
 let termsData = { terms: [] };
 
 if (localStorage.getItem("darkMode") === "true") {
@@ -20,6 +22,14 @@ if (darkModeToggle) {
   darkModeToggle.addEventListener("click", () => {
     document.body.classList.toggle("dark-mode");
     localStorage.setItem("darkMode", document.body.classList.contains("dark-mode"));
+  });
+}
+
+if (tagFilter) {
+  tagFilter.addEventListener("change", () => {
+    currentTagFilter = tagFilter.value;
+    clearDefinition();
+    populateTermsList();
   });
 }
 
@@ -137,7 +147,9 @@ function populateTermsList() {
       const matchesFavorites = !showFavoritesToggle || !showFavoritesToggle.checked || favorites.has(item.term);
       const matchesLetter =
         currentLetterFilter === "All" || item.term.charAt(0).toUpperCase() === currentLetterFilter;
-      if (matchesSearch && matchesFavorites && matchesLetter) {
+      const matchesTag =
+        currentTagFilter === "All" || (item.tags && item.tags.includes(currentTagFilter));
+      if (matchesSearch && matchesFavorites && matchesLetter && matchesTag) {
         const termDiv = document.createElement("div");
         termDiv.classList.add("dictionary-item");
 

--- a/terms.json
+++ b/terms.json
@@ -131,6 +131,202 @@
     {
       "term": "Phishing Email",
       "definition": "An email sent by attackers that appears legitimate but aims to trick recipients into revealing sensitive information or performing actions."
+    },
+    {
+      "term": "Access Token",
+      "definition": "A credential issued by an authorization server that allows a client to access protected resources.",
+      "tags": [
+        "IAM"
+      ]
+    },
+    {
+      "term": "Attribute-Based Access Control (ABAC)",
+      "definition": "An access control model that grants permissions based on attributes of users, resources, and environment.",
+      "tags": [
+        "IAM"
+      ]
+    },
+    {
+      "term": "Authorization Code Grant",
+      "definition": "An OAuth 2.0 flow where an authorization code is exchanged for an access token via the client’s backend.",
+      "tags": [
+        "IAM"
+      ]
+    },
+    {
+      "term": "Client Credentials Grant",
+      "definition": "An OAuth 2.0 flow where a client application uses its own credentials to obtain an access token.",
+      "tags": [
+        "IAM"
+      ]
+    },
+    {
+      "term": "Conditional Access",
+      "definition": "A policy-based approach to enforce specific access requirements based on user, device, or location signals.",
+      "tags": [
+        "IAM"
+      ]
+    },
+    {
+      "term": "Deprovisioning",
+      "definition": "The removal of user accounts and access rights when they are no longer needed.",
+      "tags": [
+        "IAM"
+      ]
+    },
+    {
+      "term": "Device Code Flow",
+      "definition": "An OAuth 2.0 flow designed for devices with limited input capabilities, using a user code and verification URL.",
+      "tags": [
+        "IAM"
+      ]
+    },
+    {
+      "term": "Federated Identity",
+      "definition": "A system that enables users to use the same identity across multiple organizations or domains.",
+      "tags": [
+        "IAM"
+      ]
+    },
+    {
+      "term": "Identity Governance and Administration (IGA)",
+      "definition": "Processes and technologies for managing digital identities and access rights across an organization.",
+      "tags": [
+        "IAM"
+      ]
+    },
+    {
+      "term": "Identity Provider (IdP)",
+      "definition": "A service that creates, maintains, and manages identity information and provides authentication services.",
+      "tags": [
+        "IAM"
+      ]
+    },
+    {
+      "term": "Implicit Grant",
+      "definition": "An OAuth 2.0 flow optimized for public clients where tokens are returned directly in the redirect URI.",
+      "tags": [
+        "IAM"
+      ]
+    },
+    {
+      "term": "JSON Web Token (JWT)",
+      "definition": "A compact, URL-safe token format used to securely transmit claims between parties.",
+      "tags": [
+        "IAM"
+      ]
+    },
+    {
+      "term": "Just-in-Time Provisioning",
+      "definition": "A provisioning approach that creates user accounts on demand during the first sign-in.",
+      "tags": [
+        "IAM"
+      ]
+    },
+    {
+      "term": "Least Privilege",
+      "definition": "A principle that restricts users to the minimum level of access required to perform their tasks.",
+      "tags": [
+        "IAM"
+      ]
+    },
+    {
+      "term": "Multi-Factor Authentication (MFA)",
+      "definition": "A security method that requires users to provide two or more verification factors to gain access.",
+      "tags": [
+        "IAM"
+      ]
+    },
+    {
+      "term": "OAuth 2.0",
+      "definition": "An authorization framework that enables applications to obtain limited access to user accounts on HTTP services.",
+      "tags": [
+        "IAM"
+      ]
+    },
+    {
+      "term": "OpenID Connect (OIDC)",
+      "definition": "An authentication layer built on OAuth 2.0 that allows clients to verify user identities.",
+      "tags": [
+        "IAM"
+      ]
+    },
+    {
+      "term": "Passwordless Authentication",
+      "definition": "An authentication method that does not require users to remember or enter a password.",
+      "tags": [
+        "IAM"
+      ]
+    },
+    {
+      "term": "Proof Key for Code Exchange (PKCE)",
+      "definition": "An extension to OAuth 2.0 that mitigates authorization code interception attacks using a dynamically generated secret.",
+      "tags": [
+        "IAM"
+      ]
+    },
+    {
+      "term": "Privileged Access Management (PAM)",
+      "definition": "Tools and practices used to secure, control, and monitor access to critical systems by privileged users.",
+      "tags": [
+        "IAM"
+      ]
+    },
+    {
+      "term": "Refresh Token",
+      "definition": "A long-lived credential used to obtain new access tokens without re-authenticating the user.",
+      "tags": [
+        "IAM"
+      ]
+    },
+    {
+      "term": "Resource Owner Password Credentials Grant",
+      "definition": "An OAuth 2.0 flow where the user provides credentials directly to the client to obtain an access token.",
+      "tags": [
+        "IAM"
+      ]
+    },
+    {
+      "term": "Role-Based Access Control (RBAC)",
+      "definition": "An access control model that assigns permissions to users based on their roles.",
+      "tags": [
+        "IAM"
+      ]
+    },
+    {
+      "term": "Single Sign-On (SSO)",
+      "definition": "An authentication process that allows a user to access multiple applications with one set of login credentials.",
+      "tags": [
+        "IAM"
+      ]
+    },
+    {
+      "term": "Single Sign-Out",
+      "definition": "A process that logs a user out of multiple applications simultaneously.",
+      "tags": [
+        "IAM"
+      ]
+    },
+    {
+      "term": "System for Cross-domain Identity Management (SCIM)",
+      "definition": "An open standard for automating the exchange of user identity information between identity domains or IT systems.",
+      "tags": [
+        "IAM"
+      ]
+    },
+    {
+      "term": "Token Introspection",
+      "definition": "An OAuth 2.0 endpoint that allows resource servers to validate and obtain metadata about a token.",
+      "tags": [
+        "IAM"
+      ]
+    },
+    {
+      "term": "User Provisioning",
+      "definition": "The creation of user accounts and access rights in applications and systems.",
+      "tags": [
+        "IAM"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- support filtering dictionary terms by IAM tag
- document IAM topics like SSO, OAuth 2.0, OIDC, SCIM, conditional access and more
- ensure >25 IAM entries with tagging for identity access management

## Testing
- `npm test`
- `npm run build` *(fails: Cannot find module 'scripts/build.js')*


------
https://chatgpt.com/codex/tasks/task_e_68b4d608a6e883289de9de6a163abe5a