### PR TITLE
Add trademark symbol guideline and linter

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "build": "node scripts/build.js",
     "test": "html-validate index.html",
-    "watch": "chokidar \"**/*.html\" -c \"npm run build\""
+    "watch": "chokidar \"**/*.html\" -c \"npm run build\"",
+    "lint:marks": "node scripts/lint-marks.js",
+    "lint:marks:fix": "node scripts/lint-marks.js --fix"
   },
   "keywords": [],
   "author": "",

--- a/scripts/lint-marks.js
+++ b/scripts/lint-marks.js
@@ -1,0 +1,32 @@
+const fs = require('fs');
+const path = require('path');
+
+const files = [
+  path.join(__dirname, '..', 'data', 'terms.yaml'),
+  path.join(__dirname, '..', 'terms.json')
+];
+
+const fix = process.argv.includes('--fix');
+let hasIssue = false;
+
+for (const file of files) {
+  if (!fs.existsSync(file)) continue;
+  let content = fs.readFileSync(file, 'utf8');
+  const lines = content.split(/\r?\n/);
+  lines.forEach((line, index) => {
+    if (/[\u00AE\u2122]/.test(line)) {
+      console.warn(`${path.relative(process.cwd(), file)}:${index + 1} contains trademark symbol`);
+      hasIssue = true;
+    }
+  });
+  if (fix) {
+    const newContent = content.replace(/[\u00AE\u2122]/g, '');
+    if (newContent !== content) {
+      fs.writeFileSync(file, newContent);
+    }
+  }
+}
+
+if (hasIssue) {
+  process.exitCode = 1;
+}

--- a/templates/guidelines.html
+++ b/templates/guidelines.html
@@ -11,6 +11,7 @@
     <h1>Definition Guidelines</h1>
     <p>Each entry in this dictionary should offer an original explanation of a term rather than copying text from other sources.</p>
     <p>Write definitions in your own words and back them with reputable sources. Include citations or links to the materials that informed your description.</p>
+    <p>Avoid including trademark (™) or registered (®) symbols in terms or definitions; use plain text instead.</p>
   </main>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- document that terms should avoid trademark (™) and registered (®) symbols
- add lint script to flag and optionally fix these symbols in term files

## Testing
- `npm run lint:marks`
- `npm test` *(fails: unique-landmark, no-implicit-button-type)*

------
https://chatgpt.com/codex/tasks/task_e_68b4d66a74788328a57a35bb2b8078a4