### PR TITLE
Add versioned legal pages with footer selector

### DIFF
--- a/disclaimer-v2.html
+++ b/disclaimer-v2.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Disclaimer v2</title>
+</head>
+<body>
+<h1>Disclaimer (Version 2)</h1>
+<p>This is the current disclaimer for the Cyber Security Dictionary.</p>
+</body>
+</html>

--- a/docs/legal/disclaimer-v1.html
+++ b/docs/legal/disclaimer-v1.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Disclaimer v1</title>
+</head>
+<body>
+<h1>Disclaimer (Version 1)</h1>
+<p>Previous disclaimer archived for reference.</p>
+</body>
+</html>

--- a/docs/legal/legal-v1.html
+++ b/docs/legal/legal-v1.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Legal Notice v1</title>
+</head>
+<body>
+<h1>Legal Notice (Version 1)</h1>
+<p>Previous legal notice archived for reference.</p>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -11,29 +11,49 @@
 <body>
   <main class="container">
     <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
+      <nav class="site-nav" aria-label="Guidelines navigation"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
     <div id="definition-container" style="display: none;"></div>
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+      <button id="random-term" type="button" aria-label="Show random term">Random Term</button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+      <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">Toggle Dark Mode</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 
     <ul id="terms-list"></ul>
   </main>
-  <footer class="container">
-    <p><a href="templates/contribute.html">Contribute</a></p>
-  </footer>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+    <footer class="container" aria-label="Contribute">
+      <p><a href="templates/contribute.html">Contribute</a></p>
+    </footer>
+    <button id="scrollToTopBtn" type="button" aria-label="Scroll to top">↑</button>
 
-  <footer>
+    <footer aria-label="Project links">
     <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
+    <div class="version-selectors">
+      <label for="legal-version">Legal:</label>
+      <select id="legal-version">
+        <option value="legal-v2.html">v2</option>
+        <option value="docs/legal/legal-v1.html">v1</option>
+      </select>
+      <label for="disclaimer-version">Disclaimer:</label>
+      <select id="disclaimer-version">
+        <option value="disclaimer-v2.html">v2</option>
+        <option value="docs/legal/disclaimer-v1.html">v1</option>
+      </select>
+    </div>
   </footer>
   <script src="script.js"></script>
   <script src="assets/js/app.js"></script>
+  <script>
+    document.getElementById('legal-version').addEventListener('change', function() {
+      window.location.href = this.value;
+    });
+    document.getElementById('disclaimer-version').addEventListener('change', function() {
+      window.location.href = this.value;
+    });
+  </script>
 </body>
 </html>
 

--- a/layout.html
+++ b/layout.html
@@ -23,16 +23,39 @@
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+      <button id="random-term" type="button" aria-label="Show random term">Random Term</button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+      <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">Toggle Dark Mode</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 
     <ul id="terms-list"></ul>
   </main>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+    <button id="scrollToTopBtn" type="button" aria-label="Scroll to top">↑</button>
+
+  <footer>
+    <div class="version-selectors">
+      <label for="legal-version">Legal:</label>
+      <select id="legal-version">
+        <option value="legal-v2.html">v2</option>
+        <option value="docs/legal/legal-v1.html">v1</option>
+      </select>
+      <label for="disclaimer-version">Disclaimer:</label>
+      <select id="disclaimer-version">
+        <option value="disclaimer-v2.html">v2</option>
+        <option value="docs/legal/disclaimer-v1.html">v1</option>
+      </select>
+    </div>
+  </footer>
 
   <script src="script.js"></script>
+  <script>
+    document.getElementById('legal-version').addEventListener('change', function() {
+      window.location.href = this.value;
+    });
+    document.getElementById('disclaimer-version').addEventListener('change', function() {
+      window.location.href = this.value;
+    });
+  </script>
 </body>
 </html>

--- a/legal-v2.html
+++ b/legal-v2.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Legal Notice v2</title>
+</head>
+<body>
+<h1>Legal Notice (Version 2)</h1>
+<p>This is the current legal notice for the Cyber Security Dictionary.</p>
+</body>
+</html>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -1,26 +1,26 @@
 <!DOCTYPE html>
 <html lang="{{ lang }}">
-<head>
-  <meta charset="utf-8" />
-  <title>{{ title }}</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <head>
+    <meta charset="utf-8">
+    <title>{{ title }}</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <meta property="og:title" content="{{ og_title }}" />
-  <meta property="og:description" content="{{ og_description }}" />
-  <meta property="og:type" content="{{ og_type }}" />
-  <meta property="og:url" content="{{ canonical_url }}" />
-  <meta property="og:image" content="{{ og_image }}" />
+    <meta property="og:title" content="{{ og_title }}">
+    <meta property="og:description" content="{{ og_description }}">
+    <meta property="og:type" content="{{ og_type }}">
+    <meta property="og:url" content="{{ canonical_url }}">
+    <meta property="og:image" content="{{ og_image }}">
 
-  <meta name="twitter:card" content="{{ twitter_card }}" />
-  <meta name="twitter:site" content="{{ twitter_site }}" />
-  <meta name="twitter:title" content="{{ twitter_title }}" />
-  <meta name="twitter:description" content="{{ twitter_description }}" />
-  <meta name="twitter:image" content="{{ twitter_image }}" />
+    <meta name="twitter:card" content="{{ twitter_card }}">
+    <meta name="twitter:site" content="{{ twitter_site }}">
+    <meta name="twitter:title" content="{{ twitter_title }}">
+    <meta name="twitter:description" content="{{ twitter_description }}">
+    <meta name="twitter:image" content="{{ twitter_image }}">
 
-  <link rel="canonical" href="{{ canonical_url }}" />
-  <link rel="manifest" href="{{ manifest_url }}" />
-  <link rel="icon" href="{{ favicon_url }}" />
-  <link rel="stylesheet" href="{{ stylesheet_url }}" />
+    <link rel="canonical" href="{{ canonical_url }}">
+    <link rel="manifest" href="{{ manifest_url }}">
+    <link rel="icon" href="{{ favicon_url }}">
+    <link rel="stylesheet" href="{{ stylesheet_url }}">
 
   <script>
     const BASE_URL = "{{ base_url }}";
@@ -30,22 +30,42 @@
     {{ json_ld }}
   </script>
 </head>
-<body>
-  <a href="#main" class="skip-link">Skip to content</a>
-  <header role="banner">
-    <nav role="navigation" aria-label="Primary">
-      {{ navigation }}
-    </nav>
-  </header>
-  <main id="main" role="main">
-    {{ content }}
-  </main>
-  <footer role="contentinfo">
-    <ul>
-      <li><a href="{{ privacy_url }}">{{ privacy_label }}</a></li>
-      <li><a href="{{ contact_url }}">{{ contact_label }}</a></li>
-    </ul>
+  <body>
+    <a href="#main" class="skip-link">Skip to content</a>
+    <header>
+      <nav aria-label="Primary">
+        {{ navigation }}
+      </nav>
+    </header>
+    <main id="main">
+      {{ content }}
+    </main>
+    <footer>
+      <ul>
+        <li><a href="{{ privacy_url }}">{{ privacy_label }}</a></li>
+        <li><a href="{{ contact_url }}">{{ contact_label }}</a></li>
+      </ul>
+    <div class="version-selectors">
+      <label for="legal-version">Legal:</label>
+      <select id="legal-version">
+        <option value="{{ base_url }}/legal-v2.html">v2</option>
+        <option value="{{ base_url }}/docs/legal/legal-v1.html">v1</option>
+      </select>
+      <label for="disclaimer-version">Disclaimer:</label>
+      <select id="disclaimer-version">
+        <option value="{{ base_url }}/disclaimer-v2.html">v2</option>
+        <option value="{{ base_url }}/docs/legal/disclaimer-v1.html">v1</option>
+      </select>
+    </div>
   </footer>
   <script src="{{ base_url }}/assets/js/app.js"></script>
+  <script>
+    document.getElementById('legal-version').addEventListener('change', function() {
+      window.location.href = this.value;
+    });
+    document.getElementById('disclaimer-version').addEventListener('change', function() {
+      window.location.href = this.value;
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add legal and disclaimer pages with versioned filenames
- archive previous legal and disclaimer versions under docs/legal
- introduce footer version selectors and supporting script

## Testing
- `npm test`
- `npx html-validate legal-v2.html disclaimer-v2.html docs/legal/legal-v1.html docs/legal/disclaimer-v1.html`
- `npx html-validate layout.html templates/layout.html`


------
https://chatgpt.com/codex/tasks/task_e_68b4d6645e008328a7398da5a6c2bc6d