### PR TITLE
feat: add cyber-term web component

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,18 @@ https://alex-unnippillil.github.io/CyberSecuirtyDictionary/
 
 ## Security
 For information on reporting vulnerabilities, please see our [Security Policy](SECURITY.md).
+
+## Web Component
+
+Embed individual terms on any HTML page with the `<cyber-term>` web component. Include the script and add the element with the desired `slug`:
+
+```html
+<script src="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/cyber-term.js"></script>
+<cyber-term slug="cve"></cyber-term>
+```
+
+The component fetches `terms.json` by default. You can point to a custom source with the `src` attribute:
+
+```html
+<cyber-term slug="cve" src="/path/to/terms.json"></cyber-term>
+```

--- a/component-demo.html
+++ b/component-demo.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Cyber Term Component Demo</title>
+</head>
+<body>
+  <cyber-term slug="cve" src="terms.json"></cyber-term>
+  <script src="cyber-term.js"></script>
+</body>
+</html>

--- a/cyber-term.js
+++ b/cyber-term.js
@@ -1,0 +1,54 @@
+(()=>{
+  function slugify(str){
+    return String(str).toLowerCase().replace(/[^a-z0-9]+/g,'-').replace(/(^-|-$)/g,'');
+  }
+
+  class CyberTerm extends HTMLElement{
+    async connectedCallback(){
+      if(this.shadowRoot) return; // prevent re-render
+      const slug=this.getAttribute('slug');
+      const src=this.getAttribute('src')||'terms.json';
+      if(!slug){
+        console.warn('cyber-term: missing slug attribute');
+        return;
+      }
+      try{
+        const res=await fetch(src);
+        const json=await res.json();
+        const terms=Array.isArray(json)?json:(json.terms||[]);
+        const term=terms.find(t=>{
+          const name=t.slug||t.term||t.name||'';
+          return slugify(name)===slug;
+        });
+        this.render(term,slug);
+      }catch(err){
+        console.error('cyber-term: failed to load',err);
+        this.render(null,slug,true);
+      }
+    }
+
+    render(term,slug,isError){
+      const root=this.attachShadow({mode:'open'});
+      const style=`
+        .card{border:1px solid #ccc;padding:1em;border-radius:4px;font-family:Arial,sans-serif;}
+        .card h3{margin:0 0 .5em 0;font-size:1.1em;}
+        .card.error{border-color:#f00;color:#f00;}
+      `;
+      if(isError){
+        root.innerHTML=`<style>${style}</style><div class="card error">Failed to load term</div>`;
+        return;
+      }
+      if(!term){
+        root.innerHTML=`<style>${style}</style><div class="card error">Term not found: ${slug}</div>`;
+        return;
+      }
+      const title=term.name||term.term||'';
+      const def=term.definition||'';
+      root.innerHTML=`<style>${style}</style><div class="card"><h3>${title}</h3><p>${def}</p></div>`;
+    }
+  }
+
+  if(!customElements.get('cyber-term')){
+    customElements.define('cyber-term',CyberTerm);
+  }
+})();

--- a/index.html
+++ b/index.html
@@ -11,25 +11,25 @@
 <body>
   <main class="container">
     <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
+      <nav class="site-nav" aria-label="Site navigation"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
     <div id="definition-container" style="display: none;"></div>
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+      <button id="random-term" type="button" aria-label="Show random term">Random Term</button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+      <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">Toggle Dark Mode</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 
     <ul id="terms-list"></ul>
   </main>
-  <footer class="container">
+    <footer class="container" aria-label="Main footer">
     <p><a href="templates/contribute.html">Contribute</a></p>
   </footer>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+    <button id="scrollToTopBtn" type="button" aria-label="Scroll to top">↑</button>
 
-  <footer>
+    <footer aria-label="Legal footer">
     <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
   </footer>
   <script src="script.js"></script>


### PR DESCRIPTION
## Summary
- introduce standalone `<cyber-term>` element that fetches terms and renders a card
- document web component usage and provide demo page
- add missing aria-label and button type attributes to satisfy html-validate

## Testing
- `npm test`
- `npx html-validate component-demo.html && echo "demo valid"`


------
https://chatgpt.com/codex/tasks/task_e_68b4d65013308328a70ba137b22bd45b