### PR TITLE
Add recommended resources page with affiliate disclosures

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,41 +1,56 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Cyber Security Dictionary</title>
-  <link rel="stylesheet" href="styles.css">
-  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet">
-  <link rel="canonical" id="canonical-link" href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/">
-</head>
-<body>
-  <main class="container">
-    <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav" aria-label="Site links"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
-    <div id="definition-container" style="display: none;"></div>
-    <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
-    <input type="text" id="search" placeholder="Search...">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cyber Security Dictionary</title>
+    <link rel="stylesheet" href="styles.css">
+    <link
+      href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap"
+      rel="stylesheet"
+    >
+    <link
+      rel="canonical"
+      id="canonical-link"
+      href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/"
+    >
+  </head>
+  <body>
+    <main class="container">
+      <h1>Cyber Security Dictionary</h1>
+      <nav class="site-nav" aria-label="Site links">
+        <a href="templates/guidelines.html">Definition Guidelines</a>
+        <a href="templates/resources.html">Recommended Resources</a>
+      </nav>
+      <div id="definition-container" style="display: none"></div>
+      <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
+      <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" type="button" aria-label="Show random term">Random Term</button>
+      <button id="random-term" type="button" aria-label="Show random term">
+        Random Term
+      </button>
 
-    <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">Toggle Dark Mode</button>
-    <input type="checkbox" id="show-favorites" aria-label="Show favorites">
-    <label for="show-favorites">Show Favorites</label>
+      <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">
+        Toggle Dark Mode
+      </button>
+      <input type="checkbox" id="show-favorites" aria-label="Show favorites">
+      <label for="show-favorites">Show Favorites</label>
 
-    <ul id="terms-list"></ul>
-  </main>
-  <footer class="container" aria-label="Contribute">
-    <p><a href="templates/contribute.html">Contribute</a></p>
-  </footer>
-  <button id="scrollToTopBtn" type="button" aria-label="Scroll to top">↑</button>
+      <ul id="terms-list"></ul>
+    </main>
+    <footer class="container" aria-label="Contribute">
+      <p><a href="templates/contribute.html">Contribute</a></p>
+    </footer>
+    <button id="scrollToTopBtn" type="button" aria-label="Scroll to top">
+      ↑
+    </button>
 
-  <footer aria-label="Project contribution">
-    <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
-  </footer>
-  <script src="script.js"></script>
-  <script src="assets/js/app.js"></script>
-  <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
-  <script src="assets/js/metrics.js"></script>
-</body>
+    <footer aria-label="Project contribution">
+      <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
+    </footer>
+    <script src="script.js"></script>
+    <script src="assets/js/app.js"></script>
+    <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
+    <script src="assets/js/metrics.js"></script>
+  </body>
 </html>
-

--- a/templates/resources.html
+++ b/templates/resources.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Recommended Resources</title>
+    <meta
+      name="description"
+      content="Recommended books and courses for learning cybersecurity."
+    >
+  </head>
+  <body>
+    <h1>Recommended Books and Courses</h1>
+    <p>
+      This page includes affiliate links. If you use these links to buy
+      something we may earn a commission at no extra cost to you. As an Amazon
+      Associate we earn from qualifying purchases.
+    </p>
+    <h2>Books</h2>
+    <ul>
+      <li>
+        <a href="https://www.amazon.com/dp/111955145X?tag=affiliate-20"
+          >Cybersecurity For Dummies</a
+        >
+        (Affiliate)
+      </li>
+      <li>
+        <a href="https://www.cl.cam.ac.uk/archive/rja14/book.html"
+          >Security Engineering (Ross Anderson)</a
+        >
+        (Non-affiliate)
+      </li>
+    </ul>
+    <h2>Courses</h2>
+    <ul>
+      <li>
+        <a href="https://www.cybrary.it/course/introduction-to-it-and-cybersecurity"
+          >Introduction to IT and Cybersecurity (Cybrary)</a
+        >
+        (Non-affiliate)
+      </li>
+      <li>
+        <a
+          href="https://www.amazon.com/dp/B06XWZ7H6B?tag=affiliate-20"
+          >Cyber Security Course – Level 1</a
+        >
+        (Affiliate)
+      </li>
+    </ul>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add resources page listing recommended books and courses with affiliate labels and disclaimer
- link resources page from home navigation

## Testing
- `npx html-validate templates/resources.html`
- `npx -y linkinator templates/resources.html`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4e495fb3483289105dfda6e41cd37