### PR TITLE
Add term lifecycle policy and stage metadata

### DIFF
--- a/data/terms.yaml
+++ b/data/terms.yaml
@@ -3,6 +3,7 @@
   definition: >-
     A public catalog of cybersecurity vulnerabilities providing unique identifiers
     for known software flaws.
+  stage: draft
   category: Vulnerability Tracking
   synonyms:
     - CVE ID
@@ -16,6 +17,7 @@
   slug: cwe
   definition: >-
     A community-developed list of common software and hardware weakness types.
+  stage: draft
   category: Weakness Classification
   synonyms:
     - Common Weakness Enumeration
@@ -28,6 +30,7 @@
   slug: cvss
   definition: >-
     A standardized scoring system for rating the severity of security vulnerabilities.
+  stage: draft
   category: Scoring System
   synonyms:
     - Common Vulnerability Scoring System
@@ -40,6 +43,7 @@
   slug: nvd
   definition: >-
     A U.S. government repository of standards-based vulnerability management data.
+  stage: draft
   category: Database
   synonyms:
     - National Vulnerability Database
@@ -53,6 +57,7 @@
   definition: >-
     A globally accessible knowledge base of adversary tactics and techniques based
     on real-world observations.
+  stage: draft
   category: Framework
   synonyms:
     - ATT&CK
@@ -66,6 +71,7 @@
   definition: >-
     A regularly updated report outlining the ten most critical web application
     security risks, published by the Open Web Application Security Project.
+  stage: draft
   category: Awareness Document
   synonyms:
     - OWASP Top Ten

--- a/docs/lifecycle.html
+++ b/docs/lifecycle.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Term Lifecycle Policy</title>
+    <link rel="stylesheet" href="../styles.css" />
+  </head>
+  <body>
+    <main class="container">
+      <h1>Term Lifecycle Policy</h1>
+      <h2>Creation</h2>
+      <p>
+        New terms start in the <strong>draft</strong> stage. Draft entries
+        include a proposed definition and sources for review.
+      </p>
+      <h2>Review</h2>
+      <p>
+        Draft terms are reviewed for accuracy, clarity, and sourcing. Once
+        approved, a term's stage is set to <strong>reviewed</strong>.
+      </p>
+      <h2>Deprecation</h2>
+      <p>
+        Reviewed terms may later become outdated. Such entries move to the
+        <strong>deprecated</strong> stage but remain visible with a note about
+        their status.
+      </p>
+      <h2>Archival</h2>
+      <p>
+        Deprecated terms that are no longer relevant are
+        <strong>archived</strong>. Archived entries are kept for historical
+        reference but are hidden from normal browsing.
+      </p>
+    </main>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,39 +1,57 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Cyber Security Dictionary</title>
-  <link rel="stylesheet" href="styles.css">
-  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet">
-  <link rel="canonical" id="canonical-link" href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/">
-</head>
-<body>
-  <main class="container">
-    <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
-    <div id="definition-container" style="display: none;"></div>
-    <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
-    <input type="text" id="search" placeholder="Search...">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cyber Security Dictionary</title>
+    <link rel="stylesheet" href="styles.css">
+    <link
+      href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap"
+      rel="stylesheet"
+    >
+    <link
+      rel="canonical"
+      id="canonical-link"
+      href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/"
+    >
+  </head>
+  <body>
+    <main class="container">
+      <h1>Cyber Security Dictionary</h1>
+      <nav class="site-nav" aria-label="Site navigation">
+        <a href="templates/guidelines.html">Definition Guidelines</a>
+      </nav>
+      <div id="definition-container" style="display: none"></div>
+      <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
+      <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+      <button id="random-term" aria-label="Show random term" type="button">
+        Random Term
+      </button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
-    <input type="checkbox" id="show-favorites" aria-label="Show favorites">
-    <label for="show-favorites">Show Favorites</label>
+      <button id="dark-mode-toggle" aria-label="Toggle dark mode" type="button">
+        Toggle Dark Mode
+      </button>
+      <input type="checkbox" id="show-favorites" aria-label="Show favorites">
+      <label for="show-favorites">Show Favorites</label>
 
-    <ul id="terms-list"></ul>
-  </main>
-  <footer class="container">
-    <p><a href="templates/contribute.html">Contribute</a></p>
-  </footer>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+      <ul id="terms-list"></ul>
+    </main>
+    <footer class="container" aria-label="Primary footer">
+      <p>
+        <a href="templates/contribute.html">Contribute</a> |
+        <a href="docs/lifecycle.html">Lifecycle Policy</a>
+      </p>
+    </footer>
+    <button id="scrollToTopBtn" aria-label="Scroll to top" type="button">↑</button>
 
-  <footer>
-    <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
-  </footer>
-  <script src="script.js"></script>
-  <script src="assets/js/app.js"></script>
-</body>
+    <footer aria-label="Secondary footer">
+      <p>
+        <a href="docs/lifecycle.html">Lifecycle Policy</a> |
+        <a href="CONTRIBUTING.md">Contribute to this project</a>
+      </p>
+    </footer>
+    <script src="script.js"></script>
+    <script src="assets/js/app.js"></script>
+  </body>
 </html>
-

--- a/script.js
+++ b/script.js
@@ -5,7 +5,9 @@ const randomButton = document.getElementById("random-term");
 const alphaNav = document.getElementById("alpha-nav");
 const darkModeToggle = document.getElementById("dark-mode-toggle");
 const showFavoritesToggle = document.getElementById("show-favorites");
-const favorites = new Set(JSON.parse(localStorage.getItem("favorites") || "[]"));
+const favorites = new Set(
+  JSON.parse(localStorage.getItem("favorites") || "[]"),
+);
 const siteUrl = "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/";
 const canonicalLink = document.getElementById("canonical-link");
 
@@ -19,7 +21,10 @@ if (localStorage.getItem("darkMode") === "true") {
 if (darkModeToggle) {
   darkModeToggle.addEventListener("click", () => {
     document.body.classList.toggle("dark-mode");
-    localStorage.setItem("darkMode", document.body.classList.contains("dark-mode"));
+    localStorage.setItem(
+      "darkMode",
+      document.body.classList.contains("dark-mode"),
+    );
   });
 }
 
@@ -43,9 +48,11 @@ function loadTerms() {
       populateTermsList();
 
       if (window.location.hash) {
-        const termFromHash = decodeURIComponent(window.location.hash.substring(1));
+        const termFromHash = decodeURIComponent(
+          window.location.hash.substring(1),
+        );
         const matchedTerm = termsData.terms.find(
-          (t) => t.term.toLowerCase() === termFromHash.toLowerCase()
+          (t) => t.term.toLowerCase() === termFromHash.toLowerCase(),
         );
         if (matchedTerm) {
           displayDefinition(matchedTerm);
@@ -56,7 +63,7 @@ function loadTerms() {
       console.error("Detailed error fetching data:", error);
       definitionContainer.style.display = "block";
       definitionContainer.innerHTML =
-        '<p>Unable to load dictionary data. Please check your connection and try again.</p>' +
+        "<p>Unable to load dictionary data. Please check your connection and try again.</p>" +
         '<button id="retry-fetch">Retry</button>';
       const retryBtn = document.getElementById("retry-fetch");
       if (retryBtn) {
@@ -97,12 +104,16 @@ function toggleFavorite(term) {
 }
 
 function highlightActiveButton(button) {
-  alphaNav.querySelectorAll("button").forEach((btn) => btn.classList.remove("active"));
+  alphaNav
+    .querySelectorAll("button")
+    .forEach((btn) => btn.classList.remove("active"));
   button.classList.add("active");
 }
 
 function buildAlphaNav() {
-  const letters = Array.from(new Set(termsData.terms.map((t) => t.term.charAt(0).toUpperCase()))).sort();
+  const letters = Array.from(
+    new Set(termsData.terms.map((t) => t.term.charAt(0).toUpperCase())),
+  ).sort();
 
   const allButton = document.createElement("button");
   allButton.textContent = "All";
@@ -134,9 +145,13 @@ function populateTermsList() {
     .sort((a, b) => a.term.localeCompare(b.term))
     .forEach((item) => {
       const matchesSearch = item.term.toLowerCase().includes(searchValue);
-      const matchesFavorites = !showFavoritesToggle || !showFavoritesToggle.checked || favorites.has(item.term);
+      const matchesFavorites =
+        !showFavoritesToggle ||
+        !showFavoritesToggle.checked ||
+        favorites.has(item.term);
       const matchesLetter =
-        currentLetterFilter === "All" || item.term.charAt(0).toUpperCase() === currentLetterFilter;
+        currentLetterFilter === "All" ||
+        item.term.charAt(0).toUpperCase() === currentLetterFilter;
       if (matchesSearch && matchesFavorites && matchesLetter) {
         const termDiv = document.createElement("div");
         termDiv.classList.add("dictionary-item");
@@ -182,12 +197,15 @@ function populateTermsList() {
 
 function displayDefinition(term) {
   definitionContainer.style.display = "block";
-  definitionContainer.innerHTML = `<h3>${term.term}</h3><p>${term.definition}</p>`;
+  const stage = term.stage
+    ? `<p class="term-stage">Stage: ${term.stage}</p>`
+    : "";
+  definitionContainer.innerHTML = `<h3>${term.term}</h3>${stage}<p>${term.definition}</p>`;
   window.location.hash = encodeURIComponent(term.term);
   if (canonicalLink) {
     canonicalLink.setAttribute(
       "href",
-      `${siteUrl}#${encodeURIComponent(term.term)}`
+      `${siteUrl}#${encodeURIComponent(term.term)}`,
     );
   }
 }
@@ -195,19 +213,27 @@ function displayDefinition(term) {
 function clearDefinition() {
   definitionContainer.style.display = "none";
   definitionContainer.innerHTML = "";
-  history.replaceState(null, "", window.location.pathname + window.location.search);
+  history.replaceState(
+    null,
+    "",
+    window.location.pathname + window.location.search,
+  );
   if (canonicalLink) {
     canonicalLink.setAttribute("href", siteUrl);
   }
 }
 
 function showRandomTerm() {
-  const randomTerm = termsData.terms[Math.floor(Math.random() * termsData.terms.length)];
+  const randomTerm =
+    termsData.terms[Math.floor(Math.random() * termsData.terms.length)];
   displayDefinition(randomTerm);
 
   const today = new Date().toDateString();
   try {
-    localStorage.setItem("lastRandomTerm", JSON.stringify({ date: today, term: randomTerm }));
+    localStorage.setItem(
+      "lastRandomTerm",
+      JSON.stringify({ date: today, term: randomTerm }),
+    );
   } catch (e) {
     // Ignore storage errors
   }
@@ -249,8 +275,7 @@ window.addEventListener("scroll", () => {
   scrollBtn.style.display = window.scrollY > 200 ? "block" : "none";
 });
 scrollBtn.addEventListener("click", () =>
-  window.scrollTo({ top: 0, behavior: "smooth" })
+  window.scrollTo({ top: 0, behavior: "smooth" }),
 );
 
 definitionContainer.addEventListener("click", clearDefinition);
-

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -1,51 +1,50 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="{{ lang }}">
-<head>
-  <meta charset="utf-8" />
-  <title>{{ title }}</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <head>
+    <meta charset="utf-8" />
+    <title>{{ title }}</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
 
-  <meta property="og:title" content="{{ og_title }}" />
-  <meta property="og:description" content="{{ og_description }}" />
-  <meta property="og:type" content="{{ og_type }}" />
-  <meta property="og:url" content="{{ canonical_url }}" />
-  <meta property="og:image" content="{{ og_image }}" />
+    <meta property="og:title" content="{{ og_title }}" />
+    <meta property="og:description" content="{{ og_description }}" />
+    <meta property="og:type" content="{{ og_type }}" />
+    <meta property="og:url" content="{{ canonical_url }}" />
+    <meta property="og:image" content="{{ og_image }}" />
 
-  <meta name="twitter:card" content="{{ twitter_card }}" />
-  <meta name="twitter:site" content="{{ twitter_site }}" />
-  <meta name="twitter:title" content="{{ twitter_title }}" />
-  <meta name="twitter:description" content="{{ twitter_description }}" />
-  <meta name="twitter:image" content="{{ twitter_image }}" />
+    <meta name="twitter:card" content="{{ twitter_card }}" />
+    <meta name="twitter:site" content="{{ twitter_site }}" />
+    <meta name="twitter:title" content="{{ twitter_title }}" />
+    <meta name="twitter:description" content="{{ twitter_description }}" />
+    <meta name="twitter:image" content="{{ twitter_image }}" />
 
-  <link rel="canonical" href="{{ canonical_url }}" />
-  <link rel="manifest" href="{{ manifest_url }}" />
-  <link rel="icon" href="{{ favicon_url }}" />
-  <link rel="stylesheet" href="{{ stylesheet_url }}" />
+    <link rel="canonical" href="{{ canonical_url }}" />
+    <link rel="manifest" href="{{ manifest_url }}" />
+    <link rel="icon" href="{{ favicon_url }}" />
+    <link rel="stylesheet" href="{{ stylesheet_url }}" />
 
-  <script>
-    const BASE_URL = "{{ base_url }}";
-  </script>
+    <script>
+      const BASE_URL = "{{ base_url }}";
+    </script>
 
-  <script type="application/ld+json">
-    {{ json_ld }}
-  </script>
-</head>
-<body>
-  <a href="#main" class="skip-link">Skip to content</a>
-  <header role="banner">
-    <nav role="navigation" aria-label="Primary">
-      {{ navigation }}
-    </nav>
-  </header>
-  <main id="main" role="main">
-    {{ content }}
-  </main>
-  <footer role="contentinfo">
-    <ul>
-      <li><a href="{{ privacy_url }}">{{ privacy_label }}</a></li>
-      <li><a href="{{ contact_url }}">{{ contact_label }}</a></li>
-    </ul>
-  </footer>
-  <script src="{{ base_url }}/assets/js/app.js"></script>
-</body>
+    <script type="application/ld+json">
+      {{ json_ld }}
+    </script>
+  </head>
+  <body>
+    <a href="#main" class="skip-link">Skip to content</a>
+    <header role="banner">
+      <nav role="navigation" aria-label="Primary">{{ navigation }}</nav>
+    </header>
+    <main id="main" role="main">{{ content }}</main>
+    <footer role="contentinfo">
+      <ul>
+        <li><a href="{{ privacy_url }}">{{ privacy_label }}</a></li>
+        <li><a href="{{ contact_url }}">{{ contact_label }}</a></li>
+        <li>
+          <a href="{{ base_url }}/docs/lifecycle.html">Lifecycle Policy</a>
+        </li>
+      </ul>
+    </footer>
+    <script src="{{ base_url }}/assets/js/app.js"></script>
+  </body>
 </html>

--- a/terms.json
+++ b/terms.json
@@ -2,135 +2,168 @@
   "terms": [
     {
       "term": "Phishing",
-      "definition": "An attempt to trick individuals into revealing sensitive information through fraudulent emails, websites, or messages."
+      "definition": "An attempt to trick individuals into revealing sensitive information through fraudulent emails, websites, or messages.",
+      "stage": "draft"
     },
     {
       "term": "Phishing Email",
-      "definition": "An email sent by attackers that appears legitimate but aims to trick recipients into revealing sensitive information or performing actions."
+      "definition": "An email sent by attackers that appears legitimate but aims to trick recipients into revealing sensitive information or performing actions.",
+      "stage": "draft"
     },
     {
       "term": "Social Engineering Toolkit (SET)",
-      "definition": "A framework for simulating social engineering attacks, helping organizations test their security awareness."
+      "definition": "A framework for simulating social engineering attacks, helping organizations test their security awareness.",
+      "stage": "draft"
     },
     {
       "term": "Advanced Persistent Threat (APT)",
-      "definition": "A prolonged and targeted cyber attack in which attackers gain and maintain unauthorized access to a network."
+      "definition": "A prolonged and targeted cyber attack in which attackers gain and maintain unauthorized access to a network.",
+      "stage": "draft"
     },
     {
       "term": "Cyber Espionage",
-      "definition": "The use of cyber techniques to steal sensitive information from governments, organizations, or individuals."
+      "definition": "The use of cyber techniques to steal sensitive information from governments, organizations, or individuals.",
+      "stage": "draft"
     },
     {
       "term": "Zero-Knowledge Proof",
-      "definition": "A cryptographic method that allows a party to prove knowledge of a secret without revealing the secret itself."
+      "definition": "A cryptographic method that allows a party to prove knowledge of a secret without revealing the secret itself.",
+      "stage": "draft"
     },
     {
       "term": "Security Operations Center (SOC)",
-      "definition": "A centralized unit that monitors, detects, and responds to cybersecurity incidents and threats in real-time."
+      "definition": "A centralized unit that monitors, detects, and responds to cybersecurity incidents and threats in real-time.",
+      "stage": "draft"
     },
     {
       "term": "Data Loss Prevention (DLP)",
-      "definition": "A strategy and set of tools to prevent the unauthorized loss or leakage of sensitive data."
+      "definition": "A strategy and set of tools to prevent the unauthorized loss or leakage of sensitive data.",
+      "stage": "draft"
     },
     {
       "term": "Endpoint Security",
-      "definition": "The protection of devices like laptops, desktops, and smartphones from various security threats."
+      "definition": "The protection of devices like laptops, desktops, and smartphones from various security threats.",
+      "stage": "draft"
     },
     {
       "term": "Security Token",
-      "definition": "A physical or digital device used to authenticate users or provide one-time passwords for secure access."
+      "definition": "A physical or digital device used to authenticate users or provide one-time passwords for secure access.",
+      "stage": "draft"
     },
     {
       "term": "Network Security",
-      "definition": "The protection of network infrastructure and data from unauthorized access or attacks."
+      "definition": "The protection of network infrastructure and data from unauthorized access or attacks.",
+      "stage": "draft"
     },
     {
       "term": "Payload",
-      "definition": "The part of a malware or exploit that performs malicious actions on a victim's system."
+      "definition": "The part of a malware or exploit that performs malicious actions on a victim's system.",
+      "stage": "draft"
     },
     {
       "term": "Cryptography",
-      "definition": "The practice of secure communication by converting plaintext into ciphertext and vice versa."
+      "definition": "The practice of secure communication by converting plaintext into ciphertext and vice versa.",
+      "stage": "draft"
     },
     {
       "term": "Social Engineering Attack Vectors",
-      "definition": "Different methods and techniques used in social engineering attacks to manipulate victims."
+      "definition": "Different methods and techniques used in social engineering attacks to manipulate victims.",
+      "stage": "draft"
     },
     {
       "term": "Threat Hunting",
-      "definition": "Proactively searching for and identifying cyber threats that have evaded traditional security measures."
+      "definition": "Proactively searching for and identifying cyber threats that have evaded traditional security measures.",
+      "stage": "draft"
     },
     {
       "term": "Incident Response",
-      "definition": "The process of managing and mitigating the impact of a cybersecurity incident or breach."
+      "definition": "The process of managing and mitigating the impact of a cybersecurity incident or breach.",
+      "stage": "draft"
     },
     {
       "term": "Privilege Escalation",
-      "definition": "The act of gaining higher levels of access or permissions in a system or network than originally granted."
+      "definition": "The act of gaining higher levels of access or permissions in a system or network than originally granted.",
+      "stage": "draft"
     },
     {
       "term": "Security Assessment",
-      "definition": "A systematic evaluation of an organization's security measures to identify vulnerabilities and weaknesses."
+      "definition": "A systematic evaluation of an organization's security measures to identify vulnerabilities and weaknesses.",
+      "stage": "draft"
     },
     {
       "term": "Data Encryption Standard (DES)",
-      "definition": "An early symmetric key encryption algorithm used to secure electronic data."
+      "definition": "An early symmetric key encryption algorithm used to secure electronic data.",
+      "stage": "draft"
     },
     {
       "term": "Advanced Encryption Standard (AES)",
-      "definition": "A widely used symmetric key encryption algorithm known for its security and efficiency."
+      "definition": "A widely used symmetric key encryption algorithm known for its security and efficiency.",
+      "stage": "draft"
     },
     {
       "term": "Public Key Infrastructure (PKI)",
-      "definition": "A system for managing digital certificates and public-private key pairs used in asymmetric encryption."
+      "definition": "A system for managing digital certificates and public-private key pairs used in asymmetric encryption.",
+      "stage": "draft"
     },
     {
       "term": "Certificate Authority (CA)",
-      "definition": "An entity responsible for issuing and managing digital certificates used in PKI."
+      "definition": "An entity responsible for issuing and managing digital certificates used in PKI.",
+      "stage": "draft"
     },
     {
       "term": "Secure Sockets Layer (SSL)",
-      "definition": "An older cryptographic protocol that provides secure communication over a computer network."
+      "definition": "An older cryptographic protocol that provides secure communication over a computer network.",
+      "stage": "draft"
     },
     {
       "term": "Transport Layer Security (TLS)",
-      "definition": "A more secure successor to SSL, providing encryption and authentication for secure communication."
+      "definition": "A more secure successor to SSL, providing encryption and authentication for secure communication.",
+      "stage": "draft"
     },
     {
       "term": "Key Exchange",
-      "definition": "The process of securely sharing encryption keys between parties to establish a secure communication channel."
+      "definition": "The process of securely sharing encryption keys between parties to establish a secure communication channel.",
+      "stage": "draft"
     },
     {
       "term": "Malvertising",
-      "definition": "Malicious online advertisements that deliver malware or lead to malicious websites."
+      "definition": "Malicious online advertisements that deliver malware or lead to malicious websites.",
+      "stage": "draft"
     },
     {
       "term": "Eavesdropping",
-      "definition": "Unauthorized interception and monitoring of private communications, often done surreptitiously."
+      "definition": "Unauthorized interception and monitoring of private communications, often done surreptitiously.",
+      "stage": "draft"
     },
     {
       "term": "Identity Theft",
-      "definition": "The fraudulent acquisition and use of an individual's personal information to impersonate them for malicious purposes."
+      "definition": "The fraudulent acquisition and use of an individual's personal information to impersonate them for malicious purposes.",
+      "stage": "draft"
     },
     {
       "term": "Zero-Day Vulnerability",
-      "definition": "A software vulnerability that is not yet known to the vendor or the public, making it highly valuable to attackers."
+      "definition": "A software vulnerability that is not yet known to the vendor or the public, making it highly valuable to attackers.",
+      "stage": "draft"
     },
     {
       "term": "Security Patch",
-      "definition": "An update released by software vendors to fix security vulnerabilities in their products."
+      "definition": "An update released by software vendors to fix security vulnerabilities in their products.",
+      "stage": "draft"
     },
     {
       "term": "Cross-Site Scripting (XSS)",
-      "definition": "A type of web vulnerability where attackers inject malicious scripts into web pages viewed by other users."
+      "definition": "A type of web vulnerability where attackers inject malicious scripts into web pages viewed by other users.",
+      "stage": "draft"
     },
     {
       "term": "Cross-Site Request Forgery (CSRF)",
-      "definition": "An attack that tricks a user into unknowingly submitting a malicious request on a trusted website."
+      "definition": "An attack that tricks a user into unknowingly submitting a malicious request on a trusted website.",
+      "stage": "draft"
     },
     {
       "term": "Phishing Email",
-      "definition": "An email sent by attackers that appears legitimate but aims to trick recipients into revealing sensitive information or performing actions."
+      "definition": "An email sent by attackers that appears legitimate but aims to trick recipients into revealing sensitive information or performing actions.",
+      "stage": "draft"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- introduce lifecycle policy page outlining term creation, review, deprecation, and archival
- add stage metadata to dictionary terms and surface the stage on definition pages
- link lifecycle policy from site footers for easy reference

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4d6643e38832880930aecb4dea867