### PR TITLE
feat: add term selection lookup

### DIFF
--- a/assets/js/selection.js
+++ b/assets/js/selection.js
@@ -1,0 +1,72 @@
+(function () {
+  const THRESHOLD = 150; // milliseconds
+  let graph = {};
+  let featureEnabled = false;
+
+  const infoBox = document.createElement('div');
+  infoBox.id = 'selection-info';
+  Object.assign(infoBox.style, {
+    position: 'absolute',
+    display: 'none',
+    background: '#fff',
+    color: '#000',
+    border: '1px solid #ccc',
+    padding: '8px',
+    maxWidth: '300px',
+    boxShadow: '0 2px 6px rgba(0,0,0,0.2)',
+    zIndex: 1000,
+  });
+  document.body.appendChild(infoBox);
+
+  const loadStart = performance.now();
+  fetch('graph.json')
+    .then((resp) => resp.json())
+    .then((data) => {
+      const loadTime = performance.now() - loadStart;
+      if (loadTime < THRESHOLD) {
+        Object.keys(data).forEach((k) => {
+          graph[k.toLowerCase()] = { term: k, ...data[k] };
+        });
+        featureEnabled = true;
+        document.addEventListener('mouseup', handleSelection);
+      } else {
+        console.warn(`graph.json took ${loadTime}ms to load; selection feature disabled`);
+      }
+    })
+    .catch((err) => console.error('Failed to load graph.json', err));
+
+  function handleSelection(evt) {
+    if (!featureEnabled) return;
+    const selected = window.getSelection().toString().trim().toLowerCase();
+    const entry = graph[selected];
+    if (!selected || !entry) {
+      infoBox.style.display = 'none';
+      return;
+    }
+
+    const lookupStart = performance.now();
+    let html = `<strong>${entry.term}</strong><p>${entry.definition}</p>`;
+    if (entry.related && entry.related.length) {
+      const relLinks = entry.related
+        .map((r) => `<a href="#${encodeURIComponent(r)}">${r}</a>`)
+        .join(', ');
+      html += `<p><em>Related:</em> ${relLinks}</p>`;
+    }
+    if (entry.links && entry.links.length) {
+      const navLinks = entry.links
+        .map((l) => `<a href="${l}">${l}</a>`)
+        .join(', ');
+      html += `<p><em>Links:</em> ${navLinks}</p>`;
+    }
+    const lookupTime = performance.now() - lookupStart;
+    if (lookupTime < THRESHOLD) {
+      infoBox.innerHTML = html;
+      infoBox.style.left = evt.pageX + 10 + 'px';
+      infoBox.style.top = evt.pageY + 10 + 'px';
+      infoBox.style.display = 'block';
+    } else {
+      infoBox.style.display = 'none';
+      console.warn(`Lookup/display exceeded ${THRESHOLD}ms; skipping.`);
+    }
+  }
+})();

--- a/graph.json
+++ b/graph.json
@@ -1,0 +1,12 @@
+{
+  "Phishing": {
+    "definition": "An attempt to trick individuals into revealing sensitive information through fraudulent communication.",
+    "related": ["Phishing Email", "Social Engineering Toolkit (SET)"],
+    "links": ["#Phishing%20Email", "#Social%20Engineering%20Toolkit%20(SET)"]
+  },
+  "Advanced Persistent Threat (APT)": {
+    "definition": "A prolonged and targeted cyber attack in which attackers gain and maintain unauthorized access to a network.",
+    "related": ["Cyber Espionage"],
+    "links": ["#Cyber%20Espionage"]
+  }
+}

--- a/index.html
+++ b/index.html
@@ -11,29 +11,30 @@
 <body>
   <main class="container">
     <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
+      <nav class="site-nav" aria-label="Site navigation"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
     <div id="definition-container" style="display: none;"></div>
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+      <button id="random-term" aria-label="Show random term" type="button">Random Term</button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+      <button id="dark-mode-toggle" aria-label="Toggle dark mode" type="button">Toggle Dark Mode</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 
     <ul id="terms-list"></ul>
   </main>
-  <footer class="container">
+    <footer class="container" aria-label="Contribution links">
     <p><a href="templates/contribute.html">Contribute</a></p>
   </footer>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+    <button id="scrollToTopBtn" aria-label="Scroll to top" type="button">↑</button>
 
-  <footer>
+    <footer aria-label="Project contribution">
     <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
   </footer>
   <script src="script.js"></script>
   <script src="assets/js/app.js"></script>
+  <script src="assets/js/selection.js"></script>
 </body>
 </html>
 

--- a/layout.html
+++ b/layout.html
@@ -23,16 +23,17 @@
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+      <button id="random-term" aria-label="Show random term" type="button">Random Term</button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+      <button id="dark-mode-toggle" aria-label="Toggle dark mode" type="button">Toggle Dark Mode</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 
     <ul id="terms-list"></ul>
   </main>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+    <button id="scrollToTopBtn" aria-label="Scroll to top" type="button">↑</button>
 
   <script src="script.js"></script>
+  <script src="assets/js/selection.js"></script>
 </body>
 </html>

--- a/search.html
+++ b/search.html
@@ -16,5 +16,6 @@
     window.__BASE_URL__ = window.__BASE_URL__ || '';
   </script>
   <script src="assets/js/search.js"></script>
+  <script src="assets/js/selection.js"></script>
 </body>
 </html>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -47,5 +47,6 @@
     </ul>
   </footer>
   <script src="{{ base_url }}/assets/js/app.js"></script>
+  <script src="{{ base_url }}/assets/js/selection.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add client-side selection component gated by a 150ms performance check
- display definitions, related terms, and navigation links from graph.json
- wire selection lookup into site templates and pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4d63892c08328b4eef7533019807a