### PR TITLE
Add CSV exports and download links for terms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+terms/
+sitemap.xml

--- a/build.js
+++ b/build.js
@@ -1,26 +1,35 @@
-const fs = require('fs');
-const path = require('path');
+const fs = require("fs");
+const path = require("path");
 
-const dataPath = path.join(__dirname, 'data.json');
-const data = JSON.parse(fs.readFileSync(dataPath, 'utf8'));
+const dataPath = path.join(__dirname, "terms.json");
+const data = JSON.parse(fs.readFileSync(dataPath, "utf8"));
 
-const termsDir = path.join(__dirname, 'terms');
+const termsDir = path.join(__dirname, "terms");
 fs.mkdirSync(termsDir, { recursive: true });
 
-const baseUrl = 'https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms';
+const baseUrl =
+  "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms";
 
 const urls = [];
 
 function slugify(term) {
   return term
     .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function toCSVValue(value) {
+  if (Array.isArray(value)) {
+    value = value.join("; ");
+  }
+  const str = String(value ?? "");
+  return /[",\n]/.test(str) ? `"${str.replace(/"/g, '""')}"` : str;
 }
 
 for (const term of data.terms) {
   const slug = slugify(term.term);
-  const metaRobots = term.draft ? '<meta name="robots" content="noindex">' : '';
+  const metaRobots = term.draft ? '<meta name="robots" content="noindex">' : "";
   const html = `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -31,9 +40,30 @@ for (const term of data.terms) {
 <body>
   <h1>${term.term}</h1>
   <p>${term.definition}</p>
+  <a href="${slug}.csv" download>Download CSV</a>
 </body>
 </html>`;
   fs.writeFileSync(path.join(termsDir, `${slug}.html`), html);
+
+  const fields = [
+    "term",
+    "definition",
+    "category",
+    "synonyms",
+    "see_also",
+    "sources",
+  ];
+  const headers = [];
+  const values = [];
+  for (const field of fields) {
+    if (term[field]) {
+      headers.push(field);
+      values.push(toCSVValue(term[field]));
+    }
+  }
+  const csv = headers.join(",") + "\n" + values.join(",") + "\n";
+  fs.writeFileSync(path.join(termsDir, `${slug}.csv`), csv);
+
   if (!term.draft) {
     urls.push(`${baseUrl}/${slug}.html`);
   }
@@ -41,8 +71,8 @@ for (const term of data.terms) {
 
 const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-${urls.map(u => `  <url><loc>${u}</loc></url>`).join('\n')}
+${urls.map((u) => `  <url><loc>${u}</loc></url>`).join("\n")}
 </urlset>
 `;
 
-fs.writeFileSync(path.join(__dirname, 'sitemap.xml'), sitemap);
+fs.writeFileSync(path.join(__dirname, "sitemap.xml"), sitemap);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/",
   "main": "script.js",
   "scripts": {
-    "build": "node scripts/build.js",
+    "build": "node build.js",
     "test": "html-validate index.html",
     "watch": "chokidar \"**/*.html\" -c \"npm run build\""
   },


### PR DESCRIPTION
## Summary
- generate per-term CSV files with core fields during build
- add download links on term pages
- fix build script reference in package.json and ignore build artifacts

## Testing
- `node build.js`
- `python3 - <<'PY'
import csv
with open('terms/advanced-encryption-standard-aes.csv') as f:
    print(list(csv.reader(f)))
PY`
- `npm test` *(fails: unique-landmark, no-implicit-button-type)*

------
https://chatgpt.com/codex/tasks/task_e_68b4d64b3ae883288385ec6e7970894a