### PR TITLE
feat: add CLI for fuzzy term search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+package-lock.json
+npm-debug.log

--- a/README.md
+++ b/README.md
@@ -4,3 +4,13 @@ https://alex-unnippillil.github.io/CyberSecuirtyDictionary/
 
 ## Security
 For information on reporting vulnerabilities, please see our [Security Policy](SECURITY.md).
+
+## CLI Usage
+
+Search terms from the command line with fuzzy matching:
+
+```bash
+npx @yourscope/cli-term phishing
+```
+
+Select a result to open the full definition in your browser.

--- a/bin/cli-term.js
+++ b/bin/cli-term.js
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const readline = require('readline');
+const Fuse = require('fuse.js');
+const open = require('open');
+
+const indexPath = path.join(__dirname, '..', 'terms.index.json');
+const terms = JSON.parse(fs.readFileSync(indexPath, 'utf8'));
+
+const fuse = new Fuse(terms, { keys: ['term', 'definition'], threshold: 0.3 });
+
+const query = process.argv.slice(2).join(' ');
+
+if (!query) {
+  console.error('Usage: cli-term <query>');
+  process.exit(1);
+}
+
+const results = fuse.search(query, { limit: 5 });
+
+if (results.length === 0) {
+  console.log('No matching terms found.');
+  process.exit(0);
+}
+
+results.forEach((res, idx) => {
+  console.log(`${idx + 1}. ${res.item.term} - ${res.item.definition}`);
+});
+
+const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+rl.question('Open which result? (number or enter to exit) ', answer => {
+  rl.close();
+  const n = parseInt(answer, 10);
+  if (!isNaN(n) && results[n - 1]) {
+    open(results[n - 1].item.url);
+  }
+});

--- a/index.html
+++ b/index.html
@@ -11,25 +11,25 @@
 <body>
   <main class="container">
     <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
+    <nav class="site-nav" aria-label="Site navigation"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
     <div id="definition-container" style="display: none;"></div>
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+      <button id="random-term" type="button" aria-label="Show random term">Random Term</button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+      <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">Toggle Dark Mode</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 
     <ul id="terms-list"></ul>
   </main>
-  <footer class="container">
+    <footer class="container" aria-label="Dictionary footer">
     <p><a href="templates/contribute.html">Contribute</a></p>
   </footer>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+    <button id="scrollToTopBtn" type="button" aria-label="Scroll to top">↑</button>
 
-  <footer>
+    <footer aria-label="Project footer">
     <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
   </footer>
   <script src="script.js"></script>

--- a/package.json
+++ b/package.json
@@ -1,16 +1,24 @@
 {
-  "name": "cybersecuirtydictionary",
+  "name": "@yourscope/cli-term",
   "version": "1.0.0",
   "description": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/",
   "main": "script.js",
+  "bin": {
+    "cli-term": "bin/cli-term.js"
+  },
   "scripts": {
     "build": "node scripts/build.js",
+    "build:index": "node scripts/build-index.js",
     "test": "html-validate index.html",
     "watch": "chokidar \"**/*.html\" -c \"npm run build\""
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
+  "dependencies": {
+    "fuse.js": "^6.6.2",
+    "open": "^9.1.0"
+  },
   "devDependencies": {
     "chokidar-cli": "^3.0.0",
     "html-validate": "^10.0.0",

--- a/scripts/build-index.js
+++ b/scripts/build-index.js
@@ -1,0 +1,28 @@
+const fs = require('fs');
+const path = require('path');
+
+const termsPath = path.join(__dirname, '..', 'terms.json');
+const outputPath = path.join(__dirname, '..', 'terms.index.json');
+
+const { terms } = JSON.parse(fs.readFileSync(termsPath, 'utf8'));
+
+function slugify(term) {
+  return term
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+const baseUrl = 'https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms';
+
+const index = terms.map(t => {
+  const slug = slugify(t.term);
+  return {
+    term: t.term,
+    definition: t.definition,
+    slug,
+    url: `${baseUrl}/${slug}.html`
+  };
+});
+
+fs.writeFileSync(outputPath, JSON.stringify(index, null, 2));

--- a/terms.index.json
+++ b/terms.index.json
@@ -1,0 +1,200 @@
+[
+  {
+    "term": "Phishing",
+    "definition": "An attempt to trick individuals into revealing sensitive information through fraudulent emails, websites, or messages.",
+    "slug": "phishing",
+    "url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/phishing.html"
+  },
+  {
+    "term": "Phishing Email",
+    "definition": "An email sent by attackers that appears legitimate but aims to trick recipients into revealing sensitive information or performing actions.",
+    "slug": "phishing-email",
+    "url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/phishing-email.html"
+  },
+  {
+    "term": "Social Engineering Toolkit (SET)",
+    "definition": "A framework for simulating social engineering attacks, helping organizations test their security awareness.",
+    "slug": "social-engineering-toolkit-set",
+    "url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/social-engineering-toolkit-set.html"
+  },
+  {
+    "term": "Advanced Persistent Threat (APT)",
+    "definition": "A prolonged and targeted cyber attack in which attackers gain and maintain unauthorized access to a network.",
+    "slug": "advanced-persistent-threat-apt",
+    "url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/advanced-persistent-threat-apt.html"
+  },
+  {
+    "term": "Cyber Espionage",
+    "definition": "The use of cyber techniques to steal sensitive information from governments, organizations, or individuals.",
+    "slug": "cyber-espionage",
+    "url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/cyber-espionage.html"
+  },
+  {
+    "term": "Zero-Knowledge Proof",
+    "definition": "A cryptographic method that allows a party to prove knowledge of a secret without revealing the secret itself.",
+    "slug": "zero-knowledge-proof",
+    "url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/zero-knowledge-proof.html"
+  },
+  {
+    "term": "Security Operations Center (SOC)",
+    "definition": "A centralized unit that monitors, detects, and responds to cybersecurity incidents and threats in real-time.",
+    "slug": "security-operations-center-soc",
+    "url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/security-operations-center-soc.html"
+  },
+  {
+    "term": "Data Loss Prevention (DLP)",
+    "definition": "A strategy and set of tools to prevent the unauthorized loss or leakage of sensitive data.",
+    "slug": "data-loss-prevention-dlp",
+    "url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/data-loss-prevention-dlp.html"
+  },
+  {
+    "term": "Endpoint Security",
+    "definition": "The protection of devices like laptops, desktops, and smartphones from various security threats.",
+    "slug": "endpoint-security",
+    "url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/endpoint-security.html"
+  },
+  {
+    "term": "Security Token",
+    "definition": "A physical or digital device used to authenticate users or provide one-time passwords for secure access.",
+    "slug": "security-token",
+    "url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/security-token.html"
+  },
+  {
+    "term": "Network Security",
+    "definition": "The protection of network infrastructure and data from unauthorized access or attacks.",
+    "slug": "network-security",
+    "url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/network-security.html"
+  },
+  {
+    "term": "Payload",
+    "definition": "The part of a malware or exploit that performs malicious actions on a victim's system.",
+    "slug": "payload",
+    "url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/payload.html"
+  },
+  {
+    "term": "Cryptography",
+    "definition": "The practice of secure communication by converting plaintext into ciphertext and vice versa.",
+    "slug": "cryptography",
+    "url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/cryptography.html"
+  },
+  {
+    "term": "Social Engineering Attack Vectors",
+    "definition": "Different methods and techniques used in social engineering attacks to manipulate victims.",
+    "slug": "social-engineering-attack-vectors",
+    "url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/social-engineering-attack-vectors.html"
+  },
+  {
+    "term": "Threat Hunting",
+    "definition": "Proactively searching for and identifying cyber threats that have evaded traditional security measures.",
+    "slug": "threat-hunting",
+    "url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/threat-hunting.html"
+  },
+  {
+    "term": "Incident Response",
+    "definition": "The process of managing and mitigating the impact of a cybersecurity incident or breach.",
+    "slug": "incident-response",
+    "url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/incident-response.html"
+  },
+  {
+    "term": "Privilege Escalation",
+    "definition": "The act of gaining higher levels of access or permissions in a system or network than originally granted.",
+    "slug": "privilege-escalation",
+    "url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/privilege-escalation.html"
+  },
+  {
+    "term": "Security Assessment",
+    "definition": "A systematic evaluation of an organization's security measures to identify vulnerabilities and weaknesses.",
+    "slug": "security-assessment",
+    "url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/security-assessment.html"
+  },
+  {
+    "term": "Data Encryption Standard (DES)",
+    "definition": "An early symmetric key encryption algorithm used to secure electronic data.",
+    "slug": "data-encryption-standard-des",
+    "url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/data-encryption-standard-des.html"
+  },
+  {
+    "term": "Advanced Encryption Standard (AES)",
+    "definition": "A widely used symmetric key encryption algorithm known for its security and efficiency.",
+    "slug": "advanced-encryption-standard-aes",
+    "url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/advanced-encryption-standard-aes.html"
+  },
+  {
+    "term": "Public Key Infrastructure (PKI)",
+    "definition": "A system for managing digital certificates and public-private key pairs used in asymmetric encryption.",
+    "slug": "public-key-infrastructure-pki",
+    "url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/public-key-infrastructure-pki.html"
+  },
+  {
+    "term": "Certificate Authority (CA)",
+    "definition": "An entity responsible for issuing and managing digital certificates used in PKI.",
+    "slug": "certificate-authority-ca",
+    "url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/certificate-authority-ca.html"
+  },
+  {
+    "term": "Secure Sockets Layer (SSL)",
+    "definition": "An older cryptographic protocol that provides secure communication over a computer network.",
+    "slug": "secure-sockets-layer-ssl",
+    "url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/secure-sockets-layer-ssl.html"
+  },
+  {
+    "term": "Transport Layer Security (TLS)",
+    "definition": "A more secure successor to SSL, providing encryption and authentication for secure communication.",
+    "slug": "transport-layer-security-tls",
+    "url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/transport-layer-security-tls.html"
+  },
+  {
+    "term": "Key Exchange",
+    "definition": "The process of securely sharing encryption keys between parties to establish a secure communication channel.",
+    "slug": "key-exchange",
+    "url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/key-exchange.html"
+  },
+  {
+    "term": "Malvertising",
+    "definition": "Malicious online advertisements that deliver malware or lead to malicious websites.",
+    "slug": "malvertising",
+    "url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/malvertising.html"
+  },
+  {
+    "term": "Eavesdropping",
+    "definition": "Unauthorized interception and monitoring of private communications, often done surreptitiously.",
+    "slug": "eavesdropping",
+    "url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/eavesdropping.html"
+  },
+  {
+    "term": "Identity Theft",
+    "definition": "The fraudulent acquisition and use of an individual's personal information to impersonate them for malicious purposes.",
+    "slug": "identity-theft",
+    "url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/identity-theft.html"
+  },
+  {
+    "term": "Zero-Day Vulnerability",
+    "definition": "A software vulnerability that is not yet known to the vendor or the public, making it highly valuable to attackers.",
+    "slug": "zero-day-vulnerability",
+    "url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/zero-day-vulnerability.html"
+  },
+  {
+    "term": "Security Patch",
+    "definition": "An update released by software vendors to fix security vulnerabilities in their products.",
+    "slug": "security-patch",
+    "url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/security-patch.html"
+  },
+  {
+    "term": "Cross-Site Scripting (XSS)",
+    "definition": "A type of web vulnerability where attackers inject malicious scripts into web pages viewed by other users.",
+    "slug": "cross-site-scripting-xss",
+    "url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/cross-site-scripting-xss.html"
+  },
+  {
+    "term": "Cross-Site Request Forgery (CSRF)",
+    "definition": "An attack that tricks a user into unknowingly submitting a malicious request on a trusted website.",
+    "slug": "cross-site-request-forgery-csrf",
+    "url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/cross-site-request-forgery-csrf.html"
+  },
+  {
+    "term": "Phishing Email",
+    "definition": "An email sent by attackers that appears legitimate but aims to trick recipients into revealing sensitive information or performing actions.",
+    "slug": "phishing-email",
+    "url": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/phishing-email.html"
+  }
+]


### PR DESCRIPTION
## Summary
- add Node-based `cli-term` for fuzzy searching `terms.index.json`
- generate `terms.index.json` and expose build script
- fix HTML validation errors and document CLI usage

## Testing
- `npm test`
- `time printf '\n' | node bin/cli-term.js phishing`


------
https://chatgpt.com/codex/tasks/task_e_68b4d64d19d48328bf78d411234699f3