### PR TITLE
feat: add term types and content schema

### DIFF
--- a/content/terms/_template.mdx
+++ b/content/terms/_template.mdx
@@ -1,0 +1,17 @@
+---
+title: Example Term
+slug: example-term
+definition: This is an example definition.
+category: Sample Category
+synonyms:
+  - Example
+  - Sample Term
+related:
+  - slug: another-term
+    name: Another Term
+sources:
+  - name: Example Source
+    url: https://example.com
+---
+
+Write your term content here.

--- a/lib/content.ts
+++ b/lib/content.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod';
+import type { Ref, Related, TermMeta, TermDoc } from '../types/term';
+
+export const refSchema: z.ZodType<Ref> = z.object({
+  name: z.string(),
+  url: z.string().url(),
+});
+
+export const relatedSchema: z.ZodType<Related> = z.object({
+  slug: z.string(),
+  name: z.string().optional(),
+});
+
+export const termMetaSchema: z.ZodType<TermMeta> = z.object({
+  title: z.string(),
+  slug: z.string(),
+  definition: z.string(),
+  category: z.string().optional(),
+  synonyms: z.array(z.string()).optional(),
+  related: z.array(relatedSchema).optional(),
+  sources: z.array(refSchema).optional(),
+});
+
+export const termDocSchema: z.ZodType<TermDoc> = termMetaSchema.extend({
+  body: z.string(),
+});
+
+export function parseTermFrontmatter(data: unknown): TermMeta {
+  return termMetaSchema.parse(data);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "http-server": "^14.1.1",
         "js-yaml": "^4.1.0",
         "jsdom": "^26.1.0",
-        "prettier": "^3.6.2"
+        "prettier": "^3.6.2",
+        "zod": "^4.1.5"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -2405,6 +2406,16 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.5.tgz",
+      "integrity": "sha512-rcUUZqlLJgBC33IT3PNMgsCq6TzLQEG/Ei/KTCU0PedSWRMAXoOUN+4t/0H+Q8bdnLPdqUYnvboJT0bn/229qg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "html-validate": "^10.0.0",
     "http-server": "^14.1.1",
     "js-yaml": "^4.1.0",
+    "jsdom": "^26.1.0",
     "prettier": "^3.6.2",
-    "jsdom": "^26.1.0"
+    "zod": "^4.1.5"
   }
 }

--- a/types/term.ts
+++ b/types/term.ts
@@ -1,0 +1,23 @@
+export interface Ref {
+  name: string;
+  url: string;
+}
+
+export interface Related {
+  slug: string;
+  name?: string;
+}
+
+export interface TermMeta {
+  title: string;
+  slug: string;
+  definition: string;
+  category?: string;
+  synonyms?: string[];
+  related?: Related[];
+  sources?: Ref[];
+}
+
+export interface TermDoc extends TermMeta {
+  body: string;
+}


### PR DESCRIPTION
## Summary
- define term types for references, metadata, and documents
- add Zod schemas and parser for MDX frontmatter
- provide MDX template and sample frontmatter for terms

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4e542cf2c8328873089a9bfbe497f