### PR TITLE
Add external domain allowlist policy and CI enforcement

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,3 +8,4 @@
 - [ ] Added/updated terms in `data.json`
 - [ ] Ran tests (`npm test`)
 - [ ] Updated documentation if needed
+- [ ] Checked domain allowlist (`npm run domain-check`) and updated `docs/vendor-policy.md` for new domains

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
         run: npx stylelint styles.css
       - name: cSpell
         run: npx cspell README.md terms.json
+      - name: Domain allowlist
+        run: node check-allowed-domains.js
       - name: Link checker
         uses: lycheeverse/lychee-action@v2
         with:

--- a/check-allowed-domains.js
+++ b/check-allowed-domains.js
@@ -1,0 +1,46 @@
+const fs = require('fs');
+const path = require('path');
+
+if (process.env.ALLOW_NEW_DOMAINS) {
+  console.log('ALLOW_NEW_DOMAINS set; skipping domain allowlist check.');
+  process.exit(0);
+}
+
+const projectRoot = __dirname;
+const allowlistPath = path.join(projectRoot, 'docs', 'allowed-domains.json');
+const allowed = new Set(JSON.parse(fs.readFileSync(allowlistPath, 'utf8')));
+const ignoreDirs = new Set(['node_modules', '.git', 'docs']);
+const ignoreFiles = new Set(['site.config.json']);
+const domains = new Set();
+
+function walk(dir) {
+  for (const entry of fs.readdirSync(dir)) {
+    if (ignoreDirs.has(entry)) continue;
+    const full = path.join(dir, entry);
+    const stat = fs.statSync(full);
+    if (stat.isDirectory()) {
+      walk(full);
+    } else {
+      if (ignoreFiles.has(entry)) continue;
+      const content = fs.readFileSync(full, 'utf8');
+      const regex = /https?:\/\/([^\/"'\s]+)/g;
+      let match;
+      while ((match = regex.exec(content)) !== null) {
+        domains.add(match[1]);
+      }
+    }
+  }
+}
+
+walk(projectRoot);
+
+const unknown = [...domains].filter((d) => !allowed.has(d));
+
+if (unknown.length > 0) {
+  console.error('Found external domains not in allowlist:');
+  for (const d of unknown) console.error(` - ${d}`);
+  console.error('Update docs/allowed-domains.json and docs/vendor-policy.md or set ALLOW_NEW_DOMAINS=1 to override.');
+  process.exit(1);
+}
+
+console.log('All external domains are allowlisted.');

--- a/docs/allowed-domains.json
+++ b/docs/allowed-domains.json
@@ -1,0 +1,14 @@
+[
+  "alex-unnippillil.github.io",
+  "fonts.googleapis.com",
+  "github.com",
+  "nvlpubs.nist.gov",
+  "nvd.nist.gov",
+  "cve.mitre.org",
+  "cwe.mitre.org",
+  "www.first.org",
+  "attack.mitre.org",
+  "owasp.org",
+  "www.sitemaps.org",
+  "www.rfc-editor.org"
+]

--- a/docs/vendor-policy.md
+++ b/docs/vendor-policy.md
@@ -1,0 +1,22 @@
+# External Vendor Policy
+
+This project restricts references to external domains to a vetted allowlist. Any new external domain must be reviewed for security and privacy implications before inclusion. Contributors introducing a new domain must update this policy and the allowlist or request an override.
+
+## Allowed Domains
+
+| Domain | Rationale |
+| --- | --- |
+| alex-unnippillil.github.io | Host for the project's GitHub Pages site |
+| fonts.googleapis.com | Loads typography via Google Fonts |
+| github.com | Links to repository resources and assets |
+| nvlpubs.nist.gov | References to NIST publications |
+| nvd.nist.gov | Links to the National Vulnerability Database |
+| cve.mitre.org | References to CVE entries |
+| cwe.mitre.org | References to CWE definitions |
+| www.first.org | Links to FIRST security resources |
+| attack.mitre.org | References to the MITRE ATT&CK framework |
+| owasp.org | Links to OWASP guidance |
+| www.sitemaps.org | XML sitemap namespace |
+| www.rfc-editor.org | Links to relevant RFC documents |
+
+To override this policy for exceptional cases, set the environment variable `ALLOW_NEW_DOMAINS=1` in CI and include justification in the pull request.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "node scripts/build.js",
     "test": "html-validate index.html",
-    "watch": "chokidar \"**/*.html\" -c \"npm run build\""
+    "watch": "chokidar \"**/*.html\" -c \"npm run build\"",
+    "domain-check": "node check-allowed-domains.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- document allowed external domains
- enforce domain allowlist in CI
- ensure PRs confirm domain policy adherence

## Testing
- `npm run domain-check`
- `npm test` *(fails: unique-landmark, no-implicit-button-type)*

------
https://chatgpt.com/codex/tasks/task_e_68b4d66916948328a1ddd6f524b86604