### PR TITLE
Add outdated terms dashboard

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Outdated Terms Dashboard</title>
+</head>
+<body>
+  <h1>Outdated Terms</h1>
+  <label for="domain-filter">Filter by domain:</label>
+  <select id="domain-filter">
+    <option value="all">All</option>
+    <option value="Framework">Framework</option><option value="Scoring System">Scoring System</option><option value="Weakness Classification">Weakness Classification</option>
+  </select>
+  <ul id="terms">
+    <li data-domain="Weakness Classification"><a href="https://github.com/Alex-Unnippillil/CyberSecuirtyDictionary/edit/main/data/terms.yaml#L16">CWE</a> - Weakness Classification (last reviewed Mon May 15 2023 00:00:00 GMT+0000 (Coordinated Universal Time))</li>
+    <li data-domain="Scoring System"><a href="https://github.com/Alex-Unnippillil/CyberSecuirtyDictionary/edit/main/data/terms.yaml#L29">CVSS</a> - Scoring System (last reviewed Sat Jan 20 2024 00:00:00 GMT+0000 (Coordinated Universal Time))</li>
+    <li data-domain="Framework"><a href="https://github.com/Alex-Unnippillil/CyberSecuirtyDictionary/edit/main/data/terms.yaml#L55">MITRE ATT&CK</a> - Framework (last reviewed Tue Aug 01 2023 00:00:00 GMT+0000 (Coordinated Universal Time))</li>
+  </ul>
+  <script>
+    const filter = document.getElementById('domain-filter');
+    filter.addEventListener('change', () => {
+      const domain = filter.value;
+      document.querySelectorAll('#terms li').forEach(li => {
+        li.style.display = domain === 'all' || li.dataset.domain === domain ? '' : 'none';
+      });
+    });
+  </script>
+</body>
+</html>

--- a/data/terms.yaml
+++ b/data/terms.yaml
@@ -4,6 +4,7 @@
     A public catalog of cybersecurity vulnerabilities providing unique identifiers
     for known software flaws.
   category: Vulnerability Tracking
+  last_reviewed: 2025-06-01
   synonyms:
     - CVE ID
     - Common Vulnerabilities and Exposures
@@ -17,6 +18,7 @@
   definition: >-
     A community-developed list of common software and hardware weakness types.
   category: Weakness Classification
+  last_reviewed: 2023-05-15
   synonyms:
     - Common Weakness Enumeration
   see_also:
@@ -29,6 +31,7 @@
   definition: >-
     A standardized scoring system for rating the severity of security vulnerabilities.
   category: Scoring System
+  last_reviewed: 2024-01-20
   synonyms:
     - Common Vulnerability Scoring System
   see_also:
@@ -41,6 +44,7 @@
   definition: >-
     A U.S. government repository of standards-based vulnerability management data.
   category: Database
+  last_reviewed: 2025-03-10
   synonyms:
     - National Vulnerability Database
   see_also:
@@ -54,6 +58,7 @@
     A globally accessible knowledge base of adversary tactics and techniques based
     on real-world observations.
   category: Framework
+  last_reviewed: 2023-08-01
   synonyms:
     - ATT&CK
   see_also:
@@ -67,6 +72,7 @@
     A regularly updated report outlining the ten most critical web application
     security risks, published by the Open Web Application Security Project.
   category: Awareness Document
+  last_reviewed: 2025-04-15
   synonyms:
     - OWASP Top Ten
   see_also:

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,0 +1,71 @@
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const dataPath = path.join(__dirname, '..', 'data', 'terms.yaml');
+const fileContent = fs.readFileSync(dataPath, 'utf8');
+const terms = yaml.load(fileContent);
+
+// Map term names to starting line numbers for edit links
+const lines = fileContent.split(/\r?\n/);
+const lineMap = {};
+let lineNumber = 0;
+for (const line of lines) {
+  lineNumber += 1;
+  if (line.startsWith('- name:')) {
+    const name = line.replace('- name:', '').trim();
+    lineMap[name] = lineNumber;
+  }
+}
+
+const now = new Date();
+const oneYearMs = 365 * 24 * 60 * 60 * 1000;
+const outdated = [];
+
+for (const term of terms) {
+  if (!term.last_reviewed) continue;
+  const reviewed = new Date(term.last_reviewed);
+  if (now - reviewed > oneYearMs) {
+    outdated.push({
+      name: term.name,
+      category: term.category,
+      lastReviewed: term.last_reviewed,
+      line: lineMap[term.name] || 1,
+    });
+  }
+}
+
+const domains = Array.from(new Set(outdated.map(t => t.category))).sort();
+
+const dashboardHtml = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Outdated Terms Dashboard</title>
+</head>
+<body>
+  <h1>Outdated Terms</h1>
+  <label for="domain-filter">Filter by domain:</label>
+  <select id="domain-filter">
+    <option value="all">All</option>
+    ${domains.map(d => `<option value="${d}">${d}</option>`).join('')}
+  </select>
+  <ul id="terms">
+    ${outdated.map(t => {
+      const editUrl = `https://github.com/Alex-Unnippillil/CyberSecuirtyDictionary/edit/main/data/terms.yaml#L${t.line}`;
+      return `<li data-domain="${t.category}"><a href="${editUrl}">${t.name}</a> - ${t.category} (last reviewed ${t.lastReviewed})</li>`;
+    }).join('\n    ')}
+  </ul>
+  <script>
+    const filter = document.getElementById('domain-filter');
+    filter.addEventListener('change', () => {
+      const domain = filter.value;
+      document.querySelectorAll('#terms li').forEach(li => {
+        li.style.display = domain === 'all' || li.dataset.domain === domain ? '' : 'none';
+      });
+    });
+  </script>
+</body>
+</html>\n`;
+
+fs.writeFileSync(path.join(__dirname, '..', 'dashboard.html'), dashboardHtml);


### PR DESCRIPTION
## Summary
- add `last_reviewed` metadata to term entries
- generate dashboard listing terms not reviewed in the last year, with domain filters and edit links
- build script now writes the dashboard on each build

## Testing
- `node scripts/build.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4e4932d78832883777ce143c04944