### PR TITLE
Add quiz progress heatmap

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,25 +11,25 @@
 <body>
   <main class="container">
     <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
+    <nav class="site-nav" aria-label="Site navigation"><a href="templates/guidelines.html">Definition Guidelines</a> | <a href="quiz.html">Quiz</a></nav>
     <div id="definition-container" style="display: none;"></div>
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+    <button id="random-term" type="button" aria-label="Show random term">Random Term</button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+    <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">Toggle Dark Mode</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 
     <ul id="terms-list"></ul>
   </main>
-  <footer class="container">
+  <footer class="container" aria-label="Main footer">
     <p><a href="templates/contribute.html">Contribute</a></p>
   </footer>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+  <button id="scrollToTopBtn" type="button" aria-label="Scroll to top">↑</button>
 
-  <footer>
+  <footer aria-label="Project footer">
     <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
   </footer>
   <script src="script.js"></script>

--- a/quiz.html
+++ b/quiz.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Cyber Security Quiz</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <main class="container">
+    <h1>Quiz Progress</h1>
+    <div id="heatmap" class="heatmap"></div>
+    <button id="reset-progress" type="button">Reset Progress</button>
+  </main>
+  <script src="quiz.js"></script>
+</body>
+</html>
+

--- a/quiz.js
+++ b/quiz.js
@@ -1,0 +1,63 @@
+const STORAGE_KEY = 'quizProgress';
+
+function loadProgress() {
+  try {
+    return JSON.parse(localStorage.getItem(STORAGE_KEY)) || {};
+  } catch (e) {
+    return {};
+  }
+}
+
+function saveProgress(progress) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(progress));
+  } catch (e) {
+    // Ignore storage errors
+  }
+}
+
+function renderHeatmap() {
+  const heatmap = document.getElementById('heatmap');
+  const progress = loadProgress();
+  heatmap.innerHTML = '';
+
+  const domains = Object.keys(progress);
+  if (domains.length === 0) {
+    heatmap.textContent = 'No quiz data yet.';
+    return;
+  }
+
+  domains.forEach((domain) => {
+    const { correct, total } = progress[domain];
+    const score = total ? correct / total : 0;
+    const cell = document.createElement('div');
+    cell.className = 'heatmap-cell';
+    cell.style.setProperty('--heat-color', `hsl(${score * 120}, 70%, 50%)`);
+    cell.textContent = `${domain}: ${Math.round(score * 100)}%`;
+    heatmap.appendChild(cell);
+  });
+}
+
+function recordQuizResult(domain, isCorrect) {
+  const progress = loadProgress();
+  if (!progress[domain]) {
+    progress[domain] = { correct: 0, total: 0 };
+  }
+  progress[domain].total += 1;
+  if (isCorrect) {
+    progress[domain].correct += 1;
+  }
+  saveProgress(progress);
+  renderHeatmap();
+}
+
+function resetProgress() {
+  localStorage.removeItem(STORAGE_KEY);
+  renderHeatmap();
+}
+
+document.getElementById('reset-progress').addEventListener('click', resetProgress);
+
+renderHeatmap();
+
+window.recordQuizResult = recordQuizResult;

--- a/styles.css
+++ b/styles.css
@@ -287,6 +287,27 @@ body.dark-mode .dictionary-item p {
   color: #ccc;
 }
 
+/* Quiz heatmap styles */
+.heatmap {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+  gap: 10px;
+  margin-top: 20px;
+}
+
+.heatmap-cell {
+  padding: 20px;
+  text-align: center;
+  border-radius: 4px;
+  background-color: var(--heat-color, #eee);
+  color: #fff;
+}
+
+#reset-progress {
+  margin-top: 20px;
+  padding: 10px;
+}
+
 body.dark-mode #definition-container {
   background-color: #1e1e1e;
   box-shadow: 0 0 5px rgba(255, 255, 255, 0.1);


### PR DESCRIPTION
## Summary
- Track quiz results per domain and persist them in localStorage
- Display a domain heatmap with a reset button
- Link new quiz page from the main navigation

## Testing
- `npm test`
- `npx html-validate quiz.html`


------
https://chatgpt.com/codex/tasks/task_e_68b4d64871dc83289b1aa87665de7de6