### PR TITLE
Add CI image size checker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,14 @@ jobs:
         uses: lycheeverse/lychee-action@v2
         with:
           args: --no-cache terms.json
+      - name: Check images
+        run: node scripts/check-images.mjs
+        env:
+          MAX_IMAGE_SIZE_KB: 100
+          IMAGE_THRESHOLD: 0
+      - name: Upload image report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: image-report
+          path: image-report.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+image-report.txt

--- a/index.html
+++ b/index.html
@@ -11,25 +11,25 @@
 <body>
   <main class="container">
     <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
+    <nav class="site-nav" aria-label="Definition guidelines navigation"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
     <div id="definition-container" style="display: none;"></div>
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+    <button id="random-term" type="button" aria-label="Show random term">Random Term</button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+    <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">Toggle Dark Mode</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 
     <ul id="terms-list"></ul>
   </main>
-  <footer class="container">
+  <footer class="container" aria-label="Site footer">
     <p><a href="templates/contribute.html">Contribute</a></p>
   </footer>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+  <button id="scrollToTopBtn" type="button" aria-label="Scroll to top">↑</button>
 
-  <footer>
+  <footer aria-label="Project footer">
     <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
   </footer>
   <script src="script.js"></script>

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "node scripts/build.js",
     "test": "html-validate index.html",
-    "watch": "chokidar \"**/*.html\" -c \"npm run build\""
+    "watch": "chokidar \"**/*.html\" -c \"npm run build\"",
+    "check-images": "node scripts/check-images.mjs"
   },
   "keywords": [],
   "author": "",

--- a/scripts/check-images.mjs
+++ b/scripts/check-images.mjs
@@ -1,0 +1,68 @@
+import fs from 'fs';
+import path from 'path';
+
+const rootDir = process.argv[2] || '.';
+const maxSizeKB = parseInt(process.env.MAX_IMAGE_SIZE_KB || '100', 10);
+const threshold = parseInt(process.env.IMAGE_THRESHOLD || '0', 10);
+
+const htmlFiles = [];
+function walk(dir) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (['node_modules', '.git'].includes(entry.name)) continue;
+      walk(path.join(dir, entry.name));
+    } else if (entry.name.endsWith('.html')) {
+      htmlFiles.push(path.join(dir, entry.name));
+    }
+  }
+}
+walk(rootDir);
+
+const missing = [];
+const oversized = [];
+
+for (const file of htmlFiles) {
+  const html = fs.readFileSync(file, 'utf8');
+  const regex = /<img[^>]+src=["']([^"']+)["']/gi;
+  let match;
+  while ((match = regex.exec(html))) {
+    const src = match[1];
+    if (/^(https?:|data:)/i.test(src)) continue;
+    const imgPath = path.join(rootDir, src);
+    try {
+      const stat = fs.statSync(imgPath);
+      const sizeKB = stat.size / 1024;
+      if (sizeKB > maxSizeKB) {
+        oversized.push({ path: src, sizeKB, file });
+      }
+    } catch {
+      missing.push({ path: src, file });
+    }
+  }
+}
+
+const report = [];
+report.push(`Checked ${htmlFiles.length} HTML files`);
+if (missing.length) {
+  report.push(`Missing images (${missing.length}):`);
+  for (const m of missing) {
+    report.push(`  ${m.path} referenced in ${path.relative(rootDir, m.file)}`);
+  }
+}
+if (oversized.length) {
+  report.push(`Oversized images (> ${maxSizeKB} KB) (${oversized.length}):`);
+  for (const o of oversized) {
+    report.push(`  ${o.path} - ${o.sizeKB.toFixed(1)} KB referenced in ${path.relative(rootDir, o.file)}`);
+  }
+}
+const total = missing.length + oversized.length;
+report.push(`Total issues: ${total}`);
+
+fs.writeFileSync('image-report.txt', report.join('\n') + '\n');
+
+if (total > threshold) {
+  console.error(report.join('\n'));
+  process.exit(1);
+} else {
+  console.log(report.join('\n'));
+}


### PR DESCRIPTION
## Summary
- add script to scan built HTML for missing or oversized images
- wire image checker into CI and upload report artifact
- fix index.html accessibility issues so HTML validation passes

## Testing
- `npm test`
- `node scripts/check-images.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68b4d63ed788832896f3a3d06945bba2