### PR TITLE
feat: add term browsing pages

### DIFF
--- a/app/(main)/compare/page.tsx
+++ b/app/(main)/compare/page.tsx
@@ -1,0 +1,66 @@
+"use client";
+import React, { useEffect, useState } from "react";
+import SearchBar from "../../../components/SearchBar";
+import TermCard, { Term } from "../../../components/TermCard";
+import EmptyState from "../../../components/EmptyState";
+
+function slugify(input: string) {
+  return input
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+export default function ComparePage() {
+  const [terms, setTerms] = useState<Term[]>([]);
+  const [left, setLeft] = useState("");
+  const [right, setRight] = useState("");
+
+  useEffect(() => {
+    fetch("/terms.json")
+      .then((r) => r.json())
+      .then((data) => {
+        const mapped: Term[] = data.terms.map((t: any) => ({
+          slug: slugify(t.term),
+          title: t.term,
+          description: t.definition,
+        }));
+        setTerms(mapped);
+      });
+  }, []);
+
+  const leftTerm = terms.find(
+    (t) => t.title.toLowerCase() === left.toLowerCase(),
+  );
+  const rightTerm = terms.find(
+    (t) => t.title.toLowerCase() === right.toLowerCase(),
+  );
+
+  return (
+    <div className="max-w-4xl mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">Compare Terms</h1>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+          <SearchBar value={left} onChange={setLeft} placeholder="First term" />
+          {leftTerm ? (
+            <TermCard term={leftTerm} />
+          ) : (
+            <EmptyState message="Select a term" />
+          )}
+        </div>
+        <div>
+          <SearchBar
+            value={right}
+            onChange={setRight}
+            placeholder="Second term"
+          />
+          {rightTerm ? (
+            <TermCard term={rightTerm} />
+          ) : (
+            <EmptyState message="Select a term" />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/(main)/page.tsx
+++ b/app/(main)/page.tsx
@@ -1,0 +1,68 @@
+"use client";
+import React, { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import SearchBar from "../../components/SearchBar";
+import TermCard, { Term } from "../../components/TermCard";
+import EmptyState from "../../components/EmptyState";
+
+function slugify(input: string) {
+  return input
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+/**
+ * Main landing page with a search bar and results list. Supports keyboard
+ * navigation with arrow keys and Enter to open the selected term.
+ */
+export default function HomePage() {
+  const [query, setQuery] = useState("");
+  const [terms, setTerms] = useState<Term[]>([]);
+  const [active, setActive] = useState(0);
+  const router = useRouter();
+
+  useEffect(() => {
+    fetch("/terms.json")
+      .then((r) => r.json())
+      .then((data) => {
+        const mapped: Term[] = data.terms.map((t: any) => ({
+          slug: slugify(t.term),
+          title: t.term,
+          description: t.definition,
+        }));
+        setTerms(mapped);
+      });
+  }, []);
+
+  const results = terms.filter((t) =>
+    t.title.toLowerCase().includes(query.toLowerCase()),
+  );
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setActive((i) => Math.min(i + 1, results.length - 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setActive((i) => Math.max(i - 1, 0));
+    } else if (e.key === "Enter" && results[active]) {
+      router.push(`/term/${results[active].slug}`);
+    }
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto p-4">
+      <SearchBar value={query} onChange={setQuery} onKeyDown={handleKeyDown} />
+      <div className="mt-4">
+        {results.length === 0 && query ? (
+          <EmptyState message="No matching terms" />
+        ) : (
+          results.map((term, idx) => (
+            <TermCard key={term.slug} term={term} selected={idx === active} />
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/(main)/term/[slug]/page.tsx
+++ b/app/(main)/term/[slug]/page.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import TermBody from "../../../../components/TermBody";
+import PromptChips from "../../../../components/PromptChips";
+import ExpandPane from "../../../../components/ExpandPane";
+import TermCard, { Term } from "../../../../components/TermCard";
+import EmptyState from "../../../../components/EmptyState";
+import termsFile from "../../../../terms.json";
+
+interface TermData extends Term {
+  body: string;
+}
+
+function slugify(input: string) {
+  return input
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+async function getTerms(): Promise<TermData[]> {
+  const data = termsFile as any;
+  return data.terms.map((t: any) => ({
+    slug: slugify(t.term),
+    title: t.term,
+    description: t.definition,
+    body: `<p>${t.definition}</p>`,
+  }));
+}
+
+export default async function TermPage({
+  params,
+}: {
+  params: { slug: string };
+}) {
+  const terms = await getTerms();
+  const term = terms.find((t) => t.slug === params.slug);
+
+  if (!term) {
+    return <EmptyState message="Term not found" />;
+  }
+
+  const related = terms.filter((t) => t.slug !== term.slug).slice(0, 4);
+  const prompts = [
+    `Explain ${term.title} like I'm five`,
+    `Why is ${term.title} important?`,
+    `Give an example of ${term.title}`,
+  ];
+
+  return (
+    <div className="max-w-3xl mx-auto p-4">
+      <header className="mb-6">
+        <h1 className="text-2xl font-bold">{term.title}</h1>
+      </header>
+      <TermBody body={term.body} />
+      <section className="my-6">
+        <h2 className="font-semibold mb-2">Prompts</h2>
+        <PromptChips prompts={prompts} />
+      </section>
+      <ExpandPane summary="More information">
+        <p>{term.description}</p>
+      </ExpandPane>
+      <section className="my-8">
+        <h2 className="font-semibold mb-4">Related Terms</h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {related.map((t) => (
+            <TermCard key={t.slug} term={t} />
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/components/EmptyState.tsx
+++ b/components/EmptyState.tsx
@@ -1,0 +1,13 @@
+"use client";
+import React from "react";
+
+interface EmptyStateProps {
+  message: string;
+}
+
+/** Displays a simple message when no content is available. */
+export function EmptyState({ message }: EmptyStateProps) {
+  return <p className="text-gray-500 text-center p-8">{message}</p>;
+}
+
+export default EmptyState;

--- a/components/ExpandPane.tsx
+++ b/components/ExpandPane.tsx
@@ -1,0 +1,27 @@
+"use client";
+import React, { useState } from "react";
+
+interface ExpandPaneProps {
+  summary: string;
+  children: React.ReactNode;
+}
+
+/**
+ * A simple collapsible pane used on the term page to show extra details.
+ */
+export function ExpandPane({ summary, children }: ExpandPaneProps) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="border rounded my-4">
+      <button
+        className="w-full text-left px-4 py-2 bg-gray-100 hover:bg-gray-200"
+        onClick={() => setOpen((v) => !v)}
+      >
+        {summary}
+      </button>
+      {open && <div className="p-4">{children}</div>}
+    </div>
+  );
+}
+
+export default ExpandPane;

--- a/components/PromptChips.tsx
+++ b/components/PromptChips.tsx
@@ -1,0 +1,26 @@
+"use client";
+import React from "react";
+
+interface PromptChipsProps {
+  prompts: string[];
+  onSelect?: (prompt: string) => void;
+}
+
+/** Displays prompts as selectable chips. */
+export function PromptChips({ prompts, onSelect }: PromptChipsProps) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {prompts.map((p) => (
+        <button
+          key={p}
+          onClick={() => onSelect?.(p)}
+          className="bg-gray-200 rounded-full px-3 py-1 text-sm hover:bg-gray-300"
+        >
+          {p}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export default PromptChips;

--- a/components/SearchBar.tsx
+++ b/components/SearchBar.tsx
@@ -1,0 +1,37 @@
+"use client";
+import React, { useRef } from "react";
+
+interface SearchBarProps {
+  value: string;
+  onChange: (value: string) => void;
+  onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+  placeholder?: string;
+}
+
+/**
+ * Basic search bar used across the application. It exposes a value and
+ * change handler and forwards keyboard events to enable navigation in the
+ * parent component.
+ */
+export function SearchBar({
+  value,
+  onChange,
+  onKeyDown,
+  placeholder,
+}: SearchBarProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  return (
+    <input
+      ref={inputRef}
+      type="search"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      onKeyDown={onKeyDown}
+      placeholder={placeholder ?? "Search terms"}
+      className="border px-3 py-2 rounded w-full"
+      aria-label="Search terms"
+    />
+  );
+}
+
+export default SearchBar;

--- a/components/TermBody.tsx
+++ b/components/TermBody.tsx
@@ -1,0 +1,16 @@
+"use client";
+import React from "react";
+
+interface TermBodyProps {
+  body: string;
+}
+
+/**
+ * Renders the main body of a term. The body is treated as HTML produced
+ * by markdown.
+ */
+export function TermBody({ body }: TermBodyProps) {
+  return <div className="prose" dangerouslySetInnerHTML={{ __html: body }} />;
+}
+
+export default TermBody;

--- a/components/TermCard.tsx
+++ b/components/TermCard.tsx
@@ -1,0 +1,33 @@
+"use client";
+import React from "react";
+import Link from "next/link";
+
+export interface Term {
+  slug: string;
+  title: string;
+  description?: string;
+}
+
+interface TermCardProps {
+  term: Term;
+  selected?: boolean;
+}
+
+/**
+ * Displays a single term in search results or grids.
+ */
+export function TermCard({ term, selected }: TermCardProps) {
+  return (
+    <Link
+      href={`/term/${term.slug}`}
+      className={`block border rounded p-4 mb-2 no-underline hover:bg-gray-100 ${selected ? "bg-gray-100" : ""}`}
+    >
+      <h3 className="font-semibold">{term.title}</h3>
+      {term.description && (
+        <p className="text-sm text-gray-600">{term.description}</p>
+      )}
+    </Link>
+  );
+}
+
+export default TermCard;


### PR DESCRIPTION
## Summary
- add search page with keyboard navigation and term results
- add term page rendering metadata, prompts, and related terms
- add compare page and shared components

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4e5462a4883288a8da14ee3bef7f5