### PR TITLE
Add PII scan gating to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,11 @@ jobs:
         uses: lycheeverse/lychee-action@v2
         with:
           args: --no-cache terms.json
+      - name: PII scan
+        run: npm run pii
+      - name: Upload PII report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pii-report
+          path: pii-report.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+pii-report.txt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,5 +17,8 @@ Thank you for taking the time to contribute to the Cyber Security Dictionary!
 - Make sure your changes pass tests (`npm test` if available).
 - Follow the [pull request template](.github/PULL_REQUEST_TEMPLATE.md).
 - Keep descriptions concise and clear.
+- Run `npm run pii` to ensure no PII field names are introduced. The CI pipeline
+  fails if potential PII terms are detected and stores the scan report as an
+  artifact.
 
 If you have questions, feel free to open an issue.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "node scripts/build.js",
     "test": "html-validate index.html search.html diagnostics.html && node diagnostics.test.js",
-    "watch": "chokidar \"**/*.html\" -c \"npm run build\""
+    "watch": "chokidar \"**/*.html\" -c \"npm run build\"",
+    "pii": "node pii-scan.js"
   },
   "keywords": [],
   "author": "",

--- a/pii-scan.js
+++ b/pii-scan.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const patterns = [
+  /\bssn\b/i,
+  /\bsocial\s+security\s+number\b/i,
+  /\bpassport\b/i,
+  /\blicense\s*number\b/i,
+  /\bphone\b/i,
+  /\bemail\b/i,
+  /\baddress\b/i
+];
+
+const ignoreDirs = new Set(['.git', 'node_modules']);
+const ignoreFiles = new Set(['terms.json', path.join('data', 'terms.yaml'), 'pii-scan.js']);
+const allowedExt = new Set(['.js', '.json', '.html', '.css', '.yml', '.yaml']);
+const reportLines = [];
+
+function scanFile(filePath) {
+  const content = fs.readFileSync(filePath, 'utf8');
+  for (const re of patterns) {
+    const match = content.match(re);
+    if (match) {
+      reportLines.push(`${filePath}: potential PII term "${match[0]}"`);
+    }
+  }
+}
+
+function walk(dir) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (!ignoreDirs.has(entry.name)) {
+        walk(fullPath);
+      }
+    } else {
+      const relPath = path.relative('.', fullPath);
+      if (!ignoreFiles.has(relPath) && allowedExt.has(path.extname(entry.name))) {
+        scanFile(fullPath);
+      }
+    }
+  }
+}
+
+walk('.');
+const outFile = 'pii-report.txt';
+if (reportLines.length === 0) {
+  fs.writeFileSync(outFile, 'No PII fields found.\n');
+} else {
+  fs.writeFileSync(outFile, reportLines.join('\n') + '\n');
+  console.error('PII fields detected. See pii-report.txt for details.');
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add Node-based PII scanner for common field names
- run PII scan in CI and upload report artifact
- document PII scan requirement in contributing guide

## Testing
- `npm run pii`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4e494dd1083289b58479b43eabc42