### PR TITLE
Add readability grade CLI and CI comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,30 @@ jobs:
         uses: lycheeverse/lychee-action@v2
         with:
           args: --no-cache terms.json
+      - name: Install Python dependencies
+        run: pip install textstat
+      - name: Readability
+        run: python scripts/readability.py > grade-report.txt
+      - name: Comment readability
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const report = fs.readFileSync('grade-report.txt', 'utf8');
+            const match = report.match(/Average grade level: ([0-9.]+)/);
+            const avg = match ? match[1] : 'N/A';
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: [
+                '📘 **Readability Report**',
+                '',
+                `Average grade level: ${avg}`,
+                '',
+                '```',
+                report,
+                '```'
+              ].join('\n')
+            });

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+grade-report.txt

--- a/scripts/readability.py
+++ b/scripts/readability.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+import json
+import re
+import sys
+from textstat import textstat
+
+THRESHOLD = float(sys.argv[1]) if len(sys.argv) > 1 else 12
+
+def split_sentences(text):
+    # Simple sentence splitter on punctuation followed by space
+    return [s.strip() for s in re.split(r'(?<=[.!?]) +', text.strip()) if s]
+
+with open('terms.json', 'r') as f:
+    terms = json.load(f)["terms"]
+
+flagged = []
+grades = []
+for term in terms:
+    definition = term.get("definition", "")
+    grade = textstat.flesch_kincaid_grade(definition)
+    if grade >= 0:
+        grades.append(grade)
+    for sentence in split_sentences(definition):
+        s_grade = textstat.flesch_kincaid_grade(sentence)
+        if s_grade > THRESHOLD:
+            flagged.append((term["term"], sentence, s_grade))
+
+average = sum(grades) / len(grades) if grades else 0
+print(f"Average grade level: {average:.2f}")
+if flagged:
+    print(f"Sentences above grade level {THRESHOLD}:")
+    for term, sentence, score in flagged:
+        print(f"- [{term}] {sentence} (grade {score:.2f})")
+else:
+    print(f"All sentences are at or below grade level {THRESHOLD}.")


### PR DESCRIPTION
## Summary
- add Python CLI to compute Flesch–Kincaid grade level for dictionary definitions and flag complex sentences
- run readability script in CI and comment average grade level on pull requests
- ignore temporary artifacts and dependencies in version control

## Testing
- `npm test` (fails: unique-landmark, no-implicit-button-type)
- `python scripts/readability.py`

------
https://chatgpt.com/codex/tasks/task_e_68b4d63c6068832886fc70d95815e74f