### PR TITLE
Validate term metadata via JSON schema in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+      - name: Install dependencies
+        run: npm install
       - name: Install linters
         run: npm install --no-save eslint@8 stylelint cspell
       - name: ESLint
@@ -20,6 +22,8 @@ jobs:
         run: npx stylelint styles.css
       - name: cSpell
         run: npx cspell README.md terms.json
+      - name: Schema validation
+        run: npm test
       - name: Link checker
         uses: lycheeverse/lychee-action@v2
         with:

--- a/index.html
+++ b/index.html
@@ -11,25 +11,25 @@
 <body>
   <main class="container">
     <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
+    <nav class="site-nav" aria-label="Site navigation"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
     <div id="definition-container" style="display: none;"></div>
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+    <button type="button" id="random-term" aria-label="Show random term">Random Term</button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+    <button type="button" id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 
     <ul id="terms-list"></ul>
   </main>
-  <footer class="container">
+  <footer class="container" aria-label="Primary footer">
     <p><a href="templates/contribute.html">Contribute</a></p>
   </footer>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+  <button type="button" id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
 
-  <footer>
+  <footer aria-label="Secondary footer">
     <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
   </footer>
   <script src="script.js"></script>

--- a/package.json
+++ b/package.json
@@ -5,8 +5,9 @@
   "main": "script.js",
   "scripts": {
     "build": "node scripts/build.js",
-    "test": "html-validate index.html",
-    "watch": "chokidar \"**/*.html\" -c \"npm run build\""
+    "test": "npm run validate:terms && html-validate index.html",
+    "watch": "chokidar \"**/*.html\" -c \"npm run build\"",
+    "validate:terms": "node scripts/validate-terms.js"
   },
   "keywords": [],
   "author": "",
@@ -16,6 +17,8 @@
     "html-validate": "^10.0.0",
     "http-server": "^14.1.1",
     "js-yaml": "^4.1.0",
-    "prettier": "^3.6.2"
+    "prettier": "^3.6.2",
+    "ajv": "^8.12.0",
+    "ajv-formats": "^2.1.1"
   }
 }

--- a/schemas/term.schema.json
+++ b/schemas/term.schema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Cybersecurity Dictionary Term",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "name",
+    "slug",
+    "definition",
+    "category",
+    "synonyms",
+    "see_also",
+    "sources"
+  ],
+  "properties": {
+    "name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "slug": {
+      "type": "string",
+      "pattern": "^[a-z0-9-]+$"
+    },
+    "definition": {
+      "type": "string",
+      "minLength": 1
+    },
+    "category": {
+      "type": "string",
+      "minLength": 1
+    },
+    "synonyms": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    },
+    "see_also": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    },
+    "sources": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "format": "uri"
+      },
+      "minItems": 1
+    }
+  }
+}

--- a/scripts/validate-terms.js
+++ b/scripts/validate-terms.js
@@ -1,0 +1,34 @@
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+const Ajv = require('ajv');
+const addFormats = require('ajv-formats');
+
+const schemaPath = path.join(__dirname, '..', 'schemas', 'term.schema.json');
+const termsPath = path.join(__dirname, '..', 'data', 'terms.yaml');
+
+const schema = JSON.parse(fs.readFileSync(schemaPath, 'utf8'));
+const terms = yaml.load(fs.readFileSync(termsPath, 'utf8'));
+
+const ajv = new Ajv({ allErrors: true });
+addFormats(ajv);
+const validate = ajv.compile(schema);
+
+let hasErrors = false;
+
+terms.forEach((term, index) => {
+  const valid = validate(term);
+  if (!valid) {
+    hasErrors = true;
+    console.error(`Term ${term.name || `#${index}`} is invalid:`);
+    for (const err of validate.errors) {
+      console.error(`  ${err.instancePath || '/'} ${err.message}`);
+    }
+  }
+});
+
+if (hasErrors) {
+  process.exit(1);
+} else {
+  console.log('All terms valid.');
+}


### PR DESCRIPTION
## Summary
- add JSON schema for term entries and validation script
- integrate schema checks and html validation into CI workflow
- fix HTML landmark names and button types to satisfy validator

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4d65257d8832899c13d097d015531