### PR TITLE
Add documentation for static MDX and AI expansion requirements

### DIFF
--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,0 +1,12 @@
+# Project Requirements
+
+## Static MDX Content
+- Serve static MDX files without requiring authentication.
+
+## Expand with AI
+- Provide an optional "Expand with AI" pane to enrich terms.
+- Use provider-agnostic calls so any AI backend can power expansions.
+
+## Non-goals
+- Do not implement user accounts or multi-tenant features.
+- Avoid heavy dependencies on specific vendors or platforms.


### PR DESCRIPTION
## Summary
- document serving static MDX content without auth
- outline optional "Expand with AI" pane with provider-agnostic calls
- clarify non-goals around accounts, multi-tenancy, and vendor dependencies

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4e53f8680832899cf1627a06fc505