### PR TITLE
Add OpenAPI spec for terms endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,18 @@
 # CyberSecuirtyDictionary
+
 https://alex-unnippillil.github.io/CyberSecuirtyDictionary/
 ![image](https://github.com/Alex-Unnippillil/CyberSecuirtyDictionary/assets/24538548/c5a54c56-babb-485d-b01c-4fdfb186325b)
 
 ## Security
+
 For information on reporting vulnerabilities, please see our [Security Policy](SECURITY.md).
+
+## API
+
+Static JSON endpoints expose the dictionary data:
+
+- `/data/terms.json` – full list of terms
+- `/data/terms/{slug}.json` – data for a single term identified by `slug`
+
+An OpenAPI description with example responses is available at
+[`data/openapi.yaml`](data/openapi.yaml).

--- a/data/openapi.yaml
+++ b/data/openapi.yaml
@@ -1,0 +1,114 @@
+openapi: 3.1.0
+info:
+  title: Cyber Security Dictionary API
+  version: 1.0.0
+servers:
+  - url: https://alex-unnippillil.github.io/CyberSecuirtyDictionary
+paths:
+  /data/terms.json:
+    get:
+      summary: List all terms
+      responses:
+        "200":
+          description: All terms in the dictionary
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - terms
+                properties:
+                  terms:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Term"
+              examples:
+                sample:
+                  value:
+                    terms:
+                      - name: CVE
+                        slug: cve
+                        definition: >-
+                          A public catalog of cybersecurity vulnerabilities providing
+                          unique identifiers for known software flaws.
+                        category: Vulnerability Tracking
+                        synonyms:
+                          - CVE ID
+                          - Common Vulnerabilities and Exposures
+                        see_also:
+                          - CWE
+                          - NVD
+                        sources:
+                          - https://cve.mitre.org
+  /data/terms/{slug}.json:
+    get:
+      summary: Get a term by slug
+      parameters:
+        - in: path
+          name: slug
+          required: true
+          description: URL-friendly identifier of the term
+          schema:
+            type: string
+      responses:
+        "200":
+          description: The requested term
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Term"
+              examples:
+                cve:
+                  value:
+                    name: CVE
+                    slug: cve
+                    definition: >-
+                      A public catalog of cybersecurity vulnerabilities providing
+                      unique identifiers for known software flaws.
+                    category: Vulnerability Tracking
+                    synonyms:
+                      - CVE ID
+                      - Common Vulnerabilities and Exposures
+                    see_also:
+                      - CWE
+                      - NVD
+                    sources:
+                      - https://cve.mitre.org
+        "404":
+          description: Term not found
+components:
+  schemas:
+    Term:
+      type: object
+      required:
+        - name
+        - slug
+        - definition
+      properties:
+        name:
+          type: string
+          description: Canonical name of the term
+        slug:
+          type: string
+          description: URL-friendly identifier for the term
+        definition:
+          type: string
+          description: Human-readable definition of the term
+        category:
+          type: string
+          description: Optional category for the term
+        synonyms:
+          type: array
+          description: Alternate names for the term
+          items:
+            type: string
+        see_also:
+          type: array
+          description: Related terms
+          items:
+            type: string
+        sources:
+          type: array
+          description: Sources for the definition
+          items:
+            type: string

--- a/index.html
+++ b/index.html
@@ -11,25 +11,25 @@
 <body>
   <main class="container">
     <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
+    <nav class="site-nav" aria-label="Site navigation"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
     <div id="definition-container" style="display: none;"></div>
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+    <button id="random-term" type="button" aria-label="Show random term">Random Term</button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+    <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">Toggle Dark Mode</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 
     <ul id="terms-list"></ul>
   </main>
-  <footer class="container">
+    <footer class="container" aria-label="Primary footer">
     <p><a href="templates/contribute.html">Contribute</a></p>
   </footer>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+  <button id="scrollToTopBtn" type="button" aria-label="Scroll to top">↑</button>
 
-  <footer>
+  <footer aria-label="Project footer">
     <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
   </footer>
   <script src="script.js"></script>


### PR DESCRIPTION
## Summary
- document `/data/terms.json` and `/data/terms/{slug}.json` with new OpenAPI spec
- link API documentation from README
- add accessibility labels and button types to pass HTML validation

## Testing
- `npx swagger-cli validate data/openapi.yaml`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4d64a1cf48328b7b7c9cca95d8f01