### PR TITLE
Expand search queries using abbreviations

### DIFF
--- a/abbreviations.json
+++ b/abbreviations.json
@@ -1,0 +1,6 @@
+{
+  "EPP": "endpoint protection platform",
+  "APT": "advanced persistent threat",
+  "DLP": "data loss prevention",
+  "SOC": "security operations center"
+}

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -2,6 +2,7 @@
   const resultsContainer = document.getElementById('results');
   const searchInput = document.getElementById('search-box');
   let terms = [];
+  let abbreviations = {};
 
   document.addEventListener('DOMContentLoaded', () => {
     const baseUrl = window.__BASE_URL__ || '';
@@ -15,14 +16,31 @@
         console.error('Failed to load terms.json', err);
       });
 
+    fetch(`${baseUrl}/abbreviations.json`)
+      .then(r => (r.ok ? r.json() : Promise.reject(r.statusText)))
+      .then(data => {
+        abbreviations = data;
+      })
+      .catch(err => {
+        console.error('Failed to load abbreviations.json', err);
+      });
+
     searchInput.addEventListener('input', handleSearch);
   });
 
   function handleSearch(){
-    const query = searchInput.value.trim().toLowerCase();
+    const raw = searchInput.value.trim();
     resultsContainer.innerHTML = '';
-    if(!query){
+    if(!raw){
       return;
+    }
+    const expanded = abbreviations[raw.toUpperCase()];
+    const query = (expanded || raw).toLowerCase();
+    if(expanded){
+      const hint = document.createElement('div');
+      hint.className = 'search-hint';
+      hint.textContent = `Showing results for "${expanded}" (expanded from "${raw}")`;
+      resultsContainer.appendChild(hint);
     }
     const matches = terms
       .map(term => ({ term, score: score(term, query) }))

--- a/styles.css
+++ b/styles.css
@@ -326,6 +326,12 @@ body.dark-mode #alpha-nav button.active {
   border-color: #007bff;
 }
 
+.search-hint {
+  font-style: italic;
+  margin-bottom: 0.5rem;
+  color: #555;
+}
+
 @media (max-width: 480px) {
   h1 {
     font-size: 32px;

--- a/terms.json
+++ b/terms.json
@@ -37,6 +37,10 @@
       "definition": "The protection of devices like laptops, desktops, and smartphones from various security threats."
     },
     {
+      "term": "Endpoint Protection Platform (EPP)",
+      "definition": "A comprehensive solution that integrates multiple technologies to protect endpoint devices from threats like malware and exploits."
+    },
+    {
       "term": "Security Token",
       "definition": "A physical or digital device used to authenticate users or provide one-time passwords for secure access."
     },


### PR DESCRIPTION
## Summary
- add abbreviations.json mapping common acronyms to full terms
- expand search inputs and show hints when an acronym is detected
- include new entry for Endpoint Protection Platform and related styles

## Testing
- `node -e "const fs=require('fs'); const terms=require('./terms.json').terms; const abbr=require('./abbreviations.json'); const q='EPP'; const expanded=abbr[q.toUpperCase()]; const searchValue=(expanded||q).toLowerCase(); const result=terms.filter(t=>t.term.toLowerCase().includes(searchValue)); console.log(result.map(r=>r.term));"`
- `npm test` *(fails: unique-landmark, no-implicit-button-type)*

------
https://chatgpt.com/codex/tasks/task_e_68b4d65763748328985676e1b1756dd4