### PR TITLE
Add terms metadata lint and document requirement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,8 @@ Thank you for taking the time to contribute to the Cyber Security Dictionary!
    - Use the ["New term" issue template](.github/ISSUE_TEMPLATE/new-term.yml).
    - Include the term, a clear definition, and optional sources.
 2. **Submit a pull request**
-   - Fork the repository and update `data.json` with your term.
+   - Fork the repository and update `data/terms.yaml` with your term.
+   - Include at least one `sources` entry and an `access_date` (`YYYY-MM-DD`) for the term.
    - Reference the issue in your pull request.
    - Ensure any related documentation is updated.
 

--- a/data/terms.yaml
+++ b/data/terms.yaml
@@ -12,6 +12,7 @@
     - NVD
   sources:
     - https://cve.mitre.org
+  access_date: "2024-06-07"
 - name: CWE
   slug: cwe
   definition: >-
@@ -24,6 +25,7 @@
     - OWASP Top 10
   sources:
     - https://cwe.mitre.org
+  access_date: "2024-06-07"
 - name: CVSS
   slug: cvss
   definition: >-
@@ -36,6 +38,7 @@
     - NVD
   sources:
     - https://www.first.org/cvss/
+  access_date: "2024-06-07"
 - name: NVD
   slug: nvd
   definition: >-
@@ -48,6 +51,7 @@
     - CVSS
   sources:
     - https://nvd.nist.gov/
+  access_date: "2024-06-07"
 - name: MITRE ATT&CK
   slug: mitre-attack
   definition: >-
@@ -61,6 +65,7 @@
     - CWE
   sources:
     - https://attack.mitre.org/
+  access_date: "2024-06-07"
 - name: OWASP Top 10
   slug: owasp-top-10
   definition: >-
@@ -73,3 +78,4 @@
     - CWE
   sources:
     - https://owasp.org/www-project-top-ten/
+  access_date: "2024-06-07"

--- a/index.html
+++ b/index.html
@@ -11,25 +11,25 @@
 <body>
   <main class="container">
     <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
+    <nav class="site-nav" aria-label="Definition guidelines"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
     <div id="definition-container" style="display: none;"></div>
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+    <button id="random-term" aria-label="Show random term" type="button">Random Term</button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+    <button id="dark-mode-toggle" aria-label="Toggle dark mode" type="button">Toggle Dark Mode</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 
     <ul id="terms-list"></ul>
   </main>
-  <footer class="container">
+  <footer class="container" aria-label="Primary footer">
     <p><a href="templates/contribute.html">Contribute</a></p>
   </footer>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+  <button id="scrollToTopBtn" aria-label="Scroll to top" type="button">↑</button>
 
-  <footer>
+  <footer aria-label="Secondary footer">
     <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
   </footer>
   <script src="script.js"></script>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "script.js",
   "scripts": {
     "build": "node scripts/build.js",
-    "test": "html-validate index.html",
+    "lint:terms": "node scripts/lint-terms.js",
+    "test": "npm run lint:terms && html-validate index.html",
     "watch": "chokidar \"**/*.html\" -c \"npm run build\""
   },
   "keywords": [],

--- a/scripts/lint-terms.js
+++ b/scripts/lint-terms.js
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const yaml = require('js-yaml');
+
+const filePath = 'data/terms.yaml';
+const content = fs.readFileSync(filePath, 'utf8');
+const data = yaml.load(content);
+const lines = content.split(/\r?\n/);
+const errors = [];
+
+function findLine(term) {
+  const slugLine = lines.findIndex(l => l.includes(`slug: ${term.slug}`));
+  if (slugLine !== -1) {
+    return slugLine + 1;
+  }
+  const nameLine = lines.findIndex(l => l.includes(`name: ${term.name}`));
+  return nameLine !== -1 ? nameLine + 1 : '?';
+}
+
+data.forEach(term => {
+  const line = findLine(term);
+  if (!term.sources || term.sources.length === 0) {
+    errors.push(`${filePath}:${line} missing 'sources'`);
+  }
+  if (!term.access_date || typeof term.access_date !== 'string' || !/\d{4}-\d{2}-\d{2}/.test(term.access_date)) {
+    errors.push(`${filePath}:${line} missing or invalid 'access_date'`);
+  }
+});
+
+if (errors.length) {
+  console.error(errors.join('\n'));
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add `lint:terms` script to enforce `sources` and `access_date` for each term
- document required fields for new terms in CONTRIBUTING
- fix index.html accessibility issues for passing validation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4d63ba1808328bc03874a63ec450b