### PR TITLE
Add Konami code easter egg terminal

### DIFF
--- a/assets/js/konami.js
+++ b/assets/js/konami.js
@@ -1,0 +1,86 @@
+const KONAMI_SEQUENCE = [
+  "ArrowUp",
+  "ArrowUp",
+  "ArrowDown",
+  "ArrowDown",
+  "ArrowLeft",
+  "ArrowRight",
+  "ArrowLeft",
+  "ArrowRight",
+  "b",
+  "a",
+];
+
+function setupKonamiCode(callback) {
+  let position = 0;
+  return function (event) {
+    const key = event.key;
+    if (key.toLowerCase() === KONAMI_SEQUENCE[position].toLowerCase()) {
+      position++;
+      if (position === KONAMI_SEQUENCE.length) {
+        callback();
+        position = 0;
+      }
+    } else {
+      position = key === KONAMI_SEQUENCE[0] ? 1 : 0;
+    }
+  };
+}
+
+if (typeof document !== "undefined") {
+  // Konami code easter egg. Remove this block to disable.
+  const commands = [
+    "ls -la",
+    "pwd",
+    "whoami",
+    'echo "Stay secure!"',
+    "nmap -sS localhost",
+    "ping example.com",
+    "netstat -an",
+  ];
+  let terminalVisible = false;
+  let intervalId;
+  const handler = setupKonamiCode(() => {
+    terminalVisible = !terminalVisible;
+    if (terminalVisible) {
+      showTerminal();
+    } else {
+      hideTerminal();
+    }
+  });
+  document.addEventListener("keydown", handler);
+
+  function showTerminal() {
+    let terminal = document.getElementById("konami-terminal");
+    if (!terminal) {
+      terminal = document.createElement("div");
+      terminal.id = "konami-terminal";
+      terminal.className = "konami-terminal hidden";
+      document.body.appendChild(terminal);
+    }
+    terminal.classList.remove("hidden");
+    intervalId = setInterval(() => {
+      const cmd = commands[Math.floor(Math.random() * commands.length)];
+      const line = document.createElement("div");
+      line.textContent = `$ ${cmd}`;
+      terminal.appendChild(line);
+      terminal.scrollTop = terminal.scrollHeight;
+    }, 1000);
+  }
+
+  function hideTerminal() {
+    const terminal = document.getElementById("konami-terminal");
+    if (terminal) {
+      terminal.classList.add("hidden");
+      terminal.innerHTML = "";
+    }
+    if (intervalId) {
+      clearInterval(intervalId);
+      intervalId = null;
+    }
+  }
+}
+
+if (typeof module !== "undefined") {
+  module.exports = { setupKonamiCode };
+}

--- a/index.html
+++ b/index.html
@@ -1,39 +1,52 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Cyber Security Dictionary</title>
-  <link rel="stylesheet" href="styles.css">
-  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet">
-  <link rel="canonical" id="canonical-link" href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/">
-</head>
-<body>
-  <main class="container">
-    <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
-    <div id="definition-container" style="display: none;"></div>
-    <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
-    <input type="text" id="search" placeholder="Search...">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cyber Security Dictionary</title>
+    <link rel="stylesheet" href="styles.css">
+    <link
+      href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap"
+      rel="stylesheet"
+    >
+    <link
+      rel="canonical"
+      id="canonical-link"
+      href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/"
+    >
+  </head>
+  <body>
+    <main class="container">
+      <h1>Cyber Security Dictionary</h1>
+      <nav class="site-nav" aria-label="Site navigation">
+        <a href="templates/guidelines.html">Definition Guidelines</a>
+      </nav>
+      <div id="definition-container" style="display: none"></div>
+      <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
+      <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+      <button id="random-term" aria-label="Show random term" type="button">
+        Random Term
+      </button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
-    <input type="checkbox" id="show-favorites" aria-label="Show favorites">
-    <label for="show-favorites">Show Favorites</label>
+      <button id="dark-mode-toggle" aria-label="Toggle dark mode" type="button">
+        Toggle Dark Mode
+      </button>
+      <input type="checkbox" id="show-favorites" aria-label="Show favorites">
+      <label for="show-favorites">Show Favorites</label>
 
-    <ul id="terms-list"></ul>
-  </main>
-  <footer class="container">
-    <p><a href="templates/contribute.html">Contribute</a></p>
-  </footer>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+      <ul id="terms-list"></ul>
+    </main>
+    <footer class="container" aria-label="Main footer">
+      <p><a href="templates/contribute.html">Contribute</a></p>
+    </footer>
+    <button id="scrollToTopBtn" aria-label="Scroll to top" type="button">↑</button>
 
-  <footer>
-    <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
-  </footer>
-  <script src="script.js"></script>
-  <script src="assets/js/app.js"></script>
-</body>
+    <footer aria-label="Project footer">
+      <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
+    </footer>
+    <script src="script.js"></script>
+    <script src="assets/js/konami.js"></script>
+    <script src="assets/js/app.js"></script>
+  </body>
 </html>
-

--- a/styles.css
+++ b/styles.css
@@ -25,7 +25,7 @@ body {
 
 h1 {
   text-align: center;
-  font-family: 'Cinzel', serif;
+  font-family: "Cinzel", serif;
   font-weight: 700;
   font-size: 48px;
   margin-bottom: 20px;
@@ -110,7 +110,6 @@ body.dark-mode mark {
   box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
   min-height: 44px;
 }
-
 
 /* Controls styling */
 #random-term {
@@ -206,7 +205,9 @@ label {
   border-radius: 4px;
   padding: 10px;
   cursor: pointer;
-  transition: background-color 0.2s, color 0.2s;
+  transition:
+    background-color 0.2s,
+    color 0.2s;
   min-width: 44px;
   min-height: 44px;
 }
@@ -346,4 +347,24 @@ body.dark-mode #alpha-nav button.active {
   #alpha-nav button {
     font-size: 14px;
   }
+}
+
+/* Konami terminal styles */
+.konami-terminal {
+  position: fixed;
+  bottom: 20px;
+  left: 20px;
+  width: 300px;
+  height: 200px;
+  background-color: #000;
+  color: #0f0;
+  font-family: "Courier New", monospace;
+  padding: 10px;
+  border: 2px solid #0f0;
+  overflow-y: auto;
+  z-index: 1000;
+}
+
+.konami-terminal.hidden {
+  display: none;
 }

--- a/tests/konami.test.js
+++ b/tests/konami.test.js
@@ -1,0 +1,26 @@
+const { setupKonamiCode } = require("../assets/js/konami.js");
+
+const sequence = [
+  "ArrowUp",
+  "ArrowUp",
+  "ArrowDown",
+  "ArrowDown",
+  "ArrowLeft",
+  "ArrowRight",
+  "ArrowLeft",
+  "ArrowRight",
+  "b",
+  "a",
+];
+
+let toggled = false;
+const handler = setupKonamiCode(() => {
+  toggled = !toggled;
+  console.log("toggled", toggled);
+});
+
+sequence.forEach((key) => handler({ key }));
+console.log("Activated:", toggled);
+
+sequence.forEach((key) => handler({ key }));
+console.log("Deactivated:", toggled);


### PR DESCRIPTION
## Summary
- Add Konami code listener that toggles a retro-styled terminal displaying random commands
- Include modular JS and CSS for easy removal
- Provide simple Node test harness for sequence activation

## Testing
- `npm test`
- `node tests/konami.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b4d60cefb88328b211c89a54aeb404