### PR TITLE
Add selection search via keyboard shortcut

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,27 +9,31 @@
   <link rel="canonical" id="canonical-link" href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/">
 </head>
 <body>
-  <main class="container">
-    <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
+    <main class="container">
+      <h1>Cyber Security Dictionary</h1>
+      <nav class="site-nav" aria-label="Site navigation"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
     <div id="definition-container" style="display: none;"></div>
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+      <button id="random-term" aria-label="Show random term" type="button">Random Term</button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+      <button id="dark-mode-toggle" aria-label="Toggle dark mode" type="button">Toggle Dark Mode</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 
     <ul id="terms-list"></ul>
   </main>
-  <footer class="container">
+  <aside id="selection-panel" aria-label="Search results">
+    <button id="close-selection-panel" aria-label="Close search results" type="button">×</button>
+    <div id="selection-results"></div>
+  </aside>
+  <footer class="container" aria-label="Contributor links">
     <p><a href="templates/contribute.html">Contribute</a></p>
   </footer>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+  <button id="scrollToTopBtn" aria-label="Scroll to top" type="button">↑</button>
 
-  <footer>
+  <footer aria-label="Project links">
     <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
   </footer>
   <script src="script.js"></script>

--- a/layout.html
+++ b/layout.html
@@ -23,15 +23,19 @@
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+      <button id="random-term" aria-label="Show random term" type="button">Random Term</button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+      <button id="dark-mode-toggle" aria-label="Toggle dark mode" type="button">Toggle Dark Mode</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 
     <ul id="terms-list"></ul>
   </main>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+  <aside id="selection-panel" aria-label="Search results">
+    <button id="close-selection-panel" aria-label="Close search results" type="button">×</button>
+    <div id="selection-results"></div>
+  </aside>
+  <button id="scrollToTopBtn" aria-label="Scroll to top" type="button">↑</button>
 
   <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -8,6 +8,9 @@ const showFavoritesToggle = document.getElementById("show-favorites");
 const favorites = new Set(JSON.parse(localStorage.getItem("favorites") || "[]"));
 const siteUrl = "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/";
 const canonicalLink = document.getElementById("canonical-link");
+const selectionPanel = document.getElementById("selection-panel");
+const selectionResults = document.getElementById("selection-results");
+const closeSelectionPanelBtn = document.getElementById("close-selection-panel");
 
 let currentLetterFilter = "All";
 let termsData = { terms: [] };
@@ -253,4 +256,48 @@ scrollBtn.addEventListener("click", () =>
 );
 
 definitionContainer.addEventListener("click", clearDefinition);
+
+function openSelectionPanel(query) {
+  if (!selectionPanel || !selectionResults) {
+    return;
+  }
+  const lower = query.toLowerCase();
+  selectionResults.innerHTML = "";
+  const matches = termsData.terms.filter(
+    (t) =>
+      t.term.toLowerCase().includes(lower) ||
+      (t.definition && t.definition.toLowerCase().includes(lower))
+  );
+  if (matches.length) {
+    matches.forEach((t) => {
+      const item = document.createElement("div");
+      const title = document.createElement("h4");
+      title.textContent = t.term;
+      const def = document.createElement("p");
+      def.textContent = t.definition;
+      item.appendChild(title);
+      item.appendChild(def);
+      selectionResults.appendChild(item);
+    });
+  } else {
+    selectionResults.innerHTML = `<p>No results for "${query}"</p>`;
+  }
+  selectionPanel.style.display = "block";
+}
+
+if (closeSelectionPanelBtn) {
+  closeSelectionPanelBtn.addEventListener("click", () => {
+    selectionPanel.style.display = "none";
+  });
+}
+
+document.addEventListener("keydown", (e) => {
+  if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key.toLowerCase() === "f") {
+    const selectedText = window.getSelection().toString().trim();
+    if (selectedText) {
+      e.preventDefault();
+      openSelectionPanel(selectedText);
+    }
+  }
+});
 

--- a/styles.css
+++ b/styles.css
@@ -242,6 +242,37 @@ label {
   background-color: #0056b3;
 }
 
+/* Side search panel */
+#selection-panel {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: 300px;
+  max-width: 90%;
+  height: 100%;
+  background-color: #fff;
+  border-left: 1px solid #ccc;
+  overflow-y: auto;
+  padding: 20px;
+  box-shadow: -2px 0 5px rgba(0, 0, 0, 0.1);
+  z-index: 1000;
+  display: none;
+}
+
+#selection-panel h4 {
+  margin-top: 0;
+}
+
+#close-selection-panel {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  background: none;
+  border: none;
+  font-size: 1.2em;
+  cursor: pointer;
+}
+
 /* Dark Mode styles */
 body.dark-mode {
   background-color: #121212;
@@ -324,6 +355,12 @@ body.dark-mode #alpha-nav button:focus {
 body.dark-mode #alpha-nav button.active {
   background-color: #007bff;
   border-color: #007bff;
+}
+
+body.dark-mode #selection-panel {
+  background-color: #1e1e1e;
+  border-color: #333;
+  color: #fff;
 }
 
 @media (max-width: 480px) {


### PR DESCRIPTION
## Summary
- support Ctrl+Shift+F to search selected text
- show search results in a side panel available on list and term pages
- add styling and dark mode support for the side search panel

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4d662a6cc8328ae4fed0c79deb079