### PR TITLE
Add A/B experiment banner with hashed user assignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
   <link rel="canonical" id="canonical-link" href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/">
 </head>
 <body>
+  <div id="experiment-banner" role="status" aria-live="polite"></div>
   <main class="container">
     <h1>Cyber Security Dictionary</h1>
     <nav class="site-nav"><a href="templates/guidelines.html">Definition Guidelines</a></nav>

--- a/script.js
+++ b/script.js
@@ -8,6 +8,70 @@ const showFavoritesToggle = document.getElementById("show-favorites");
 const favorites = new Set(JSON.parse(localStorage.getItem("favorites") || "[]"));
 const siteUrl = "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/";
 const canonicalLink = document.getElementById("canonical-link");
+const experimentBanner = document.getElementById("experiment-banner");
+
+const experimentConfig = {
+  variants: {
+    A: 1,
+    B: 1,
+  },
+};
+
+function getOrCreateUserId() {
+  let id = localStorage.getItem("userId");
+  if (!id) {
+    id = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    try {
+      localStorage.setItem("userId", id);
+    } catch (e) {
+      // Ignore storage errors
+    }
+  }
+  return id;
+}
+
+function simpleHash(str) {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    hash = (hash << 5) - hash + str.charCodeAt(i);
+    hash |= 0;
+  }
+  return hash >>> 0;
+}
+
+function assignVariant(userId, config) {
+  const totalWeight = Object.values(config.variants).reduce(
+    (sum, weight) => sum + weight,
+    0
+  );
+  const hashValue = simpleHash(userId) % totalWeight;
+  let cumulative = 0;
+  for (const [variant, weight] of Object.entries(config.variants)) {
+    cumulative += weight;
+    if (hashValue < cumulative) {
+      return variant;
+    }
+  }
+  return Object.keys(config.variants)[0];
+}
+
+function displayExperimentBanner(variant) {
+  if (experimentBanner) {
+    experimentBanner.textContent = `Experiment Variant: ${variant}`;
+  }
+}
+
+let assignedVariant = localStorage.getItem("experimentVariant");
+if (!assignedVariant) {
+  const userId = getOrCreateUserId();
+  assignedVariant = assignVariant(userId, experimentConfig);
+  try {
+    localStorage.setItem("experimentVariant", assignedVariant);
+  } catch (e) {
+    // Ignore storage errors
+  }
+}
+displayExperimentBanner(assignedVariant);
 
 let currentLetterFilter = "All";
 let termsData = { terms: [] };

--- a/styles.css
+++ b/styles.css
@@ -13,6 +13,19 @@ body {
   overflow-x: hidden;
 }
 
+#experiment-banner {
+  padding: 10px;
+  text-align: center;
+  background-color: #ffeeba;
+  border-bottom: 1px solid #ccc;
+}
+
+body.dark-mode #experiment-banner {
+  background-color: #333;
+  border-bottom-color: #555;
+  color: #fff;
+}
+
 .container {
   max-width: 800px;
   width: 100%;


### PR DESCRIPTION
## Summary
- hash a persistent user identifier to assign experiment variants
- show an on-page banner indicating the active variant
- style banner for light and dark mode

## Testing
- `node - <<'NODE'
function simpleHash(str){let hash=0;for(let i=0;i<str.length;i++){hash=(hash<<5)-hash+str.charCodeAt(i);hash|=0;}return hash>>>0;}
function assignVariant(userId,config){const total=Object.values(config.variants).reduce((a,b)=>a+b,0);const hv=simpleHash(userId)%total;let cum=0;for(const [variant,weight] of Object.entries(config.variants)){cum+=weight;if(hv<cum){return variant;}}return Object.keys(config.variants)[0];}
const config={variants:{A:1,B:1}};let counts={A:0,B:0};for(let i=0;i<10000;i++){const v=assignVariant('user-'+i,config);counts[v]++;}
console.log(counts);
NODE`
- `npm test` *(fails: Landmarks must have a non-empty and unique accessible name (aria-label or aria-labelledby); <button> is missing recommended "type" attribute)*

------
https://chatgpt.com/codex/tasks/task_e_68b4d66d3670832890f6f2071af84323