### PR TITLE
feat: add study planner with queue

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,25 +11,25 @@
 <body>
   <main class="container">
     <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
+    <nav class="site-nav" aria-label="Site navigation"><a href="templates/guidelines.html">Definition Guidelines</a> | <a href="planner.html">Study Planner</a></nav>
     <div id="definition-container" style="display: none;"></div>
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+      <button id="random-term" type="button" aria-label="Show random term">Random Term</button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+      <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">Toggle Dark Mode</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 
     <ul id="terms-list"></ul>
   </main>
-  <footer class="container">
+    <footer class="container" aria-label="Primary footer">
     <p><a href="templates/contribute.html">Contribute</a></p>
   </footer>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+    <button id="scrollToTopBtn" type="button" aria-label="Scroll to top">↑</button>
 
-  <footer>
+    <footer aria-label="Secondary footer">
     <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
   </footer>
   <script src="script.js"></script>

--- a/planner.html
+++ b/planner.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Study Planner - Cyber Security Dictionary</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <main class="container">
+    <h1>Study Planner</h1>
+    <ul id="queue"></ul>
+    <button id="reset-plan" type="button">Reset Plan</button>
+  </main>
+  <script src="planner.js"></script>
+</body>
+</html>

--- a/planner.js
+++ b/planner.js
@@ -1,0 +1,80 @@
+const planTerms = [
+  { term: 'Phishing' },
+  { term: 'Phishing Email', prereqs: ['Phishing'] },
+  { term: 'Social Engineering Toolkit (SET)', prereqs: ['Phishing', 'Phishing Email'] },
+  { term: 'Advanced Persistent Threat (APT)', prereqs: ['Social Engineering Toolkit (SET)'] },
+  { term: 'Cyber Espionage', prereqs: ['Advanced Persistent Threat (APT)'] }
+];
+
+const masteryKey = 'plannerMastery';
+const mastery = new Set(JSON.parse(localStorage.getItem(masteryKey) || '[]'));
+
+function topologicalSort(items) {
+  const result = [];
+  const visited = new Set();
+  const temp = new Set();
+
+  function visit(item) {
+    if (visited.has(item.term)) return;
+    if (temp.has(item.term)) {
+      console.error('Cyclic dependency detected');
+      return;
+    }
+    temp.add(item.term);
+    (item.prereqs || []).forEach((pr) => {
+      const prereqItem = items.find((i) => i.term === pr);
+      if (prereqItem) visit(prereqItem);
+    });
+    temp.delete(item.term);
+    visited.add(item.term);
+    result.push(item);
+  }
+
+  items.forEach(visit);
+  return result;
+}
+
+function buildQueue() {
+  const sorted = topologicalSort(planTerms);
+  const available = sorted.filter(
+    (item) =>
+      !mastery.has(item.term) && (item.prereqs || []).every((p) => mastery.has(p))
+  );
+  const queue = available.slice(0, 7);
+  renderQueue(queue);
+}
+
+function renderQueue(queue) {
+  const container = document.getElementById('queue');
+  container.innerHTML = '';
+  if (queue.length === 0) {
+    const li = document.createElement('li');
+    li.textContent = 'All terms mastered!';
+    container.appendChild(li);
+    return;
+  }
+  queue.forEach((item, index) => {
+    const li = document.createElement('li');
+    li.textContent = `Day ${index + 1}: ${item.term}`;
+    const btn = document.createElement('button');
+    btn.textContent = 'Complete Quiz';
+    btn.addEventListener('click', () => completeTerm(item.term));
+    li.appendChild(btn);
+    container.appendChild(li);
+  });
+}
+
+function completeTerm(term) {
+  mastery.add(term);
+  localStorage.setItem(masteryKey, JSON.stringify(Array.from(mastery)));
+  buildQueue();
+}
+
+function resetPlan() {
+  mastery.clear();
+  localStorage.removeItem(masteryKey);
+  buildQueue();
+}
+
+document.getElementById('reset-plan').addEventListener('click', resetPlan);
+window.addEventListener('DOMContentLoaded', buildQueue);


### PR DESCRIPTION
## Summary
- add standalone Study Planner page that schedules terms based on prerequisites and user mastery
- track mastery in localStorage with reset option
- expose planner via new navigation link

## Testing
- `npm test`
- `npx html-validate planner.html`


------
https://chatgpt.com/codex/tasks/task_e_68b4d640ec9883289f993f89c749e26d