### PR TITLE
Add definition diff highlighting

### DIFF
--- a/diffUtil.js
+++ b/diffUtil.js
@@ -1,0 +1,84 @@
+function tokenize(text) {
+  return text.split(/(\s+)/).filter(t => t.length > 0);
+}
+
+function escapeHtml(str) {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function diffTokens(oldTokens, newTokens) {
+  const dp = Array.from({ length: oldTokens.length + 1 }, () =>
+    Array(newTokens.length + 1).fill(0)
+  );
+  for (let i = 1; i <= oldTokens.length; i++) {
+    for (let j = 1; j <= newTokens.length; j++) {
+      if (oldTokens[i - 1] === newTokens[j - 1]) {
+        dp[i][j] = dp[i - 1][j - 1] + 1;
+      } else {
+        dp[i][j] = Math.max(dp[i - 1][j], dp[i][j - 1]);
+      }
+    }
+  }
+  const diff = [];
+  let i = oldTokens.length;
+  let j = newTokens.length;
+  while (i > 0 && j > 0) {
+    if (oldTokens[i - 1] === newTokens[j - 1]) {
+      diff.unshift({ type: 'same', text: oldTokens[i - 1] });
+      i--;
+      j--;
+    } else if (dp[i - 1][j] >= dp[i][j - 1]) {
+      diff.unshift({ type: 'removed', text: oldTokens[i - 1] });
+      i--;
+    } else {
+      diff.unshift({ type: 'added', text: newTokens[j - 1] });
+      j--;
+    }
+  }
+  while (i > 0) {
+    diff.unshift({ type: 'removed', text: oldTokens[i - 1] });
+    i--;
+  }
+  while (j > 0) {
+    diff.unshift({ type: 'added', text: newTokens[j - 1] });
+    j--;
+  }
+  return diff;
+}
+
+function generateDiff(oldText, newText) {
+  const oldTokens = tokenize(oldText);
+  const newTokens = tokenize(newText);
+  const diff = diffTokens(oldTokens, newTokens);
+  const htmlParts = [];
+  diff.forEach((part, idx) => {
+    const next = diff[idx + 1];
+    const text = escapeHtml(part.text);
+    let token = text;
+    if (part.type === 'added') {
+      token = `<span class="diff-added">${text}</span>`;
+    } else if (part.type === 'removed') {
+      token = `<span class="diff-removed">${text}</span>`;
+    }
+    htmlParts.push(token);
+    if (
+      next &&
+      !/\s/.test(next.text[0]) &&
+      (part.type === 'added' || part.type === 'removed') &&
+      (next.type === 'added' || next.type === 'removed')
+    ) {
+      htmlParts.push(' ');
+    }
+  });
+  return htmlParts.join('');
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { generateDiff };
+}
+

--- a/diffUtil.test.js
+++ b/diffUtil.test.js
@@ -1,0 +1,7 @@
+const { generateDiff } = require('./diffUtil');
+
+const oldText = 'An attempt to acquire sensitive information by masquerading as a trustworthy entity in electronic communication.';
+const newText = 'An attempt to trick individuals into revealing sensitive information through fraudulent emails, websites, or messages.';
+
+const result = generateDiff(oldText, newText);
+console.log(result);

--- a/index.html
+++ b/index.html
@@ -9,31 +9,31 @@
   <link rel="canonical" id="canonical-link" href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/">
 </head>
 <body>
-  <main class="container">
-    <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
+    <main class="container" aria-label="Main content">
+      <h1>Cyber Security Dictionary</h1>
+      <nav class="site-nav" aria-label="Site navigation"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
     <div id="definition-container" style="display: none;"></div>
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+      <button id="random-term" type="button" aria-label="Show random term">Random Term</button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+      <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">Toggle Dark Mode</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 
     <ul id="terms-list"></ul>
-  </main>
-  <footer class="container">
-    <p><a href="templates/contribute.html">Contribute</a></p>
-  </footer>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
-
-  <footer>
-    <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
-  </footer>
-  <script src="script.js"></script>
-  <script src="assets/js/app.js"></script>
-</body>
-</html>
+    </main>
+    <footer class="container" aria-label="Primary footer">
+      <p><a href="templates/contribute.html">Contribute</a></p>
+    </footer>
+    <footer aria-label="Secondary footer">
+      <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
+    </footer>
+    <button id="scrollToTopBtn" type="button" aria-label="Scroll to top">↑</button>
+    <script src="diffUtil.js"></script>
+    <script src="script.js"></script>
+    <script src="assets/js/app.js"></script>
+  </body>
+  </html>
 

--- a/script.js
+++ b/script.js
@@ -180,17 +180,24 @@ function populateTermsList() {
     });
 }
 
-function displayDefinition(term) {
-  definitionContainer.style.display = "block";
-  definitionContainer.innerHTML = `<h3>${term.term}</h3><p>${term.definition}</p>`;
-  window.location.hash = encodeURIComponent(term.term);
-  if (canonicalLink) {
-    canonicalLink.setAttribute(
-      "href",
-      `${siteUrl}#${encodeURIComponent(term.term)}`
-    );
+  function displayDefinition(term) {
+    definitionContainer.style.display = "block";
+    let definitionHTML = `<p>${term.definition}</p>`;
+    if (term.previousDefinition) {
+      definitionHTML = `<p class="definition-diff">${generateDiff(
+        term.previousDefinition,
+        term.definition
+      )}</p>`;
+    }
+    definitionContainer.innerHTML = `<h3>${term.term}</h3>${definitionHTML}`;
+    window.location.hash = encodeURIComponent(term.term);
+    if (canonicalLink) {
+      canonicalLink.setAttribute(
+        "href",
+        `${siteUrl}#${encodeURIComponent(term.term)}`
+      );
+    }
   }
-}
 
 function clearDefinition() {
   definitionContainer.style.display = "none";

--- a/styles.css
+++ b/styles.css
@@ -66,6 +66,15 @@ body.dark-mode mark {
   color: #000;
 }
 
+.diff-added {
+  background-color: #c8e6c9;
+}
+
+.diff-removed {
+  background-color: #ffcdd2;
+  text-decoration: line-through;
+}
+
 .dictionary-item {
   margin-bottom: 20px;
   padding: 12px;

--- a/terms.json
+++ b/terms.json
@@ -2,7 +2,8 @@
   "terms": [
     {
       "term": "Phishing",
-      "definition": "An attempt to trick individuals into revealing sensitive information through fraudulent emails, websites, or messages."
+      "definition": "An attempt to trick individuals into revealing sensitive information through fraudulent emails, websites, or messages.",
+      "previousDefinition": "An attempt to acquire sensitive information by masquerading as a trustworthy entity in electronic communication."
     },
     {
       "term": "Phishing Email",


### PR DESCRIPTION
## Summary
- highlight definition changes by computing diffs between previous and current text
- render diff view on term page when historical definitions exist
- add styles and accessibility fixes for buttons and landmarks

## Testing
- `npm test`
- `node diffUtil.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b4d60beda483289274cc504df1c11b