### PR TITLE
feat: add expandable topic support

### DIFF
--- a/api/expand/route.ts
+++ b/api/expand/route.ts
@@ -1,0 +1,14 @@
+import { expandTopic } from '../../lib/ai';
+
+/**
+ * API route that expands a topic using the configured AI provider.
+ * Expects a JSON body: `{ topic: string, prompt?: string, provider?: string }`.
+ */
+export async function POST(request: Request): Promise<Response> {
+  const { topic, prompt = '', provider } = await request.json();
+  const combined = prompt ? `${topic}\n\n${prompt}` : topic;
+  const expansion = await expandTopic(combined, provider);
+  return new Response(JSON.stringify({ expansion }), {
+    headers: { 'Content-Type': 'application/json' }
+  });
+}

--- a/api/suggest/route.ts
+++ b/api/suggest/route.ts
@@ -1,0 +1,14 @@
+import { chipsForTags } from '../../lib/prompts';
+
+/**
+ * Return prompt chips for the provided comma separated `tags` query parameter.
+ */
+export async function GET(request: Request): Promise<Response> {
+  const url = new URL(request.url);
+  const tagsParam = url.searchParams.get('tags') || '';
+  const tags = tagsParam.split(',').map((t) => t.trim()).filter(Boolean);
+  const suggestions = chipsForTags(tags);
+  return new Response(JSON.stringify({ suggestions }), {
+    headers: { 'Content-Type': 'application/json' }
+  });
+}

--- a/components/ExpandPane.ts
+++ b/components/ExpandPane.ts
@@ -1,0 +1,61 @@
+import type { PromptChip } from '../lib/prompts';
+
+/**
+ * Basic UI component that renders prompt chips and displays the expanded
+ * response returned from `/api/expand`.
+ */
+export class ExpandPane {
+  private topic: string;
+  private container: HTMLElement;
+  private resultEl: HTMLElement;
+  private chipsEl: HTMLElement;
+
+  constructor(container: HTMLElement, topic: string) {
+    this.topic = topic;
+    this.container = container;
+    this.chipsEl = document.createElement('div');
+    this.chipsEl.className = 'prompt-chips';
+    this.resultEl = document.createElement('div');
+    this.resultEl.className = 'expand-result';
+    container.appendChild(this.chipsEl);
+    container.appendChild(this.resultEl);
+  }
+
+  /** Fetch prompt suggestions based on the provided tags. */
+  async load(tags: string[]): Promise<void> {
+    const qs = encodeURIComponent(tags.join(','));
+    const res = await fetch(`/api/suggest?tags=${qs}`);
+    if (!res.ok) return;
+    const { suggestions } = await res.json();
+    this.renderChips(suggestions || []);
+  }
+
+  private renderChips(chips: PromptChip[]): void {
+    this.chipsEl.innerHTML = '';
+    for (const chip of chips) {
+      const btn = document.createElement('button');
+      btn.textContent = chip.label;
+      btn.addEventListener('click', () => {
+        this.expand(chip.prompt);
+      });
+      this.chipsEl.appendChild(btn);
+    }
+  }
+
+  /** Call the server to expand the topic using the provided prompt. */
+  async expand(prompt: string): Promise<void> {
+    this.resultEl.textContent = 'Loading...';
+    try {
+      const res = await fetch('/api/expand', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ topic: this.topic, prompt })
+      });
+      if (!res.ok) throw new Error(`Request failed: ${res.status}`);
+      const data = await res.json();
+      this.resultEl.textContent = data.expansion || '';
+    } catch (err: any) {
+      this.resultEl.textContent = err.message || 'Failed to expand topic';
+    }
+  }
+}

--- a/lib/ai.ts
+++ b/lib/ai.ts
@@ -1,0 +1,62 @@
+export type AIProvider = 'openai' | 'anthropic';
+
+/**
+ * Expand a topic using the configured AI provider. The provider can be
+ * specified explicitly or via the AI_PROVIDER environment variable.
+ */
+export async function expandTopic(
+  topic: string,
+  provider: AIProvider = (process.env.AI_PROVIDER as AIProvider) || 'openai'
+): Promise<string> {
+  switch (provider) {
+    case 'openai':
+      return openAIExpand(topic);
+    case 'anthropic':
+      return anthropicExpand(topic);
+    default:
+      throw new Error(`Unsupported AI provider: ${provider}`);
+  }
+}
+
+async function openAIExpand(topic: string): Promise<string> {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) throw new Error('Missing OPENAI_API_KEY');
+
+  const res = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`
+    },
+    body: JSON.stringify({
+      model: 'gpt-4o-mini',
+      messages: [{ role: 'user', content: `Expand on: ${topic}` }]
+    })
+  });
+  const data = await res.json();
+  // OpenAI responses may vary in structure; attempt to retrieve the text safely.
+  const text = data?.choices?.[0]?.message?.content;
+  return typeof text === 'string' ? text.trim() : '';
+}
+
+async function anthropicExpand(topic: string): Promise<string> {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) throw new Error('Missing ANTHROPIC_API_KEY');
+
+  const res = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01'
+    },
+    body: JSON.stringify({
+      model: 'claude-3-haiku-20240307',
+      max_tokens: 256,
+      messages: [{ role: 'user', content: `Expand on: ${topic}` }]
+    })
+  });
+  const data = await res.json();
+  const text = data?.content?.[0]?.text;
+  return typeof text === 'string' ? text.trim() : '';
+}

--- a/lib/prompts.ts
+++ b/lib/prompts.ts
@@ -1,0 +1,43 @@
+export interface PromptChip {
+  /** Tag associated with this chip */
+  tag: string;
+  /** Text displayed in the UI */
+  label: string;
+  /** Prompt text sent to the AI provider */
+  prompt: string;
+}
+
+// Map of known tags to prompt chips that should be offered to the user.
+// Tags can originate from the current dictionary term or user selection.
+// Each tag maps to one or more chips containing helpful prompt templates.
+export const TAG_PROMPTS: Record<string, PromptChip[]> = {
+  // Basic explanation prompts
+  explain: [
+    { tag: 'explain', label: 'Explain simply', prompt: 'Explain this topic in simple terms.' },
+    { tag: 'explain', label: 'Why it matters', prompt: 'Describe why this topic is important.' }
+  ],
+  // Provide an analogy to aid understanding
+  analogy: [
+    { tag: 'analogy', label: 'Give an analogy', prompt: 'Provide a real-world analogy.' }
+  ],
+  // Security focused prompts
+  security: [
+    { tag: 'security', label: 'Mitigation', prompt: 'How can this be mitigated or prevented?' },
+    { tag: 'security', label: 'Examples', prompt: 'Give practical security examples.' }
+  ]
+};
+
+/**
+ * Return all prompt chips for a set of tags. Duplicates (same label/prompt) are removed.
+ */
+export function chipsForTags(tags: string[]): PromptChip[] {
+  const byPrompt = new Map<string, PromptChip>();
+  for (const tag of tags) {
+    const chips = TAG_PROMPTS[tag];
+    if (!chips) continue;
+    for (const chip of chips) {
+      byPrompt.set(chip.prompt, chip);
+    }
+  }
+  return Array.from(byPrompt.values());
+}


### PR DESCRIPTION
## Summary
- map tags to prompt chips for dynamic suggestions
- build ExpandPane component with fetch to `/api/expand`
- support provider-agnostic AI topic expansion and expose `/api/suggest`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4e5444ea4832888f748692ed83b55