### PR TITLE
Add keyboard shortcut overlay with global support

### DIFF
--- a/assets/js/shortcuts.js
+++ b/assets/js/shortcuts.js
@@ -1,0 +1,90 @@
+(function(){
+  let overlay;
+  let lastFocused;
+
+  const shortcuts = [
+    { key: '/', description: 'Focus search' },
+    { key: 'r', description: 'Show random term' },
+    { key: 'f', description: 'Toggle favorites' },
+    { key: 'd', description: 'Toggle dark mode' },
+    { key: '?', description: 'Show this help' }
+  ];
+
+  function buildOverlay(){
+    overlay = document.createElement('div');
+    overlay.id = 'shortcut-overlay';
+    overlay.setAttribute('role', 'dialog');
+    overlay.setAttribute('aria-modal', 'true');
+    overlay.innerHTML = `
+      <div class="overlay-content">
+        <h2 id="shortcut-overlay-title">Keyboard Shortcuts</h2>
+        <ul>
+          ${shortcuts.map(sc => `<li><kbd>${sc.key}</kbd> - ${sc.description}</li>`).join('')}
+        </ul>
+        <button id="close-shortcut-overlay" aria-label="Close">Close</button>
+      </div>`;
+    document.body.appendChild(overlay);
+    overlay.addEventListener('click', e => {
+      if(e.target === overlay) hideOverlay();
+    });
+    document.getElementById('close-shortcut-overlay').addEventListener('click', hideOverlay);
+  }
+
+  function showOverlay(){
+    if(!overlay) buildOverlay();
+    overlay.style.display = 'flex';
+    lastFocused = document.activeElement;
+    document.getElementById('close-shortcut-overlay').focus();
+  }
+
+  function hideOverlay(){
+    if(!overlay) return;
+    overlay.style.display = 'none';
+    if(lastFocused) lastFocused.focus();
+  }
+
+  function isTypingTarget(el){
+    const tag = el.tagName;
+    return tag === 'INPUT' || tag === 'TEXTAREA' || el.isContentEditable;
+  }
+
+  document.addEventListener('keydown', function(e){
+    if(isTypingTarget(e.target)) return;
+
+    const open = overlay && overlay.style.display === 'flex';
+
+    if(e.key === '?' || (e.shiftKey && e.key === '/')){
+      e.preventDefault();
+      showOverlay();
+    } else if(open && e.key === 'Escape'){
+      e.preventDefault();
+      hideOverlay();
+    } else if(!open){
+      if(e.key === '/' && !e.shiftKey){
+        const input = document.getElementById('search') || document.getElementById('search-box');
+        if(input){
+          e.preventDefault();
+          input.focus();
+        }
+      } else if(e.key === 'r'){
+        const btn = document.getElementById('random-term');
+        if(btn){
+          e.preventDefault();
+          btn.click();
+        }
+      } else if(e.key === 'f'){
+        const fav = document.getElementById('show-favorites');
+        if(fav){
+          e.preventDefault();
+          fav.click();
+        }
+      } else if(e.key === 'd'){
+        const dark = document.getElementById('dark-mode-toggle');
+        if(dark){
+          e.preventDefault();
+          dark.click();
+        }
+      }
+    }
+  });
+})();

--- a/index.html
+++ b/index.html
@@ -9,31 +9,34 @@
   <link rel="canonical" id="canonical-link" href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/">
 </head>
 <body>
-  <main class="container">
-    <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
-    <div id="definition-container" style="display: none;"></div>
-    <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
-    <input type="text" id="search" placeholder="Search...">
+    <main class="container">
+      <h1>Cyber Security Dictionary</h1>
+      <nav class="site-nav" aria-label="Primary">
+        <a href="templates/guidelines.html">Definition Guidelines</a>
+      </nav>
+      <div id="definition-container" style="display: none;"></div>
+      <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
+      <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+      <button id="random-term" type="button" aria-label="Show random term">Random Term</button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
-    <input type="checkbox" id="show-favorites" aria-label="Show favorites">
-    <label for="show-favorites">Show Favorites</label>
+      <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+      <input type="checkbox" id="show-favorites" aria-label="Show favorites">
+      <label for="show-favorites">Show Favorites</label>
 
-    <ul id="terms-list"></ul>
-  </main>
-  <footer class="container">
-    <p><a href="templates/contribute.html">Contribute</a></p>
-  </footer>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+      <ul id="terms-list"></ul>
+    </main>
+    <footer class="container" aria-label="Primary footer">
+      <p><a href="templates/contribute.html">Contribute</a></p>
+    </footer>
+    <button id="scrollToTopBtn" type="button" aria-label="Scroll to top">↑</button>
 
-  <footer>
-    <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
-  </footer>
+    <footer aria-label="Project footer">
+      <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
+    </footer>
   <script src="script.js"></script>
   <script src="assets/js/app.js"></script>
+  <script src="assets/js/shortcuts.js"></script>
 </body>
 </html>
 

--- a/layout.html
+++ b/layout.html
@@ -23,16 +23,17 @@
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+      <button id="random-term" type="button" aria-label="Show random term">Random Term</button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+      <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">Toggle Dark Mode</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 
     <ul id="terms-list"></ul>
   </main>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+    <button id="scrollToTopBtn" type="button" aria-label="Scroll to top">↑</button>
 
   <script src="script.js"></script>
+  <script src="assets/js/shortcuts.js"></script>
 </body>
 </html>

--- a/search.html
+++ b/search.html
@@ -9,12 +9,13 @@
 <body>
   <main class="container">
     <h1>Search</h1>
-    <input id="search-box" type="text" placeholder="Search terms..." />
+    <input id="search-box" type="text" placeholder="Search terms...">
     <div id="results"></div>
   </main>
   <script>
     window.__BASE_URL__ = window.__BASE_URL__ || '';
   </script>
   <script src="assets/js/search.js"></script>
+  <script src="assets/js/shortcuts.js"></script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -347,3 +347,35 @@ body.dark-mode #alpha-nav button.active {
     font-size: 14px;
   }
 }
+
+/* Shortcuts overlay */
+#shortcut-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.8);
+  color: #fff;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+#shortcut-overlay .overlay-content {
+  background: #333;
+  padding: 20px;
+  border-radius: 8px;
+  max-width: 90%;
+}
+
+#shortcut-overlay kbd {
+  background: #555;
+  border-radius: 4px;
+  padding: 2px 4px;
+}
+
+body.dark-mode #shortcut-overlay .overlay-content {
+  background: #1e1e1e;
+}

--- a/templates/about.html
+++ b/templates/about.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8" />
+  <meta charset="UTF-8">
   <title>About</title>
 </head>
 <body>
@@ -16,5 +16,6 @@
     <li><a href="https://attack.mitre.org/">MITRE ATT&amp;CK</a></li>
     <li><a href="https://owasp.org/Top10/">OWASP Top 10</a></li>
   </ul>
+  <script src="../assets/js/shortcuts.js"></script>
 </body>
 </html>

--- a/templates/contribute.html
+++ b/templates/contribute.html
@@ -18,5 +18,6 @@
       <li>Open a pull request.</li>
     </ol>
   </main>
+  <script src="../assets/js/shortcuts.js"></script>
 </body>
 </html>

--- a/templates/guidelines.html
+++ b/templates/guidelines.html
@@ -12,5 +12,6 @@
     <p>Each entry in this dictionary should offer an original explanation of a term rather than copying text from other sources.</p>
     <p>Write definitions in your own words and back them with reputable sources. Include citations or links to the materials that informed your description.</p>
   </main>
+  <script src="../assets/js/shortcuts.js"></script>
 </body>
 </html>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -1,26 +1,26 @@
 <!DOCTYPE html>
 <html lang="{{ lang }}">
 <head>
-  <meta charset="utf-8" />
+  <meta charset="utf-8">
   <title>{{ title }}</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <meta property="og:title" content="{{ og_title }}" />
-  <meta property="og:description" content="{{ og_description }}" />
-  <meta property="og:type" content="{{ og_type }}" />
-  <meta property="og:url" content="{{ canonical_url }}" />
-  <meta property="og:image" content="{{ og_image }}" />
+  <meta property="og:title" content="{{ og_title }}">
+  <meta property="og:description" content="{{ og_description }}">
+  <meta property="og:type" content="{{ og_type }}">
+  <meta property="og:url" content="{{ canonical_url }}">
+  <meta property="og:image" content="{{ og_image }}">
 
-  <meta name="twitter:card" content="{{ twitter_card }}" />
-  <meta name="twitter:site" content="{{ twitter_site }}" />
-  <meta name="twitter:title" content="{{ twitter_title }}" />
-  <meta name="twitter:description" content="{{ twitter_description }}" />
-  <meta name="twitter:image" content="{{ twitter_image }}" />
+  <meta name="twitter:card" content="{{ twitter_card }}">
+  <meta name="twitter:site" content="{{ twitter_site }}">
+  <meta name="twitter:title" content="{{ twitter_title }}">
+  <meta name="twitter:description" content="{{ twitter_description }}">
+  <meta name="twitter:image" content="{{ twitter_image }}">
 
-  <link rel="canonical" href="{{ canonical_url }}" />
-  <link rel="manifest" href="{{ manifest_url }}" />
-  <link rel="icon" href="{{ favicon_url }}" />
-  <link rel="stylesheet" href="{{ stylesheet_url }}" />
+  <link rel="canonical" href="{{ canonical_url }}">
+  <link rel="manifest" href="{{ manifest_url }}">
+  <link rel="icon" href="{{ favicon_url }}">
+  <link rel="stylesheet" href="{{ stylesheet_url }}">
 
   <script>
     const BASE_URL = "{{ base_url }}";
@@ -32,20 +32,21 @@
 </head>
 <body>
   <a href="#main" class="skip-link">Skip to content</a>
-  <header role="banner">
-    <nav role="navigation" aria-label="Primary">
+  <header>
+    <nav aria-label="Primary">
       {{ navigation }}
     </nav>
   </header>
-  <main id="main" role="main">
+  <main id="main">
     {{ content }}
   </main>
-  <footer role="contentinfo">
+  <footer>
     <ul>
       <li><a href="{{ privacy_url }}">{{ privacy_label }}</a></li>
       <li><a href="{{ contact_url }}">{{ contact_label }}</a></li>
     </ul>
   </footer>
+  <script src="{{ base_url }}/assets/js/shortcuts.js"></script>
   <script src="{{ base_url }}/assets/js/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add `?` keyboard shortcut overlay listing site shortcuts
- wire shortcuts script on all pages and improve button/accessibility markup
- style overlay for light and dark modes

## Testing
- `npm test`
- `npx html-validate search.html templates/about.html templates/contribute.html templates/guidelines.html layout.html templates/layout.html`
- `npx -y pa11y index.html` *(fails: libXcomposite.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b4d60b683c8328a375445d78546ebc