### PR TITLE
Add search analytics processing and dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,7 @@ https://alex-unnippillil.github.io/CyberSecuirtyDictionary/
 
 ## Security
 For information on reporting vulnerabilities, please see our [Security Policy](SECURITY.md).
+
+## Analytics
+
+Run `npm run analytics` to process search query logs. This command ingests query summaries, click-through rates (CTR), and zero-result counts from `data/query-log.json` and writes the results to `analytics/analytics.json`. The `analytics.html` dashboard uses this data to render trend lines and list the top 20 queries with poor performance along with suggested alternative terms. Schedule the command to run daily (for example with cron) to keep the dashboard up to date.

--- a/analytics.html
+++ b/analytics.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Analytics Dashboard</title>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <h1>Search Analytics</h1>
+  <canvas id="trendChart" width="400" height="200"></canvas>
+  <h2>Poor Queries</h2>
+  <ul id="poor-queries"></ul>
+  <script src="assets/js/analytics-dashboard.js"></script>
+</body>
+</html>

--- a/analytics/analytics.json
+++ b/analytics/analytics.json
@@ -1,0 +1,98 @@
+{
+  "generatedAt": "2025-09-01T00:12:22.536Z",
+  "trend": [
+    {
+      "date": "2024-05-01",
+      "impressions": 150,
+      "ctr": 0.16666666666666666,
+      "zeroResults": 10
+    },
+    {
+      "date": "2024-05-02",
+      "impressions": 120,
+      "ctr": 0.08333333333333333,
+      "zeroResults": 40
+    },
+    {
+      "date": "2024-05-03",
+      "impressions": 80,
+      "ctr": 0.1875,
+      "zeroResults": 20
+    }
+  ],
+  "queries": [
+    {
+      "query": "phishing",
+      "impressions": 180,
+      "clicks": 30,
+      "zeroResults": 0,
+      "ctr": 0.16666666666666666
+    },
+    {
+      "query": "malware",
+      "impressions": 50,
+      "clicks": 5,
+      "zeroResults": 10,
+      "ctr": 0.1
+    },
+    {
+      "query": "ransomware",
+      "impressions": 40,
+      "clicks": 0,
+      "zeroResults": 40,
+      "ctr": 0
+    },
+    {
+      "query": "encryption",
+      "impressions": 60,
+      "clicks": 15,
+      "zeroResults": 0,
+      "ctr": 0.25
+    },
+    {
+      "query": "unknownterm",
+      "impressions": 20,
+      "clicks": 0,
+      "zeroResults": 20,
+      "ctr": 0
+    }
+  ],
+  "poorQueries": [
+    {
+      "query": "ransomware",
+      "impressions": 40,
+      "clicks": 0,
+      "zeroResults": 40,
+      "ctr": 0,
+      "suggestions": [
+        "Payload",
+        "Phishing",
+        "Cryptography"
+      ]
+    },
+    {
+      "query": "unknownterm",
+      "impressions": 20,
+      "clicks": 0,
+      "zeroResults": 20,
+      "ctr": 0,
+      "suggestions": [
+        "Phishing",
+        "Payload",
+        "Endpoint Security"
+      ]
+    },
+    {
+      "query": "malware",
+      "impressions": 50,
+      "clicks": 5,
+      "zeroResults": 10,
+      "ctr": 0.1,
+      "suggestions": [
+        "Payload",
+        "Phishing",
+        "Malvertising"
+      ]
+    }
+  ]
+}

--- a/assets/js/analytics-dashboard.js
+++ b/assets/js/analytics-dashboard.js
@@ -1,0 +1,38 @@
+(async function(){
+  try {
+    const res = await fetch('analytics/analytics.json');
+    const data = await res.json();
+
+    // Trend line chart
+    const ctx = document.getElementById('trendChart').getContext('2d');
+    new Chart(ctx, {
+      type: 'line',
+      data: {
+        labels: data.trend.map(t => t.date),
+        datasets: [
+          {
+            label: 'Impressions',
+            data: data.trend.map(t => t.impressions),
+            borderColor: 'blue',
+            fill: false
+          },
+          {
+            label: 'Zero Results',
+            data: data.trend.map(t => t.zeroResults),
+            borderColor: 'red',
+            fill: false
+          }
+        ]
+      }
+    });
+
+    const list = document.getElementById('poor-queries');
+    data.poorQueries.forEach(q => {
+      const li = document.createElement('li');
+      li.textContent = `${q.query} - CTR ${(q.ctr*100).toFixed(2)}% - Zero Results ${q.zeroResults}. Suggestions: ${q.suggestions.join(', ')}`;
+      list.appendChild(li);
+    });
+  } catch (err) {
+    console.error('Failed to load analytics', err);
+  }
+})();

--- a/data/query-log.json
+++ b/data/query-log.json
@@ -1,0 +1,8 @@
+[
+  {"date":"2024-05-01","query":"phishing","impressions":100,"clicks":20,"zeroResults":0},
+  {"date":"2024-05-01","query":"malware","impressions":50,"clicks":5,"zeroResults":10},
+  {"date":"2024-05-02","query":"ransomware","impressions":40,"clicks":0,"zeroResults":40},
+  {"date":"2024-05-02","query":"phishing","impressions":80,"clicks":10,"zeroResults":0},
+  {"date":"2024-05-03","query":"encryption","impressions":60,"clicks":15,"zeroResults":0},
+  {"date":"2024-05-03","query":"unknownterm","impressions":20,"clicks":0,"zeroResults":20}
+]

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "node scripts/build.js",
     "test": "html-validate index.html search.html diagnostics.html && node diagnostics.test.js",
-    "watch": "chokidar \"**/*.html\" -c \"npm run build\""
+    "watch": "chokidar \"**/*.html\" -c \"npm run build\"",
+    "analytics": "node scripts/updateAnalytics.js"
   },
   "keywords": [],
   "author": "",

--- a/scripts/updateAnalytics.js
+++ b/scripts/updateAnalytics.js
@@ -1,0 +1,83 @@
+const fs = require('fs');
+const path = require('path');
+
+// Load query log
+const logPath = path.join(__dirname, '..', 'data', 'query-log.json');
+const termsPath = path.join(__dirname, '..', 'terms.json');
+const outPath = path.join(__dirname, '..', 'analytics', 'analytics.json');
+
+function loadJSON(p){
+  return JSON.parse(fs.readFileSync(p, 'utf-8'));
+}
+
+function ensureDir(p){
+  if(!fs.existsSync(p)) fs.mkdirSync(p, {recursive: true});
+}
+
+function levenshtein(a, b){
+  const dp = Array.from({length: a.length+1}, () => Array(b.length+1).fill(0));
+  for(let i=0;i<=a.length;i++) dp[i][0] = i;
+  for(let j=0;j<=b.length;j++) dp[0][j] = j;
+  for(let i=1;i<=a.length;i++){
+    for(let j=1;j<=b.length;j++){
+      const cost = a[i-1] === b[j-1] ? 0 : 1;
+      dp[i][j] = Math.min(
+        dp[i-1][j] + 1,
+        dp[i][j-1] + 1,
+        dp[i-1][j-1] + cost
+      );
+    }
+  }
+  return dp[a.length][b.length];
+}
+
+function suggest(query, terms){
+  const scores = terms.map(t => ({term: t, score: levenshtein(query.toLowerCase(), t.toLowerCase())}));
+  scores.sort((a,b)=>a.score-b.score);
+  return scores.slice(0,3).map(s=>s.term);
+}
+
+function aggregate(){
+  const log = loadJSON(logPath);
+  const terms = loadJSON(termsPath).terms.map(t=>t.term || t.name || '');
+  const analytics = { generatedAt: new Date().toISOString(), trend: [], queries: [], poorQueries: [] };
+  const byDate = {};
+  const byQuery = {};
+
+  for(const entry of log){
+    const {date, query, impressions, clicks, zeroResults} = entry;
+    if(!byDate[date]) byDate[date] = {date, impressions:0, clicks:0, zeroResults:0};
+    if(!byQuery[query]) byQuery[query] = {query, impressions:0, clicks:0, zeroResults:0};
+    byDate[date].impressions += impressions;
+    byDate[date].clicks += clicks;
+    byDate[date].zeroResults += zeroResults;
+    byQuery[query].impressions += impressions;
+    byQuery[query].clicks += clicks;
+    byQuery[query].zeroResults += zeroResults;
+  }
+
+  analytics.trend = Object.values(byDate)
+    .sort((a,b)=>a.date.localeCompare(b.date))
+    .map(d=>({date: d.date, impressions: d.impressions, ctr: d.impressions?d.clicks/d.impressions:0, zeroResults: d.zeroResults}));
+
+  analytics.queries = Object.values(byQuery).map(q=>({
+    query: q.query,
+    impressions: q.impressions,
+    clicks: q.clicks,
+    zeroResults: q.zeroResults,
+    ctr: q.impressions ? q.clicks / q.impressions : 0
+  }));
+
+  const poor = analytics.queries
+    .filter(q=> q.zeroResults > 0 || q.ctr < 0.1)
+    .sort((a,b)=> b.zeroResults - a.zeroResults || a.ctr - b.ctr)
+    .slice(0,20)
+    .map(q=> ({...q, suggestions: suggest(q.query, terms)}));
+
+  analytics.poorQueries = poor;
+
+  ensureDir(path.dirname(outPath));
+  fs.writeFileSync(outPath, JSON.stringify(analytics, null, 2));
+}
+
+aggregate();


### PR DESCRIPTION
## Summary
- Aggregate query log data into analytics with CTR, zero-result counts, and suggestions
- Render trend charts and top poor queries in a new dashboard page
- Provide npm script and docs for daily analytics updates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4e493eb3883289a7de8cf0865e78e