### PR TITLE
Add interactive scenarios and link from term definitions

### DIFF
--- a/components/ScenarioSteps.mdx
+++ b/components/ScenarioSteps.mdx
@@ -1,0 +1,34 @@
+import { useState } from 'react';
+
+/**
+ * ScenarioSteps component displays scenario steps one at a time.
+ * After all steps are revealed, reflection prompts are shown.
+ *
+ * @param {{steps: string[], reflections?: string[]}} props
+ */
+export default function ScenarioSteps({ steps = [], reflections = [] }) {
+  const [index, setIndex] = useState(0);
+  const revealNext = () => setIndex((i) => Math.min(i + 1, steps.length));
+
+  return (
+    <div className="scenario-steps">
+      {steps.slice(0, index).map((step, i) => (
+        <p key={i}>{step}</p>
+      ))}
+      {index < steps.length ? (
+        <button onClick={revealNext}>Reveal Step {index + 1}</button>
+      ) : (
+        reflections.length > 0 && (
+          <div className="reflection">
+            <h4>Reflection</h4>
+            <ul>
+              {reflections.map((q, i) => (
+                <li key={i}>{q}</li>
+              ))}
+            </ul>
+          </div>
+        )
+      )}
+    </div>
+  );
+}

--- a/index.html
+++ b/index.html
@@ -11,25 +11,25 @@
 <body>
   <main class="container">
     <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
+      <nav class="site-nav" aria-label="Site navigation"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
     <div id="definition-container" style="display: none;"></div>
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+      <button id="random-term" aria-label="Show random term" type="button">Random Term</button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+      <button id="dark-mode-toggle" aria-label="Toggle dark mode" type="button">Toggle Dark Mode</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 
     <ul id="terms-list"></ul>
   </main>
-  <footer class="container">
+    <footer class="container" aria-label="Page footer">
     <p><a href="templates/contribute.html">Contribute</a></p>
   </footer>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+    <button id="scrollToTopBtn" aria-label="Scroll to top" type="button">↑</button>
 
-  <footer>
+    <footer aria-label="Project information">
     <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
   </footer>
   <script src="script.js"></script>

--- a/scenarios/malvertising-data-loss.mdx
+++ b/scenarios/malvertising-data-loss.mdx
@@ -1,0 +1,20 @@
+---
+title: Malvertising Leads to Data Loss
+terms:
+  - Malvertising
+  - Data Loss Prevention (DLP)
+---
+
+import ScenarioSteps from '../components/ScenarioSteps.mdx';
+
+<ScenarioSteps
+  steps={[
+    "An employee visits a legitimate news site displaying malvertising.",
+    "The advertisement redirects the browser to a malware download.",
+    "Sensitive files begin transferring outside the network."
+  ]}
+  reflections={[
+    "How can DLP tools detect unusual data transfers?",
+    "What browsing practices reduce exposure to malvertising?"
+  ]}
+/>

--- a/scenarios/phishing-email-incident.mdx
+++ b/scenarios/phishing-email-incident.mdx
@@ -1,0 +1,21 @@
+---
+title: Phishing Email Incident
+terms:
+  - Phishing
+  - Phishing Email
+  - Social Engineering Attack Vectors
+---
+
+import ScenarioSteps from '../components/ScenarioSteps.mdx';
+
+<ScenarioSteps
+  steps={[
+    "You receive an unexpected email claiming to be from your bank.",
+    "The message urges immediate action and includes a link to verify your account.",
+    "The link leads to a site requesting your login credentials."
+  ]}
+  reflections={[
+    "What elements in the email suggest it might be a phishing attempt?",
+    "How could you verify whether the message is legitimate?"
+  ]}
+/>

--- a/scenarios/soc-incident-response.mdx
+++ b/scenarios/soc-incident-response.mdx
@@ -1,0 +1,21 @@
+---
+title: SOC Incident Response Drill
+terms:
+  - Security Operations Center (SOC)
+  - Incident Response
+  - Threat Hunting
+---
+
+import ScenarioSteps from '../components/ScenarioSteps.mdx';
+
+<ScenarioSteps
+  steps={[
+    "The SOC detects unusual outbound traffic during routine monitoring.",
+    "Analysts initiate incident response procedures and isolate affected systems.",
+    "Threat hunting uncovers a persistent backdoor left by attackers."
+  ]}
+  reflections={[
+    "Why is collaboration between SOC monitoring and incident response important?",
+    "What benefits does proactive threat hunting provide after containment?"
+  ]}
+/>

--- a/scenarios/xss-attack.mdx
+++ b/scenarios/xss-attack.mdx
@@ -1,0 +1,20 @@
+---
+title: XSS Attack on Comment Form
+terms:
+  - Cross-Site Scripting (XSS)
+  - Payload
+---
+
+import ScenarioSteps from '../components/ScenarioSteps.mdx';
+
+<ScenarioSteps
+  steps={[
+    "A user submits a comment containing a malicious script payload.",
+    "The website fails to sanitize input and stores the script.",
+    "Other visitors load the page and the script executes in their browsers."
+  ]}
+  reflections={[
+    "What secure coding practices can prevent XSS?",
+    "How does a payload differ from other parts of malware?"
+  ]}
+/>

--- a/scenarios/zero-day-exploit.mdx
+++ b/scenarios/zero-day-exploit.mdx
@@ -1,0 +1,21 @@
+---
+title: Zero-Day Exploit
+terms:
+  - Zero-Day Vulnerability
+  - Security Patch
+  - Advanced Persistent Threat (APT)
+---
+
+import ScenarioSteps from '../components/ScenarioSteps.mdx';
+
+<ScenarioSteps
+  steps={[
+    "An attacker discovers a zero-day vulnerability in widely used software.",
+    "An APT group deploys a payload to exploit the flaw before a patch is available.",
+    "Vendors release a security patch after the exploit becomes public."
+  ]}
+  reflections={[
+    "Why are zero-day vulnerabilities valuable to attackers?",
+    "How can organizations respond quickly when no patch exists?"
+  ]}
+/>

--- a/script.js
+++ b/script.js
@@ -182,7 +182,17 @@ function populateTermsList() {
 
 function displayDefinition(term) {
   definitionContainer.style.display = "block";
-  definitionContainer.innerHTML = `<h3>${term.term}</h3><p>${term.definition}</p>`;
+  let html = `<h3>${term.term}</h3><p>${term.definition}</p>`;
+  if (term.scenarios && term.scenarios.length) {
+    html += '<h4>Scenarios</h4><ul>';
+    term.scenarios.forEach((s) => {
+      const slug = s.slug || s;
+      const title = s.title || slug.replace(/-/g, ' ');
+      html += `<li><a href="scenarios/${slug}.mdx">${title}</a></li>`;
+    });
+    html += '</ul>';
+  }
+  definitionContainer.innerHTML = html;
   window.location.hash = encodeURIComponent(term.term);
   if (canonicalLink) {
     canonicalLink.setAttribute(

--- a/terms.json
+++ b/terms.json
@@ -2,11 +2,23 @@
   "terms": [
     {
       "term": "Phishing",
-      "definition": "An attempt to trick individuals into revealing sensitive information through fraudulent emails, websites, or messages."
+      "definition": "An attempt to trick individuals into revealing sensitive information through fraudulent emails, websites, or messages.",
+      "scenarios": [
+        {
+          "slug": "phishing-email-incident",
+          "title": "Phishing Email Incident"
+        }
+      ]
     },
     {
       "term": "Phishing Email",
-      "definition": "An email sent by attackers that appears legitimate but aims to trick recipients into revealing sensitive information or performing actions."
+      "definition": "An email sent by attackers that appears legitimate but aims to trick recipients into revealing sensitive information or performing actions.",
+      "scenarios": [
+        {
+          "slug": "phishing-email-incident",
+          "title": "Phishing Email Incident"
+        }
+      ]
     },
     {
       "term": "Social Engineering Toolkit (SET)",
@@ -14,7 +26,13 @@
     },
     {
       "term": "Advanced Persistent Threat (APT)",
-      "definition": "A prolonged and targeted cyber attack in which attackers gain and maintain unauthorized access to a network."
+      "definition": "A prolonged and targeted cyber attack in which attackers gain and maintain unauthorized access to a network.",
+      "scenarios": [
+        {
+          "slug": "zero-day-exploit",
+          "title": "Zero-Day Exploit"
+        }
+      ]
     },
     {
       "term": "Cyber Espionage",
@@ -26,11 +44,23 @@
     },
     {
       "term": "Security Operations Center (SOC)",
-      "definition": "A centralized unit that monitors, detects, and responds to cybersecurity incidents and threats in real-time."
+      "definition": "A centralized unit that monitors, detects, and responds to cybersecurity incidents and threats in real-time.",
+      "scenarios": [
+        {
+          "slug": "soc-incident-response",
+          "title": "SOC Incident Response Drill"
+        }
+      ]
     },
     {
       "term": "Data Loss Prevention (DLP)",
-      "definition": "A strategy and set of tools to prevent the unauthorized loss or leakage of sensitive data."
+      "definition": "A strategy and set of tools to prevent the unauthorized loss or leakage of sensitive data.",
+      "scenarios": [
+        {
+          "slug": "malvertising-data-loss",
+          "title": "Malvertising Leads to Data Loss"
+        }
+      ]
     },
     {
       "term": "Endpoint Security",
@@ -46,7 +76,13 @@
     },
     {
       "term": "Payload",
-      "definition": "The part of a malware or exploit that performs malicious actions on a victim's system."
+      "definition": "The part of a malware or exploit that performs malicious actions on a victim's system.",
+      "scenarios": [
+        {
+          "slug": "xss-attack",
+          "title": "XSS Attack on Comment Form"
+        }
+      ]
     },
     {
       "term": "Cryptography",
@@ -54,15 +90,33 @@
     },
     {
       "term": "Social Engineering Attack Vectors",
-      "definition": "Different methods and techniques used in social engineering attacks to manipulate victims."
+      "definition": "Different methods and techniques used in social engineering attacks to manipulate victims.",
+      "scenarios": [
+        {
+          "slug": "phishing-email-incident",
+          "title": "Phishing Email Incident"
+        }
+      ]
     },
     {
       "term": "Threat Hunting",
-      "definition": "Proactively searching for and identifying cyber threats that have evaded traditional security measures."
+      "definition": "Proactively searching for and identifying cyber threats that have evaded traditional security measures.",
+      "scenarios": [
+        {
+          "slug": "soc-incident-response",
+          "title": "SOC Incident Response Drill"
+        }
+      ]
     },
     {
       "term": "Incident Response",
-      "definition": "The process of managing and mitigating the impact of a cybersecurity incident or breach."
+      "definition": "The process of managing and mitigating the impact of a cybersecurity incident or breach.",
+      "scenarios": [
+        {
+          "slug": "soc-incident-response",
+          "title": "SOC Incident Response Drill"
+        }
+      ]
     },
     {
       "term": "Privilege Escalation",
@@ -102,7 +156,13 @@
     },
     {
       "term": "Malvertising",
-      "definition": "Malicious online advertisements that deliver malware or lead to malicious websites."
+      "definition": "Malicious online advertisements that deliver malware or lead to malicious websites.",
+      "scenarios": [
+        {
+          "slug": "malvertising-data-loss",
+          "title": "Malvertising Leads to Data Loss"
+        }
+      ]
     },
     {
       "term": "Eavesdropping",
@@ -114,23 +174,37 @@
     },
     {
       "term": "Zero-Day Vulnerability",
-      "definition": "A software vulnerability that is not yet known to the vendor or the public, making it highly valuable to attackers."
+      "definition": "A software vulnerability that is not yet known to the vendor or the public, making it highly valuable to attackers.",
+      "scenarios": [
+        {
+          "slug": "zero-day-exploit",
+          "title": "Zero-Day Exploit"
+        }
+      ]
     },
     {
       "term": "Security Patch",
-      "definition": "An update released by software vendors to fix security vulnerabilities in their products."
+      "definition": "An update released by software vendors to fix security vulnerabilities in their products.",
+      "scenarios": [
+        {
+          "slug": "zero-day-exploit",
+          "title": "Zero-Day Exploit"
+        }
+      ]
     },
     {
       "term": "Cross-Site Scripting (XSS)",
-      "definition": "A type of web vulnerability where attackers inject malicious scripts into web pages viewed by other users."
+      "definition": "A type of web vulnerability where attackers inject malicious scripts into web pages viewed by other users.",
+      "scenarios": [
+        {
+          "slug": "xss-attack",
+          "title": "XSS Attack on Comment Form"
+        }
+      ]
     },
     {
       "term": "Cross-Site Request Forgery (CSRF)",
       "definition": "An attack that tricks a user into unknowingly submitting a malicious request on a trusted website."
-    },
-    {
-      "term": "Phishing Email",
-      "definition": "An email sent by attackers that appears legitimate but aims to trick recipients into revealing sensitive information or performing actions."
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add `ScenarioSteps` MDX component for stepwise scenarios with reflection prompts
- write five scenario pages referencing dictionary terms
- show scenario links from term definitions and improve index accessibility

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4d642928c8328b853320262b1e01d