### PR TITLE
Add reviewer assignment workflow

### DIFF
--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -1,0 +1,34 @@
+name: Assign Reviewers
+
+on:
+  pull_request:
+    types: [opened, labeled]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign-reviewers:
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: Assign reviewers based on label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labelReviewers = {
+              'domain:security': ['octocat'],
+              'domain:docs': ['octocat']
+            };
+            const fallbackReviewers = ['octocat'];
+
+            const labels = context.payload.pull_request.labels.map(l => l.name);
+            let reviewers = labels.flatMap(label => labelReviewers[label] || []);
+            if (reviewers.length === 0) reviewers = fallbackReviewers;
+
+            await github.pulls.requestReviewers({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              reviewers
+            });


### PR DESCRIPTION
## Summary
- Automatically assign pull-request reviewers based on domain labels with a 1 minute timeout

## Testing
- `npm install`
- `npm test` *(fails: Landmarks must have a non-empty and unique accessible name)*
- `node - <<'NODE' ...`

------
https://chatgpt.com/codex/tasks/task_e_68b4d63ab0308328813f0e40ddcd03cc