### PR TITLE
Add incident logging template and footer link

### DIFF
--- a/diagnostics.html
+++ b/diagnostics.html
@@ -16,6 +16,9 @@
       <tbody id="metrics-body"></tbody>
     </table>
   </main>
+  <footer aria-label="Incident log">
+    <p><a href="docs/incidents.md">Incident Log</a></p>
+  </footer>
   <script src="assets/js/diagnostics.js"></script>
 </body>
 </html>

--- a/docs/incidents.md
+++ b/docs/incidents.md
@@ -1,0 +1,6 @@
+# Incident Log
+
+Track site incidents. Append entries using `npm run log-incident -- "Description" "Scope"`.
+
+| Timestamp (UTC) | Description | Scope |
+|-----------------|-------------|-------|

--- a/index.html
+++ b/index.html
@@ -31,6 +31,7 @@
 
   <footer aria-label="Project contribution">
     <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
+    <p><a href="docs/incidents.md">Incident Log</a></p>
   </footer>
   <script src="script.js"></script>
   <script src="assets/js/app.js"></script>

--- a/layout.html
+++ b/layout.html
@@ -35,6 +35,9 @@
 
   <script src="script.js"></script>
   <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
+  <footer aria-label="Incident log">
+    <p><a href="docs/incidents.md">Incident Log</a></p>
+  </footer>
   <script src="assets/js/metrics.js"></script>
 </body>
 </html>

--- a/log-incident.js
+++ b/log-incident.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+const path = require('path');
+
+const [,, description, scope] = process.argv;
+
+if (!description || !scope) {
+  console.error('Usage: node log-incident.js "Description" "Scope"');
+  process.exit(1);
+}
+
+const logPath = path.join(__dirname, 'docs', 'incidents.md');
+
+if (!fs.existsSync(logPath)) {
+  const header = '# Incident Log\n\n| Timestamp (UTC) | Description | Scope |\n|-----------------|-------------|-------|\n';
+  fs.writeFileSync(logPath, header);
+}
+
+const timestamp = new Date().toISOString();
+const entry = `| ${timestamp} | ${description} | ${scope} |\n`;
+
+fs.appendFileSync(logPath, entry);
+console.log(`Logged incident at ${timestamp}`);

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "node scripts/build.js",
     "test": "html-validate index.html search.html diagnostics.html && node diagnostics.test.js",
-    "watch": "chokidar \"**/*.html\" -c \"npm run build\""
+    "watch": "chokidar \"**/*.html\" -c \"npm run build\"",
+    "log-incident": "node log-incident.js"
   },
   "keywords": [],
   "author": "",

--- a/search.html
+++ b/search.html
@@ -17,6 +17,9 @@
   </script>
   <script src="assets/js/search.js"></script>
   <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
+  <footer aria-label="Incident log">
+    <p><a href="docs/incidents.md">Incident Log</a></p>
+  </footer>
   <script src="assets/js/metrics.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add `docs/incidents.md` template for incident tracking
- provide `log-incident.js` script and npm task to append incidents
- link the incident log from site footers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4e49515548328952adb941e24faa9