### PR TITLE
Add generated topic pages from clusters with navigation links

### DIFF
--- a/clusters.json
+++ b/clusters.json
@@ -1,0 +1,54 @@
+{
+  "clusters": [
+    {
+      "title": "Attack Techniques",
+      "summary": "Common methods used by adversaries to compromise systems and data.",
+      "terms": [
+        "Phishing",
+        "Phishing Email",
+        "Social Engineering Toolkit (SET)",
+        "Social Engineering Attack Vectors",
+        "Advanced Persistent Threat (APT)",
+        "Cyber Espionage",
+        "Malvertising",
+        "Cross-Site Scripting (XSS)",
+        "Cross-Site Request Forgery (CSRF)",
+        "Privilege Escalation",
+        "Zero-Day Vulnerability"
+      ]
+    },
+    {
+      "title": "Cryptography & Encryption",
+      "summary": "Techniques and standards for protecting information through encoding and key management.",
+      "terms": [
+        "Cryptography",
+        "Zero-Knowledge Proof",
+        "Data Encryption Standard (DES)",
+        "Advanced Encryption Standard (AES)",
+        "Public Key Infrastructure (PKI)",
+        "Certificate Authority (CA)",
+        "Secure Sockets Layer (SSL)",
+        "Transport Layer Security (TLS)",
+        "Key Exchange",
+        "Security Token"
+      ]
+    },
+    {
+      "title": "Defense & Operations",
+      "summary": "Practices and tools used to monitor, protect, and respond to security threats.",
+      "terms": [
+        "Security Operations Center (SOC)",
+        "Data Loss Prevention (DLP)",
+        "Endpoint Security",
+        "Threat Hunting",
+        "Incident Response",
+        "Security Assessment",
+        "Network Security",
+        "Security Patch",
+        "Identity Theft",
+        "Eavesdropping",
+        "Payload"
+      ]
+    }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -11,25 +11,25 @@
 <body>
   <main class="container">
     <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
+    <nav class="site-nav" aria-label="Site navigation"><a href="templates/guidelines.html">Definition Guidelines</a> <a href="topics/attack-techniques.html">Attack Techniques</a> <a href="topics/cryptography-encryption.html">Cryptography &amp; Encryption</a> <a href="topics/defense-operations.html">Defense &amp; Operations</a></nav>
     <div id="definition-container" style="display: none;"></div>
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+    <button id="random-term" type="button" aria-label="Show random term">Random Term</button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+    <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">Toggle Dark Mode</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 
     <ul id="terms-list"></ul>
   </main>
-  <footer class="container">
+  <footer class="container" aria-label="Contribution link">
     <p><a href="templates/contribute.html">Contribute</a></p>
   </footer>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+  <button id="scrollToTopBtn" type="button" aria-label="Scroll to top">↑</button>
 
-  <footer>
+  <footer aria-label="Project information">
     <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
   </footer>
   <script src="script.js"></script>

--- a/scripts/generate-topics.js
+++ b/scripts/generate-topics.js
@@ -1,0 +1,47 @@
+const fs = require('fs');
+const path = require('path');
+
+const clustersPath = path.join(__dirname, '..', 'clusters.json');
+const templatePath = path.join(__dirname, '..', 'templates', 'topic.html');
+const outputDir = path.join(__dirname, '..', 'topics');
+
+const data = JSON.parse(fs.readFileSync(clustersPath, 'utf8'));
+const template = fs.readFileSync(templatePath, 'utf8');
+
+function slugify(term) {
+  return term
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function escapeHtml(str) {
+  return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+const clusters = data.clusters || [];
+fs.mkdirSync(outputDir, { recursive: true });
+
+const navLinks = [
+  '<a href="../index.html">Home</a>',
+  '<a href="../templates/guidelines.html">Definition Guidelines</a>',
+  ...clusters.map(c => `<a href="${slugify(c.title)}.html">${escapeHtml(c.title)}</a>`)
+].join(' ');
+
+clusters.forEach(cluster => {
+  const termsList = cluster.terms
+    .map(term => {
+      const url = `../index.html#${encodeURIComponent(term)}`;
+      return `<li><a href="${url}">${escapeHtml(term)}</a></li>`;
+    })
+    .join('\n    ');
+
+  const content = template
+    .replace(/{{title}}/g, escapeHtml(cluster.title))
+    .replace('{{summary}}', escapeHtml(cluster.summary))
+    .replace('{{terms}}', termsList)
+    .replace('{{nav}}', navLinks);
+
+  const fileName = `${slugify(cluster.title)}.html`;
+  fs.writeFileSync(path.join(outputDir, fileName), content);
+});

--- a/templates/topic.html
+++ b/templates/topic.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>{{title}}</title>
+</head>
+<body>
+  <nav class="site-nav">{{nav}}</nav>
+  <h1>{{title}}</h1>
+  <p>{{summary}}</p>
+  <ul>
+    {{terms}}
+  </ul>
+</body>
+</html>

--- a/topics/attack-techniques.html
+++ b/topics/attack-techniques.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Attack Techniques</title>
+</head>
+<body>
+  <nav class="site-nav"><a href="../index.html">Home</a> <a href="../templates/guidelines.html">Definition Guidelines</a> <a href="attack-techniques.html">Attack Techniques</a> <a href="cryptography-encryption.html">Cryptography &amp; Encryption</a> <a href="defense-operations.html">Defense &amp; Operations</a></nav>
+  <h1>Attack Techniques</h1>
+  <p>Common methods used by adversaries to compromise systems and data.</p>
+  <ul>
+    <li><a href="../index.html#Phishing">Phishing</a></li>
+    <li><a href="../index.html#Phishing%20Email">Phishing Email</a></li>
+    <li><a href="../index.html#Social%20Engineering%20Toolkit%20(SET)">Social Engineering Toolkit (SET)</a></li>
+    <li><a href="../index.html#Social%20Engineering%20Attack%20Vectors">Social Engineering Attack Vectors</a></li>
+    <li><a href="../index.html#Advanced%20Persistent%20Threat%20(APT)">Advanced Persistent Threat (APT)</a></li>
+    <li><a href="../index.html#Cyber%20Espionage">Cyber Espionage</a></li>
+    <li><a href="../index.html#Malvertising">Malvertising</a></li>
+    <li><a href="../index.html#Cross-Site%20Scripting%20(XSS)">Cross-Site Scripting (XSS)</a></li>
+    <li><a href="../index.html#Cross-Site%20Request%20Forgery%20(CSRF)">Cross-Site Request Forgery (CSRF)</a></li>
+    <li><a href="../index.html#Privilege%20Escalation">Privilege Escalation</a></li>
+    <li><a href="../index.html#Zero-Day%20Vulnerability">Zero-Day Vulnerability</a></li>
+  </ul>
+</body>
+</html>

--- a/topics/cryptography-encryption.html
+++ b/topics/cryptography-encryption.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Cryptography &amp; Encryption</title>
+</head>
+<body>
+  <nav class="site-nav"><a href="../index.html">Home</a> <a href="../templates/guidelines.html">Definition Guidelines</a> <a href="attack-techniques.html">Attack Techniques</a> <a href="cryptography-encryption.html">Cryptography &amp; Encryption</a> <a href="defense-operations.html">Defense &amp; Operations</a></nav>
+  <h1>Cryptography &amp; Encryption</h1>
+  <p>Techniques and standards for protecting information through encoding and key management.</p>
+  <ul>
+    <li><a href="../index.html#Cryptography">Cryptography</a></li>
+    <li><a href="../index.html#Zero-Knowledge%20Proof">Zero-Knowledge Proof</a></li>
+    <li><a href="../index.html#Data%20Encryption%20Standard%20(DES)">Data Encryption Standard (DES)</a></li>
+    <li><a href="../index.html#Advanced%20Encryption%20Standard%20(AES)">Advanced Encryption Standard (AES)</a></li>
+    <li><a href="../index.html#Public%20Key%20Infrastructure%20(PKI)">Public Key Infrastructure (PKI)</a></li>
+    <li><a href="../index.html#Certificate%20Authority%20(CA)">Certificate Authority (CA)</a></li>
+    <li><a href="../index.html#Secure%20Sockets%20Layer%20(SSL)">Secure Sockets Layer (SSL)</a></li>
+    <li><a href="../index.html#Transport%20Layer%20Security%20(TLS)">Transport Layer Security (TLS)</a></li>
+    <li><a href="../index.html#Key%20Exchange">Key Exchange</a></li>
+    <li><a href="../index.html#Security%20Token">Security Token</a></li>
+  </ul>
+</body>
+</html>

--- a/topics/defense-operations.html
+++ b/topics/defense-operations.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Defense &amp; Operations</title>
+</head>
+<body>
+  <nav class="site-nav"><a href="../index.html">Home</a> <a href="../templates/guidelines.html">Definition Guidelines</a> <a href="attack-techniques.html">Attack Techniques</a> <a href="cryptography-encryption.html">Cryptography &amp; Encryption</a> <a href="defense-operations.html">Defense &amp; Operations</a></nav>
+  <h1>Defense &amp; Operations</h1>
+  <p>Practices and tools used to monitor, protect, and respond to security threats.</p>
+  <ul>
+    <li><a href="../index.html#Security%20Operations%20Center%20(SOC)">Security Operations Center (SOC)</a></li>
+    <li><a href="../index.html#Data%20Loss%20Prevention%20(DLP)">Data Loss Prevention (DLP)</a></li>
+    <li><a href="../index.html#Endpoint%20Security">Endpoint Security</a></li>
+    <li><a href="../index.html#Threat%20Hunting">Threat Hunting</a></li>
+    <li><a href="../index.html#Incident%20Response">Incident Response</a></li>
+    <li><a href="../index.html#Security%20Assessment">Security Assessment</a></li>
+    <li><a href="../index.html#Network%20Security">Network Security</a></li>
+    <li><a href="../index.html#Security%20Patch">Security Patch</a></li>
+    <li><a href="../index.html#Identity%20Theft">Identity Theft</a></li>
+    <li><a href="../index.html#Eavesdropping">Eavesdropping</a></li>
+    <li><a href="../index.html#Payload">Payload</a></li>
+  </ul>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `clusters.json` with Attack Techniques, Cryptography & Encryption, and Defense & Operations term groups
- generate topic pages from a new template via `scripts/generate-topics.js`
- link new topic pages in the site's navigation and improve accessibility

## Testing
- `npx html-validate index.html topics/*.html`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4d637814483289992c8be5519363d