### PR TITLE
Add post-merge hook to auto-update changelog

### DIFF
--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+function run(cmd) {
+  return execSync(cmd, { encoding: 'utf8' }).trim();
+}
+
+function getTerms(ref) {
+  try {
+    const content = run(`git show ${ref}:terms.json`);
+    const json = JSON.parse(content);
+    return json.terms.map(t => t.term);
+  } catch (e) {
+    return [];
+  }
+}
+
+function slugify(term) {
+  return term
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+const date = run('git log -1 --date=short --pretty=%ad');
+const author = run('git log -1 --pretty=%an');
+const summary = run('git log -1 --pretty=%s');
+
+const headTerms = new Set(getTerms('HEAD'));
+const parentTerms = new Set(getTerms('HEAD^'));
+const newTerms = [...headTerms].filter(t => !parentTerms.has(t));
+
+const termLinks = newTerms.map(t => `[${t}](terms/${slugify(t)}.html)`).join(', ');
+const entry = `- ${date} | ${author} | ${summary}${termLinks ? ' | ' + termLinks : ''}\n`;
+
+const changelogPath = path.join(__dirname, '..', 'CHANGELOG.md');
+fs.appendFileSync(changelogPath, entry);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+


### PR DESCRIPTION
## Summary
- add a `CHANGELOG.md` placeholder
- add a post-merge hook that appends merge summaries with added term links, author and date

## Testing
- `npm install`
- `npm test` *(fails: unique-landmark and no-implicit-button-type errors in index.html)*
- merged a sample term change to confirm changelog entry is appended

------
https://chatgpt.com/codex/tasks/task_e_68b4d63ddfb88328b004602d7de407af