### PR TITLE
Add role-based learning pages with progress tracking

### DIFF
--- a/assets/js/roles.js
+++ b/assets/js/roles.js
@@ -1,0 +1,41 @@
+function initRolePage(roleKey, terms) {
+  const list = document.getElementById("terms-list");
+  const progressBar = document.getElementById("progress-bar");
+  const progressText = document.getElementById("progress-text");
+  const stored = JSON.parse(localStorage.getItem(roleKey) || "{}");
+
+  function updateProgress() {
+    const completed = terms.filter((t) => stored[t]).length;
+    progressBar.value = completed;
+    progressText.textContent = `${completed}/${terms.length} terms completed`;
+  }
+
+  progressBar.max = terms.length;
+
+  terms.forEach((term) => {
+    const li = document.createElement("li");
+    const label = document.createElement("label");
+
+    const checkbox = document.createElement("input");
+    checkbox.type = "checkbox";
+    checkbox.checked = stored[term] || false;
+    checkbox.addEventListener("change", () => {
+      stored[term] = checkbox.checked;
+      localStorage.setItem(roleKey, JSON.stringify(stored));
+      updateProgress();
+    });
+
+    const link = document.createElement("a");
+    link.href = `../index.html#${encodeURIComponent(term)}`;
+    link.textContent = term;
+
+    label.appendChild(checkbox);
+    label.appendChild(link);
+    li.appendChild(label);
+    list.appendChild(li);
+  });
+
+  updateProgress();
+}
+
+window.initRolePage = initRolePage;

--- a/index.html
+++ b/index.html
@@ -1,39 +1,56 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Cyber Security Dictionary</title>
-  <link rel="stylesheet" href="styles.css">
-  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet">
-  <link rel="canonical" id="canonical-link" href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/">
-</head>
-<body>
-  <main class="container">
-    <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
-    <div id="definition-container" style="display: none;"></div>
-    <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
-    <input type="text" id="search" placeholder="Search...">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Cyber Security Dictionary</title>
+    <link rel="stylesheet" href="styles.css" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      rel="canonical"
+      id="canonical-link"
+      href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/"
+    />
+  </head>
+  <body>
+    <main class="container">
+      <h1>Cyber Security Dictionary</h1>
+      <nav class="site-nav" aria-label="Site navigation">
+        <a href="templates/guidelines.html">Definition Guidelines</a>
+        <a href="roles/soc-analyst.html">SOC Analyst Path</a>
+        <a href="roles/appsec-engineer.html">AppSec Engineer Path</a>
+        <a href="roles/cloud-security.html">Cloud Security Path</a>
+      </nav>
+      <div id="definition-container" style="display: none"></div>
+      <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
+      <input type="text" id="search" placeholder="Search..." />
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+      <button id="random-term" aria-label="Show random term" type="button">
+        Random Term
+      </button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
-    <input type="checkbox" id="show-favorites" aria-label="Show favorites">
-    <label for="show-favorites">Show Favorites</label>
+      <button id="dark-mode-toggle" aria-label="Toggle dark mode" type="button">
+        Toggle Dark Mode
+      </button>
+      <input type="checkbox" id="show-favorites" aria-label="Show favorites" />
+      <label for="show-favorites">Show Favorites</label>
 
-    <ul id="terms-list"></ul>
-  </main>
-  <footer class="container">
-    <p><a href="templates/contribute.html">Contribute</a></p>
-  </footer>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+      <ul id="terms-list"></ul>
+    </main>
+    <footer class="container" aria-label="Main footer">
+      <p><a href="templates/contribute.html">Contribute</a></p>
+    </footer>
+    <button id="scrollToTopBtn" aria-label="Scroll to top" type="button">
+      ↑
+    </button>
 
-  <footer>
-    <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
-  </footer>
-  <script src="script.js"></script>
-  <script src="assets/js/app.js"></script>
-</body>
+    <footer aria-label="Project link footer">
+      <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
+    </footer>
+    <script src="script.js"></script>
+    <script src="assets/js/app.js"></script>
+  </body>
 </html>
-

--- a/roles/appsec-engineer.html
+++ b/roles/appsec-engineer.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AppSec Engineer Terms - Cyber Security Dictionary</title>
+    <link rel="stylesheet" href="../styles.css" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <main class="container">
+      <h1>AppSec Engineer Terms</h1>
+      <progress id="progress-bar" value="0" max="0"></progress>
+      <p id="progress-text"></p>
+      <ul id="terms-list"></ul>
+    </main>
+    <script src="../assets/js/roles.js"></script>
+    <script>
+      initRolePage("appsec-engineer", [
+        "Cross-Site Scripting (XSS)",
+        "Cross-Site Request Forgery (CSRF)",
+        "Security Assessment",
+        "Zero-Day Vulnerability",
+        "Security Patch",
+      ]);
+    </script>
+  </body>
+</html>

--- a/roles/cloud-security.html
+++ b/roles/cloud-security.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Cloud Security Terms - Cyber Security Dictionary</title>
+    <link rel="stylesheet" href="../styles.css" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <main class="container">
+      <h1>Cloud Security Terms</h1>
+      <progress id="progress-bar" value="0" max="0"></progress>
+      <p id="progress-text"></p>
+      <ul id="terms-list"></ul>
+    </main>
+    <script src="../assets/js/roles.js"></script>
+    <script>
+      initRolePage("cloud-security", [
+        "Public Key Infrastructure (PKI)",
+        "Advanced Encryption Standard (AES)",
+        "Transport Layer Security (TLS)",
+        "Certificate Authority (CA)",
+        "Network Security",
+      ]);
+    </script>
+  </body>
+</html>

--- a/roles/soc-analyst.html
+++ b/roles/soc-analyst.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SOC Analyst Terms - Cyber Security Dictionary</title>
+    <link rel="stylesheet" href="../styles.css" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <main class="container">
+      <h1>SOC Analyst Terms</h1>
+      <progress id="progress-bar" value="0" max="0"></progress>
+      <p id="progress-text"></p>
+      <ul id="terms-list"></ul>
+    </main>
+    <script src="../assets/js/roles.js"></script>
+    <script>
+      initRolePage("soc-analyst", [
+        "Security Operations Center (SOC)",
+        "Threat Hunting",
+        "Incident Response",
+        "Data Loss Prevention (DLP)",
+        "Endpoint Security",
+      ]);
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Add SOC analyst, AppSec engineer, and Cloud security role pages
- Track role milestones locally with reusable script
- Link role paths from main navigation and improve accessibility

## Testing
- `npm test`
- `npx html-validate roles/soc-analyst.html roles/appsec-engineer.html roles/cloud-security.html`

------
https://chatgpt.com/codex/tasks/task_e_68b4d646e7248328831dd56d766e3dc3