### PR TITLE
feat: add offline hover dictionary extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,8 @@
 https://alex-unnippillil.github.io/CyberSecuirtyDictionary/
 ![image](https://github.com/Alex-Unnippillil/CyberSecuirtyDictionary/assets/24538548/c5a54c56-babb-485d-b01c-4fdfb186325b)
 
+## Browser Extension
+An offline browser extension is available in the `extension` directory. It highlights cybersecurity terms on any page and shows definitions on hover using a local JSON dictionary. See [extension/README.md](extension/README.md) for installation and demo instructions.
+
 ## Security
 For information on reporting vulnerabilities, please see our [Security Policy](SECURITY.md).

--- a/extension/README.md
+++ b/extension/README.md
@@ -1,0 +1,14 @@
+# Cybersecurity Dictionary Extension
+
+This browser extension highlights cybersecurity terms on any web page and shows their definitions on hover. All data is loaded from a local `terms.json` file so the extension works completely offline.
+
+## Installation
+
+1. Open the browser's extensions page (e.g. `chrome://extensions`).
+2. Enable **Developer mode**.
+3. Choose **Load unpacked** and select this repository's `extension` folder.
+4. Open `extension/demo.html` to test the extension offline.
+
+## Usage
+
+The extension scans pages for terms from the included dictionary. Any matching words are highlighted. Hover over a highlighted term to see its definition.

--- a/extension/content.js
+++ b/extension/content.js
@@ -1,0 +1,71 @@
+async function init() {
+  const response = await fetch(chrome.runtime.getURL('terms.json'));
+  const data = await response.json();
+  const terms = data.terms;
+
+  const style = document.createElement('style');
+  style.textContent = `
+    .csd-term { background-color: #fffd75; cursor: help; }
+    .csd-tooltip { position: absolute; background: #333; color: #fff; padding: 4px 8px; border-radius: 4px; z-index: 10000; max-width: 250px; }
+  `;
+  document.head.appendChild(style);
+
+  const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, null, false);
+  const nodes = [];
+  while (walker.nextNode()) nodes.push(walker.currentNode);
+  nodes.forEach(node => processNode(node, terms));
+
+  document.addEventListener('mouseover', e => {
+    if (e.target.classList && e.target.classList.contains('csd-term')) {
+      const tooltip = document.createElement('div');
+      tooltip.className = 'csd-tooltip';
+      tooltip.textContent = e.target.dataset.definition;
+      document.body.appendChild(tooltip);
+      const rect = e.target.getBoundingClientRect();
+      tooltip.style.left = `${rect.left + window.scrollX}px`;
+      tooltip.style.top = `${rect.bottom + window.scrollY + 4}px`;
+      e.target._tooltip = tooltip;
+    }
+  });
+
+  document.addEventListener('mouseout', e => {
+    if (e.target.classList && e.target.classList.contains('csd-term') && e.target._tooltip) {
+      e.target._tooltip.remove();
+      e.target._tooltip = null;
+    }
+  });
+}
+
+function processNode(node, terms) {
+  const text = node.nodeValue;
+  let idx = 0;
+  const frag = document.createDocumentFragment();
+  let matched = false;
+  const lower = text.toLowerCase();
+  while (idx < text.length) {
+    let foundTerm = null;
+    let foundIndex = -1;
+    for (const t of terms) {
+      const i = lower.indexOf(t.term.toLowerCase(), idx);
+      if (i !== -1 && (foundIndex === -1 || i < foundIndex)) {
+        foundIndex = i;
+        foundTerm = t;
+      }
+    }
+    if (foundTerm === null) break;
+    matched = true;
+    frag.appendChild(document.createTextNode(text.slice(idx, foundIndex)));
+    const span = document.createElement('span');
+    span.className = 'csd-term';
+    span.textContent = text.substr(foundIndex, foundTerm.term.length);
+    span.dataset.definition = foundTerm.definition;
+    frag.appendChild(span);
+    idx = foundIndex + foundTerm.term.length;
+  }
+  if (matched) {
+    frag.appendChild(document.createTextNode(text.slice(idx)));
+    node.parentNode.replaceChild(frag, node);
+  }
+}
+
+init();

--- a/extension/demo.html
+++ b/extension/demo.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Cybersecurity Dictionary Demo</title>
+</head>
+<body>
+  <p>Phishing is a common attack. Users should be aware of Malware and other threats.</p>
+  <p>Hover over highlighted terms to view their definitions. This page works offline.</p>
+</body>
+</html>

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,19 @@
+{
+  "manifest_version": 3,
+  "name": "Cybersecurity Dictionary",
+  "description": "Highlights cybersecurity terms and shows definitions on hover using a local JSON file.",
+  "version": "1.0",
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content.js"],
+      "run_at": "document_end"
+    }
+  ],
+  "web_accessible_resources": [
+    {
+      "resources": ["terms.json"],
+      "matches": ["<all_urls>"]
+    }
+  ]
+}

--- a/extension/terms.json
+++ b/extension/terms.json
@@ -1,0 +1,136 @@
+{
+  "terms": [
+    {
+      "term": "Phishing",
+      "definition": "An attempt to trick individuals into revealing sensitive information through fraudulent emails, websites, or messages."
+    },
+    {
+      "term": "Phishing Email",
+      "definition": "An email sent by attackers that appears legitimate but aims to trick recipients into revealing sensitive information or performing actions."
+    },
+    {
+      "term": "Social Engineering Toolkit (SET)",
+      "definition": "A framework for simulating social engineering attacks, helping organizations test their security awareness."
+    },
+    {
+      "term": "Advanced Persistent Threat (APT)",
+      "definition": "A prolonged and targeted cyber attack in which attackers gain and maintain unauthorized access to a network."
+    },
+    {
+      "term": "Cyber Espionage",
+      "definition": "The use of cyber techniques to steal sensitive information from governments, organizations, or individuals."
+    },
+    {
+      "term": "Zero-Knowledge Proof",
+      "definition": "A cryptographic method that allows a party to prove knowledge of a secret without revealing the secret itself."
+    },
+    {
+      "term": "Security Operations Center (SOC)",
+      "definition": "A centralized unit that monitors, detects, and responds to cybersecurity incidents and threats in real-time."
+    },
+    {
+      "term": "Data Loss Prevention (DLP)",
+      "definition": "A strategy and set of tools to prevent the unauthorized loss or leakage of sensitive data."
+    },
+    {
+      "term": "Endpoint Security",
+      "definition": "The protection of devices like laptops, desktops, and smartphones from various security threats."
+    },
+    {
+      "term": "Security Token",
+      "definition": "A physical or digital device used to authenticate users or provide one-time passwords for secure access."
+    },
+    {
+      "term": "Network Security",
+      "definition": "The protection of network infrastructure and data from unauthorized access or attacks."
+    },
+    {
+      "term": "Payload",
+      "definition": "The part of a malware or exploit that performs malicious actions on a victim's system."
+    },
+    {
+      "term": "Cryptography",
+      "definition": "The practice of secure communication by converting plaintext into ciphertext and vice versa."
+    },
+    {
+      "term": "Social Engineering Attack Vectors",
+      "definition": "Different methods and techniques used in social engineering attacks to manipulate victims."
+    },
+    {
+      "term": "Threat Hunting",
+      "definition": "Proactively searching for and identifying cyber threats that have evaded traditional security measures."
+    },
+    {
+      "term": "Incident Response",
+      "definition": "The process of managing and mitigating the impact of a cybersecurity incident or breach."
+    },
+    {
+      "term": "Privilege Escalation",
+      "definition": "The act of gaining higher levels of access or permissions in a system or network than originally granted."
+    },
+    {
+      "term": "Security Assessment",
+      "definition": "A systematic evaluation of an organization's security measures to identify vulnerabilities and weaknesses."
+    },
+    {
+      "term": "Data Encryption Standard (DES)",
+      "definition": "An early symmetric key encryption algorithm used to secure electronic data."
+    },
+    {
+      "term": "Advanced Encryption Standard (AES)",
+      "definition": "A widely used symmetric key encryption algorithm known for its security and efficiency."
+    },
+    {
+      "term": "Public Key Infrastructure (PKI)",
+      "definition": "A system for managing digital certificates and public-private key pairs used in asymmetric encryption."
+    },
+    {
+      "term": "Certificate Authority (CA)",
+      "definition": "An entity responsible for issuing and managing digital certificates used in PKI."
+    },
+    {
+      "term": "Secure Sockets Layer (SSL)",
+      "definition": "An older cryptographic protocol that provides secure communication over a computer network."
+    },
+    {
+      "term": "Transport Layer Security (TLS)",
+      "definition": "A more secure successor to SSL, providing encryption and authentication for secure communication."
+    },
+    {
+      "term": "Key Exchange",
+      "definition": "The process of securely sharing encryption keys between parties to establish a secure communication channel."
+    },
+    {
+      "term": "Malvertising",
+      "definition": "Malicious online advertisements that deliver malware or lead to malicious websites."
+    },
+    {
+      "term": "Eavesdropping",
+      "definition": "Unauthorized interception and monitoring of private communications, often done surreptitiously."
+    },
+    {
+      "term": "Identity Theft",
+      "definition": "The fraudulent acquisition and use of an individual's personal information to impersonate them for malicious purposes."
+    },
+    {
+      "term": "Zero-Day Vulnerability",
+      "definition": "A software vulnerability that is not yet known to the vendor or the public, making it highly valuable to attackers."
+    },
+    {
+      "term": "Security Patch",
+      "definition": "An update released by software vendors to fix security vulnerabilities in their products."
+    },
+    {
+      "term": "Cross-Site Scripting (XSS)",
+      "definition": "A type of web vulnerability where attackers inject malicious scripts into web pages viewed by other users."
+    },
+    {
+      "term": "Cross-Site Request Forgery (CSRF)",
+      "definition": "An attack that tricks a user into unknowingly submitting a malicious request on a trusted website."
+    },
+    {
+      "term": "Phishing Email",
+      "definition": "An email sent by attackers that appears legitimate but aims to trick recipients into revealing sensitive information or performing actions."
+    }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -11,25 +11,25 @@
 <body>
   <main class="container">
     <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
+      <nav class="site-nav" aria-label="Site navigation"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
     <div id="definition-container" style="display: none;"></div>
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+      <button id="random-term" aria-label="Show random term" type="button">Random Term</button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+      <button id="dark-mode-toggle" aria-label="Toggle dark mode" type="button">Toggle Dark Mode</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 
     <ul id="terms-list"></ul>
   </main>
-  <footer class="container">
+    <footer class="container" aria-label="Primary footer">
     <p><a href="templates/contribute.html">Contribute</a></p>
   </footer>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+    <button id="scrollToTopBtn" aria-label="Scroll to top" type="button">↑</button>
 
-  <footer>
+    <footer aria-label="Project footer">
     <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
   </footer>
   <script src="script.js"></script>


### PR DESCRIPTION
## Summary
- add manifest and content script for browser extension reading local JSON to show hover definitions
- include offline demo page and instructions
- fix HTML validation issues in `index.html`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4d64e0fbc8328b5e07355ee39ac66