### PR TITLE
Add accessibility statement and footer links

### DIFF
--- a/accessibility.html
+++ b/accessibility.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Accessibility Statement</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <main class="container">
+    <h1>Accessibility Statement</h1>
+    <p>We aim to make the Cyber Security Dictionary accessible to everyone.</p>
+    <section>
+      <h2>WCAG Targets</h2>
+      <p>Our goal is to conform to the Web Content Accessibility Guidelines (WCAG) 2.1 Level AA.</p>
+    </section>
+    <section>
+      <h2>Audit Cadence</h2>
+      <p>Automated and manual accessibility audits are conducted annually.</p>
+    </section>
+    <section>
+      <h2>Contact</h2>
+      <p>If you encounter accessibility barriers, please email <a href="mailto:accessibility@example.com">accessibility@example.com</a>.</p>
+    </section>
+    <section>
+      <h2>Last Audit</h2>
+      <p>The most recent accessibility review was completed on August 31, 2025.</p>
+    </section>
+  </main>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -25,12 +25,20 @@
     <ul id="terms-list"></ul>
   </main>
   <footer class="container">
-    <p><a href="templates/contribute.html">Contribute</a></p>
+    <p>
+      <a href="templates/contribute.html">Contribute</a>
+      |
+      <a href="accessibility.html">Accessibility Statement</a>
+    </p>
   </footer>
   <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
 
   <footer>
-    <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
+    <p>
+      <a href="CONTRIBUTING.md">Contribute to this project</a>
+      |
+      <a href="accessibility.html">Accessibility Statement</a>
+    </p>
   </footer>
   <script src="script.js"></script>
   <script src="assets/js/app.js"></script>

--- a/search.html
+++ b/search.html
@@ -12,6 +12,9 @@
     <input id="search-box" type="text" placeholder="Search terms..." />
     <div id="results"></div>
   </main>
+  <footer class="container">
+    <p><a href="accessibility.html">Accessibility Statement</a></p>
+  </footer>
   <script>
     window.__BASE_URL__ = window.__BASE_URL__ || '';
   </script>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -44,6 +44,7 @@
     <ul>
       <li><a href="{{ privacy_url }}">{{ privacy_label }}</a></li>
       <li><a href="{{ contact_url }}">{{ contact_label }}</a></li>
+      <li><a href="{{ base_url }}/accessibility.html">Accessibility Statement</a></li>
     </ul>
   </footer>
   <script src="{{ base_url }}/assets/js/app.js"></script>


### PR DESCRIPTION
## Summary
- add dedicated accessibility statement detailing WCAG target, audit cadence, contact, and last audit
- link new statement from site footers

## Testing
- `npx html-validate index.html accessibility.html search.html` *(fails: unique-landmark, no-implicit-button-type, void-style)*
- `npx --yes pa11y -c pa11y.json accessibility.html`
- `npx --yes pa11y -c pa11y.json index.html` *(fails: missing labels, insufficient contrast)*

------
https://chatgpt.com/codex/tasks/task_e_68b4d66569608328aa3853f83d733c96