### PR TITLE
feat: add data import adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,10 @@ https://alex-unnippillil.github.io/CyberSecuirtyDictionary/
 
 ## Security
 For information on reporting vulnerabilities, please see our [Security Policy](SECURITY.md).
+
+## Importing terms
+
+Sample adapters for converting CSV, YAML, or JSON data into the internal term
+format are available under [`tools/importers`](tools/importers/). The internal
+format expects each term to provide a `term`, `definition`, and a list of
+`tags`. See the importer README for usage examples and sample source files.

--- a/tools/importers/README.md
+++ b/tools/importers/README.md
@@ -1,0 +1,44 @@
+# Importers
+
+Adapters convert CSV, YAML, or JSON content into the internal term format used
+by the project.
+
+## Internal term format
+
+Each term is represented as an object:
+
+```
+{ term: string, definition: string, tags: string[] }
+```
+
+## Usage
+
+```javascript
+const fs = require('fs');
+const { CSVAdapter } = require('./csv');
+
+const content = fs.readFileSync('samples/sample.csv', 'utf8');
+const adapter = new CSVAdapter();
+const terms = adapter.parse(content);
+console.log(terms);
+```
+
+The example above reads `samples/sample.csv` and produces:
+
+```json
+[
+  {
+    "term": "Phishing",
+    "definition": "An attempt to trick users into revealing information",
+    "tags": ["attack", "social"]
+  },
+  {
+    "term": "Firewall",
+    "definition": "A device that monitors and filters network traffic",
+    "tags": ["defense", "network"]
+  }
+]
+```
+
+Additional adapters for YAML (`YAMLAdapter`) and JSON (`JSONAdapter`) are also
+available. Sample source files for each format are located in `samples/`.

--- a/tools/importers/adapter.js
+++ b/tools/importers/adapter.js
@@ -1,0 +1,16 @@
+// Adapter interface for transforming external data into internal term format.
+// An adapter implements a `parse` method which accepts a string of source
+// content and returns an array of terms in the internal format:
+// { term: string, definition: string, tags: string[] }
+class Adapter {
+  /**
+   * Convert raw content into an array of terms.
+   * @param {string} content - Raw file contents.
+   * @returns {Array<{term: string, definition: string, tags: string[]}>}
+   */
+  parse(content) {
+    throw new Error('parse() must be implemented by subclasses');
+  }
+}
+
+module.exports = { Adapter };

--- a/tools/importers/csv.js
+++ b/tools/importers/csv.js
@@ -1,0 +1,33 @@
+const { Adapter } = require('./adapter');
+
+// CSV adapter: expects header row with columns term,definition,tags.
+// Tags are semicolon-separated within the tags column.
+class CSVAdapter extends Adapter {
+  parse(content) {
+    const lines = content.trim().split(/\r?\n/);
+    if (lines.length === 0) return [];
+    const headers = lines[0].split(',').map(h => h.trim().toLowerCase());
+    const termIndex = headers.indexOf('term');
+    const definitionIndex = headers.indexOf('definition');
+    const tagsIndex = headers.indexOf('tags');
+    const terms = [];
+    for (const line of lines.slice(1)) {
+      if (!line.trim()) continue;
+      const cols = line.split(',');
+      const term = cols[termIndex] ? cols[termIndex].trim() : '';
+      const definition = cols[definitionIndex] ? cols[definitionIndex].trim() : '';
+      const tags = cols[tagsIndex]
+        ? cols[tagsIndex]
+            .split(';')
+            .map(t => t.trim())
+            .filter(Boolean)
+        : [];
+      if (term && definition) {
+        terms.push({ term, definition, tags });
+      }
+    }
+    return terms;
+  }
+}
+
+module.exports = { CSVAdapter };

--- a/tools/importers/json.js
+++ b/tools/importers/json.js
@@ -1,0 +1,20 @@
+const { Adapter } = require('./adapter');
+
+// JSON adapter: expects an array of objects with term, definition, and tags.
+class JSONAdapter extends Adapter {
+  parse(content) {
+    const data = JSON.parse(content);
+    if (!Array.isArray(data)) return [];
+    return data
+      .filter(item => item.term && item.definition)
+      .map(item => ({
+        term: String(item.term),
+        definition: String(item.definition),
+        tags: Array.isArray(item.tags)
+          ? item.tags.map(t => String(t))
+          : [],
+      }));
+  }
+}
+
+module.exports = { JSONAdapter };

--- a/tools/importers/samples/sample.csv
+++ b/tools/importers/samples/sample.csv
@@ -1,0 +1,3 @@
+term,definition,tags
+Phishing,An attempt to trick users into revealing information,attack;social
+Firewall,A device that monitors and filters network traffic,defense;network

--- a/tools/importers/samples/sample.json
+++ b/tools/importers/samples/sample.json
@@ -1,0 +1,12 @@
+[
+  {
+    "term": "Phishing",
+    "definition": "An attempt to trick users into revealing information",
+    "tags": ["attack", "social"]
+  },
+  {
+    "term": "Firewall",
+    "definition": "A device that monitors and filters network traffic",
+    "tags": ["defense", "network"]
+  }
+]

--- a/tools/importers/samples/sample.yaml
+++ b/tools/importers/samples/sample.yaml
@@ -1,0 +1,10 @@
+- term: Phishing
+  definition: An attempt to trick users into revealing information
+  tags:
+    - attack
+    - social
+- term: Firewall
+  definition: A device that monitors and filters network traffic
+  tags:
+    - defense
+    - network

--- a/tools/importers/yaml.js
+++ b/tools/importers/yaml.js
@@ -1,0 +1,21 @@
+const { Adapter } = require('./adapter');
+const yaml = require('js-yaml');
+
+// YAML adapter: expects a list of objects with term, definition, and tags.
+class YAMLAdapter extends Adapter {
+  parse(content) {
+    const data = yaml.load(content);
+    if (!Array.isArray(data)) return [];
+    return data
+      .filter(item => item.term && item.definition)
+      .map(item => ({
+        term: String(item.term),
+        definition: String(item.definition),
+        tags: Array.isArray(item.tags)
+          ? item.tags.map(t => String(t))
+          : [],
+      }));
+  }
+}
+
+module.exports = { YAMLAdapter };


### PR DESCRIPTION
## Summary
- add adapter interface for importing external data
- support CSV, YAML and JSON term import
- document importers with sample inputs including tags

## Testing
- `node - <<'NODE' ...`
- `npm test` *(fails: unique-landmark, no-implicit-button-type)*

------
https://chatgpt.com/codex/tasks/task_e_68b4d65654f8832893df38290e194e92