### PR TITLE
feat: add settings hook and shortcut overlays

### DIFF
--- a/src/components/KeyboardShortcuts.tsx
+++ b/src/components/KeyboardShortcuts.tsx
@@ -1,0 +1,49 @@
+import React, { useEffect, useState } from "react";
+
+/**
+ * KeyboardShortcuts listens for the `?` key and displays a help overlay
+ * describing available keyboard commands. Press `Escape` to close.
+ */
+export const KeyboardShortcuts: React.FC = () => {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const key = e.key;
+      if ((key === "?" || (key === "/" && e.shiftKey)) && !open) {
+        e.preventDefault();
+        setOpen(true);
+      } else if (key === "Escape" && open) {
+        setOpen(false);
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [open]);
+
+  if (!open) return null;
+
+  return (
+    <div className="keyboard-shortcuts-overlay" onClick={() => setOpen(false)}>
+      <div
+        className="keyboard-shortcuts-modal"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2>Keyboard Shortcuts</h2>
+        <ul>
+          <li>
+            <kbd>?</kbd> Open shortcuts
+          </li>
+          <li>
+            <kbd>Esc</kbd> Close
+          </li>
+          <li>
+            <kbd>/</kbd> Focus search
+          </li>
+        </ul>
+      </div>
+    </div>
+  );
+};
+
+export default KeyboardShortcuts;

--- a/src/components/SettingsSheet.tsx
+++ b/src/components/SettingsSheet.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import useSettings from "../hooks/useSettings";
+
+/**
+ * SettingsSheet renders toggle controls for each user setting.
+ * All changes are persisted using the useSettings hook.
+ */
+export const SettingsSheet: React.FC = () => {
+  const { settings, updateSetting } = useSettings();
+
+  return (
+    <div className="settings-sheet">
+      <h2>Settings</h2>
+      <label>
+        <input
+          type="checkbox"
+          checked={settings.darkMode}
+          onChange={(e) => updateSetting("darkMode", e.target.checked)}
+        />
+        Dark mode
+      </label>
+      <label>
+        <input
+          type="checkbox"
+          checked={settings.showFavorites}
+          onChange={(e) => updateSetting("showFavorites", e.target.checked)}
+        />
+        Show favorites only
+      </label>
+    </div>
+  );
+};
+
+export default SettingsSheet;

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -1,0 +1,50 @@
+import { useState, useCallback } from "react";
+
+export type SettingKey = "darkMode" | "showFavorites";
+
+export interface Settings {
+  darkMode: boolean;
+  showFavorites: boolean;
+}
+
+const DEFAULT_SETTINGS: Settings = {
+  darkMode: false,
+  showFavorites: false,
+};
+
+const STORAGE_KEY = "settings";
+
+export function useSettings() {
+  const [settings, setSettings] = useState<Settings>(() => {
+    if (typeof window === "undefined") {
+      return DEFAULT_SETTINGS;
+    }
+    try {
+      const raw = window.localStorage.getItem(STORAGE_KEY);
+      return raw
+        ? { ...DEFAULT_SETTINGS, ...JSON.parse(raw) }
+        : DEFAULT_SETTINGS;
+    } catch {
+      return DEFAULT_SETTINGS;
+    }
+  });
+
+  const updateSetting = useCallback(
+    <K extends SettingKey>(key: K, value: Settings[K]) => {
+      setSettings((prev) => {
+        const next = { ...prev, [key]: value };
+        try {
+          window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+        } catch {
+          /* ignore storage errors */
+        }
+        return next;
+      });
+    },
+    [],
+  );
+
+  return { settings, updateSetting };
+}
+
+export default useSettings;


### PR DESCRIPTION
## Summary
- add `useSettings` hook to manage localStorage-backed preferences
- create `SettingsSheet` component with toggles for dark mode and favorites
- show `KeyboardShortcuts` overlay when `?` is pressed

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4e545350c832892a15b3280f27479