### PR TITLE
Add bias language check and allowlist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,31 @@ jobs:
         uses: lycheeverse/lychee-action@v2
         with:
           args: --no-cache terms.json
+      - name: Bias language scan
+        id: bias
+        run: node scripts/check-bias.js || true
+      - name: Comment bias findings
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const report = JSON.parse(fs.readFileSync('bias_report.json', 'utf8'));
+            if (report.length > 0) {
+              const lines = report.map(r => `- **${r.term}**: contains "${r.phrase}"`);
+              const body = ['## Biased language detected', '', ...lines].join('\n');
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body
+              });
+              core.setFailed('Biased language found');
+            }
+      - name: Fail if bias detected
+        if: github.event_name != 'pull_request'
+        run: |
+          if [ -s bias_report.json ] && [ "$(cat bias_report.json)" != "[]" ]; then
+            echo 'Biased language found';
+            exit 1;
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+bias_report.json

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "node scripts/build.js",
     "test": "html-validate index.html",
-    "watch": "chokidar \"**/*.html\" -c \"npm run build\""
+    "watch": "chokidar \"**/*.html\" -c \"npm run build\"",
+    "bias-check": "node scripts/check-bias.js"
   },
   "keywords": [],
   "author": "",

--- a/scripts/bias-allowlist.json
+++ b/scripts/bias-allowlist.json
@@ -1,0 +1,6 @@
+[
+  "critical",
+  "malicious",
+  "attack",
+  "threat"
+]

--- a/scripts/check-bias.js
+++ b/scripts/check-bias.js
@@ -1,0 +1,48 @@
+const fs = require('fs');
+const path = require('path');
+
+const termsPath = path.join(__dirname, '..', 'terms.json');
+const allowlistPath = path.join(__dirname, 'bias-allowlist.json');
+
+const bannedPhrases = [
+  'catastrophic',
+  'doomsday',
+  'panic',
+  'world-ending',
+  'terrifying',
+  'horrifying',
+  'massive loss',
+  'critical failure',
+  'fatal',
+  'evil',
+  'cyber apocalypse',
+  'fearmongering',
+  'fear-mongering'
+];
+
+const allowlist = JSON.parse(fs.readFileSync(allowlistPath, 'utf8')).map(p => p.toLowerCase());
+const terms = JSON.parse(fs.readFileSync(termsPath, 'utf8')).terms;
+
+const findings = [];
+
+for (const { term, definition } of terms) {
+  const lowerDef = definition.toLowerCase();
+  for (const phrase of bannedPhrases) {
+    const lowerPhrase = phrase.toLowerCase();
+    if (lowerDef.includes(lowerPhrase) && !allowlist.includes(lowerPhrase)) {
+      findings.push({ term, phrase });
+    }
+  }
+}
+
+fs.writeFileSync('bias_report.json', JSON.stringify(findings, null, 2));
+
+if (findings.length > 0) {
+  console.error('Biased or fear-inducing phrases found in definitions:');
+  for (const f of findings) {
+    console.error(`- ${f.term}: "${f.phrase}"`);
+  }
+  process.exit(1);
+} else {
+  console.log('No biased or fear-inducing phrases found.');
+}


### PR DESCRIPTION
## Summary
- add script to flag biased or fear-based phrases in term definitions
- create allowlist for permitted terms
- integrate bias scan with CI and comment on PRs

## Testing
- `node scripts/check-bias.js`
- `npm test` *(fails: Landmarks must have a non-empty and unique accessible name (aria-label or aria-labelledby))*

------
https://chatgpt.com/codex/tasks/task_e_68b4d64633ac83288b7a15a4642060a9