### PR TITLE
Add graph exports and data downloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+*.class
+gephi-toolkit.jar

--- a/data/graph.csv
+++ b/data/graph.csv
@@ -1,0 +1,3 @@
+source,target
+phishing,malware
+malware,ransomware

--- a/data/graph.graphml
+++ b/data/graph.graphml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<graphml xmlns="http://graphml.graphdrawing.org/xmlns">
+  <graph id="G" edgedefault="directed">
+    <node id="phishing"/>
+    <node id="malware"/>
+    <node id="ransomware"/>
+    <edge id="e0" source="phishing" target="malware"/>
+    <edge id="e1" source="malware" target="ransomware"/>
+  </graph>
+</graphml>

--- a/graph.json
+++ b/graph.json
@@ -1,0 +1,11 @@
+{
+  "nodes": [
+    {"id": "phishing", "label": "Phishing"},
+    {"id": "malware", "label": "Malware"},
+    {"id": "ransomware", "label": "Ransomware"}
+  ],
+  "edges": [
+    {"source": "phishing", "target": "malware"},
+    {"source": "malware", "target": "ransomware"}
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -11,25 +11,25 @@
 <body>
   <main class="container">
     <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
+    <nav class="site-nav" aria-label="Site navigation"><a href="templates/guidelines.html">Definition Guidelines</a> | <a href="templates/data.html">Data</a></nav>
     <div id="definition-container" style="display: none;"></div>
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+    <button id="random-term" type="button" aria-label="Show random term">Random Term</button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+    <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">Toggle Dark Mode</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 
     <ul id="terms-list"></ul>
   </main>
-  <footer class="container">
+    <footer class="container" aria-label="Page footer">
     <p><a href="templates/contribute.html">Contribute</a></p>
   </footer>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+    <button id="scrollToTopBtn" type="button" aria-label="Scroll to top">↑</button>
 
-  <footer>
+    <footer aria-label="Project footer">
     <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
   </footer>
   <script src="script.js"></script>

--- a/scripts/convert-graph.js
+++ b/scripts/convert-graph.js
@@ -1,0 +1,29 @@
+const fs = require('fs');
+const path = require('path');
+
+const graphPath = path.join(__dirname, '..', 'graph.json');
+const outDir = path.join(__dirname, '..', 'data');
+
+const graph = JSON.parse(fs.readFileSync(graphPath, 'utf8'));
+
+// Write CSV
+const csvLines = ['source,target'];
+for (const edge of graph.edges) {
+  csvLines.push(`${edge.source},${edge.target}`);
+}
+fs.writeFileSync(path.join(outDir, 'graph.csv'), csvLines.join('\n'), 'utf8');
+
+// Write GraphML
+let graphml = '<?xml version="1.0" encoding="UTF-8"?>\n';
+graphml += '<graphml xmlns="http://graphml.graphdrawing.org/xmlns">\n';
+graphml += '  <graph id="G" edgedefault="directed">\n';
+for (const node of graph.nodes) {
+  graphml += `    <node id="${node.id}"/>\n`;
+}
+graph.edges.forEach((edge, idx) => {
+  graphml += `    <edge id="e${idx}" source="${edge.source}" target="${edge.target}"/>\n`;
+});
+graphml += '  </graph>\n';
+graphml += '</graphml>\n';
+
+fs.writeFileSync(path.join(outDir, 'graph.graphml'), graphml, 'utf8');

--- a/templates/data.html
+++ b/templates/data.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Data Downloads</title>
+  <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+  <main class="container">
+    <h1>Data Downloads</h1>
+    <ul>
+      <li><a href="../data/graph.csv" download>Graph Edges (CSV)</a></li>
+      <li><a href="../data/graph.graphml" download>Graph (GraphML)</a></li>
+    </ul>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- convert `graph.json` into edge lists in CSV and GraphML formats
- add a Data page linking to downloadable graph files
- update home page navigation and accessibility

## Testing
- `java -cp gephi-toolkit.jar:scripts ValidateGraph data/graph.graphml`
- `npm test`
- `npx html-validate templates/data.html`


------
https://chatgpt.com/codex/tasks/task_e_68b4d63805588328a66333e04524850e