### PR TITLE
Add high-value terms contribution board

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # CyberSecuirtyDictionary
+
 https://alex-unnippillil.github.io/CyberSecuirtyDictionary/
 ![image](https://github.com/Alex-Unnippillil/CyberSecuirtyDictionary/assets/24538548/c5a54c56-babb-485d-b01c-4fdfb186325b)
 
 ## Security
+
 For information on reporting vulnerabilities, please see our [Security Policy](SECURITY.md).
+
+## Contribution Board
+
+Explore the [High-Value Terms board](templates/high-value-terms.html) to see prioritized terms for each locale. Each item links to a prefilled issue template so you can quickly volunteer a definition.

--- a/high_value_terms.json
+++ b/high_value_terms.json
@@ -1,0 +1,10 @@
+{
+  "es": {
+    "localeName": "Spanish",
+    "terms": ["Zero Trust", "Threat Modeling", "Ransomware"]
+  },
+  "fr": {
+    "localeName": "French",
+    "terms": ["Phishing", "Multi-Factor Authentication"]
+  }
+}

--- a/index.html
+++ b/index.html
@@ -11,7 +11,10 @@
 <body>
   <main class="container">
     <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav" aria-label="Site links"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
+    <nav class="site-nav" aria-label="Site links">
+      <a href="templates/guidelines.html">Definition Guidelines</a>
+      <a href="templates/high-value-terms.html">High-Value Terms</a>
+    </nav>
     <div id="definition-container" style="display: none;"></div>
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">
@@ -38,4 +41,3 @@
   <script src="assets/js/metrics.js"></script>
 </body>
 </html>
-

--- a/templates/high-value-terms.html
+++ b/templates/high-value-terms.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>High-Value Terms Board - Cyber Security Dictionary</title>
+  <link rel="stylesheet" href="../styles.css">
+  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet">
+</head>
+<body>
+  <main class="container">
+    <h1>High-Value Terms by Locale</h1>
+    <p>These terms are a priority for translation or definition. Select a term to open a prefilled issue and contribute your knowledge.</p>
+    <ol>
+      <li>Choose a term for your locale.</li>
+      <li>Use the link to open an issue with details prefilled.</li>
+      <li>Add the definition and any relevant sources in the issue.</li>
+    </ol>
+    <p><em>Maintainers update this board periodically based on project needs.</em></p>
+    <div id="terms"></div>
+  </main>
+  <script>
+    fetch('../high_value_terms.json')
+      .then(response => response.json())
+      .then(data => {
+        const container = document.getElementById('terms');
+        const repoUrl = 'https://github.com/Alex-Unnippillil/CyberSecuirtyDictionary';
+        for (const [locale, info] of Object.entries(data)) {
+          const section = document.createElement('section');
+          const heading = document.createElement('h2');
+          heading.textContent = `${info.localeName} (${locale})`;
+          section.appendChild(heading);
+          const list = document.createElement('ul');
+          for (const term of info.terms) {
+            const item = document.createElement('li');
+            const link = document.createElement('a');
+            const issueUrl = `${repoUrl}/issues/new?template=new-term.yml&title=${encodeURIComponent('Add ' + term + ' (' + locale + ')')}&body=${encodeURIComponent('Term: ' + term + '\nLocale: ' + locale + '\nDefinition:\nSource:')}`;
+            link.href = issueUrl;
+            link.textContent = term;
+            item.appendChild(link);
+            list.appendChild(item);
+          }
+          section.appendChild(list);
+          container.appendChild(section);
+        }
+      });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add locale-specific board listing high-value terms with prefilled issue links
- link the board from the homepage and README

## Testing
- `npx html-validate index.html templates/high-value-terms.html`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4e49780c08328adc78bf55683977e