### PR TITLE
feat: add runtime feature flags

### DIFF
--- a/flags.json
+++ b/flags.json
@@ -1,0 +1,3 @@
+{
+  "hovercards": true
+}

--- a/index.html
+++ b/index.html
@@ -11,25 +11,25 @@
 <body>
   <main class="container">
     <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
+    <nav class="site-nav" aria-label="Definition guidelines"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
     <div id="definition-container" style="display: none;"></div>
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+    <button id="random-term" aria-label="Show random term" type="button">Random Term</button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+    <button id="dark-mode-toggle" aria-label="Toggle dark mode" type="button">Toggle Dark Mode</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 
     <ul id="terms-list"></ul>
   </main>
-  <footer class="container">
+  <footer class="container" aria-label="Primary footer">
     <p><a href="templates/contribute.html">Contribute</a></p>
   </footer>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+    <button id="scrollToTopBtn" aria-label="Scroll to top" type="button">↑</button>
 
-  <footer>
+  <footer aria-label="Secondary footer">
     <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
   </footer>
   <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -11,6 +11,7 @@ const canonicalLink = document.getElementById("canonical-link");
 
 let currentLetterFilter = "All";
 let termsData = { terms: [] };
+let featureFlags = { hovercards: false };
 
 if (localStorage.getItem("darkMode") === "true") {
   document.body.classList.add("dark-mode");
@@ -23,7 +24,20 @@ if (darkModeToggle) {
   });
 }
 
-window.addEventListener("DOMContentLoaded", () => {
+async function loadFlags() {
+  try {
+    const response = await fetch("flags.json");
+    if (response.ok) {
+      const data = await response.json();
+      featureFlags = { ...featureFlags, ...data };
+    }
+  } catch (e) {
+    console.warn("Using default feature flags:", e);
+  }
+}
+
+window.addEventListener("DOMContentLoaded", async () => {
+  await loadFlags();
   loadTerms();
 });
 
@@ -140,6 +154,9 @@ function populateTermsList() {
       if (matchesSearch && matchesFavorites && matchesLetter) {
         const termDiv = document.createElement("div");
         termDiv.classList.add("dictionary-item");
+        if (featureFlags.hovercards) {
+          termDiv.setAttribute("title", item.definition);
+        }
 
         const termHeader = document.createElement("h3");
         if (searchValue) {


### PR DESCRIPTION
## Summary
- load optional `flags.json` at startup for feature toggles
- gate hovercard tooltips behind `hovercards` flag
- fix HTML validation warnings with aria labels and button types

## Testing
- `node <<'NODE' ...` (shows hovercards flag true vs false)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4d66c490083289179064ac859497a