### PR TITLE
Add content calendar page with monthly planning data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/calendar.json
+++ b/calendar.json
@@ -1,0 +1,58 @@
+{
+  "months": [
+    {
+      "year": 2025,
+      "month": 9,
+      "milestone": "Finalize threat taxonomy and prepare initial content batches.",
+      "batches": [
+        {
+          "name": "Batch 1",
+          "terms": [
+            "Malvertising",
+            "Phishing",
+            "Zero-Day Vulnerability"
+          ]
+        },
+        {
+          "name": "Batch 2",
+          "terms": [
+            "Security Operations Center (SOC)",
+            "Incident Response",
+            "Threat Hunting"
+          ]
+        },
+        {
+          "name": "Batch 3",
+          "terms": [
+            "Data Loss Prevention (DLP)",
+            "Endpoint Security",
+            "Network Security"
+          ]
+        }
+      ]
+    },
+    {
+      "year": 2025,
+      "month": 10,
+      "milestone": "Expand cryptography coverage and introduce advanced concepts.",
+      "batches": [
+        {
+          "name": "Batch 1",
+          "terms": [
+            "Advanced Encryption Standard (AES)",
+            "Public Key Infrastructure (PKI)",
+            "Certificate Authority (CA)"
+          ]
+        },
+        {
+          "name": "Batch 2",
+          "terms": [
+            "Transport Layer Security (TLS)",
+            "Key Exchange",
+            "Zero-Knowledge Proof"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -11,25 +11,25 @@
 <body>
   <main class="container">
     <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
+    <nav class="site-nav" aria-label="Site navigation"><a href="templates/guidelines.html">Definition Guidelines</a> | <a href="templates/calendar.html">Calendar</a></nav>
     <div id="definition-container" style="display: none;"></div>
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+    <button id="random-term" type="button" aria-label="Show random term">Random Term</button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+    <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">Toggle Dark Mode</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 
     <ul id="terms-list"></ul>
   </main>
-  <footer class="container">
+  <footer class="container" aria-label="Contribution navigation">
     <p><a href="templates/contribute.html">Contribute</a></p>
   </footer>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+  <button id="scrollToTopBtn" type="button" aria-label="Scroll to top">↑</button>
 
-  <footer>
+  <footer aria-label="Project information">
     <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
   </footer>
   <script src="script.js"></script>

--- a/templates/calendar.html
+++ b/templates/calendar.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Content Calendar</title>
+  <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+  <main class="container">
+    <h1>Content Calendar</h1>
+    <section id="upcoming"></section>
+    <section id="all-months"></section>
+  </main>
+  <script>
+  fetch('../calendar.json')
+    .then(resp => resp.json())
+    .then(data => {
+      const today = new Date();
+      const nextMonth = new Date(today.getFullYear(), today.getMonth() + 1, 1);
+      const upcoming = data.months.find(m => m.year === nextMonth.getFullYear() && m.month === (nextMonth.getMonth() + 1));
+      const upcomingSection = document.getElementById('upcoming');
+      if (upcoming) {
+        const heading = document.createElement('h2');
+        heading.textContent = `Upcoming Month: ${new Date(upcoming.year, upcoming.month - 1).toLocaleString('default', { month: 'long', year: 'numeric' })}`;
+        upcomingSection.appendChild(heading);
+        const milestone = document.createElement('p');
+        milestone.textContent = upcoming.milestone;
+        upcomingSection.appendChild(milestone);
+        const list = document.createElement('ol');
+        upcoming.batches.forEach(batch => {
+          const li = document.createElement('li');
+          li.innerHTML = `<strong>${batch.name}</strong>: ${batch.terms.join(', ')}`;
+          list.appendChild(li);
+        });
+        upcomingSection.appendChild(list);
+      }
+      const allSection = document.getElementById('all-months');
+      data.months.forEach(m => {
+        const monthDiv = document.createElement('section');
+        const h3 = document.createElement('h3');
+        h3.textContent = new Date(m.year, m.month - 1).toLocaleString('default', { month: 'long', year: 'numeric' });
+        monthDiv.appendChild(h3);
+        const p = document.createElement('p');
+        p.textContent = m.milestone;
+        monthDiv.appendChild(p);
+        const ol = document.createElement('ol');
+        m.batches.forEach(batch => {
+          const li = document.createElement('li');
+          li.innerHTML = `<strong>${batch.name}</strong>: ${batch.terms.join(', ')}`;
+          ol.appendChild(li);
+        });
+        monthDiv.appendChild(ol);
+        allSection.appendChild(monthDiv);
+      });
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `calendar.json` with monthly milestones and term batches
- build `calendar.html` page that highlights the upcoming month's focus and lists all planned batches
- link calendar page from site navigation

## Testing
- `npx html-validate index.html templates/calendar.html`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4d6399be883289e3281404e25d99c