### PR TITLE
Generate static term pages and lazy-load heavy components

### DIFF
--- a/assets/js/expand-pane.js
+++ b/assets/js/expand-pane.js
@@ -1,0 +1,19 @@
+export default function expandPane(container, contentHtml) {
+  const wrapper = document.createElement("div");
+  const toggle = document.createElement("button");
+  toggle.textContent = "Expand";
+  const content = document.createElement("div");
+  content.innerHTML = contentHtml;
+  content.style.display = "none";
+
+  toggle.addEventListener("click", (e) => {
+    e.stopPropagation();
+    const open = content.style.display === "block";
+    content.style.display = open ? "none" : "block";
+    toggle.textContent = open ? "Expand" : "Collapse";
+  });
+
+  wrapper.appendChild(toggle);
+  wrapper.appendChild(content);
+  container.appendChild(wrapper);
+}

--- a/assets/js/mdx-block.js
+++ b/assets/js/mdx-block.js
@@ -1,0 +1,6 @@
+export function renderMDX(source) {
+  const div = document.createElement("div");
+  // Placeholder for MDX rendering. In production, compile MDX to HTML.
+  div.innerHTML = source;
+  return div.innerHTML;
+}

--- a/assets/js/metrics.js
+++ b/assets/js/metrics.js
@@ -1,9 +1,9 @@
 (function () {
-  const KEY = 'web-vitals';
+  const KEY = "web-vitals";
 
   function storeSample(sample) {
     try {
-      const samples = JSON.parse(localStorage.getItem(KEY) || '[]');
+      const samples = JSON.parse(localStorage.getItem(KEY) || "[]");
       samples.push(sample);
       while (samples.length > 20) samples.shift();
       localStorage.setItem(KEY, JSON.stringify(samples));
@@ -24,19 +24,31 @@
       sample.cls = value;
     });
 
-    window.addEventListener('load', () => {
-      const tasks = performance.getEntriesByType('longtask');
+    window.addEventListener("load", () => {
+      const tasks = performance.getEntriesByType("longtask");
       sample.tbt = tasks.reduce(
         (sum, task) => sum + Math.max(0, task.duration - 50),
-        0
+        0,
       );
       setTimeout(() => storeSample(sample), 0);
+      setTimeout(() => sendToVercel(sample), 0);
     });
   }
 
-  if (document.readyState === 'complete') {
+  if (document.readyState === "complete") {
     init();
   } else {
-    window.addEventListener('DOMContentLoaded', init);
+    window.addEventListener("DOMContentLoaded", init);
   }
 })();
+
+function sendToVercel(sample) {
+  try {
+    const id = window.VERCEL_ANALYTICS_ID;
+    if (!id || !navigator.sendBeacon) return;
+    const body = JSON.stringify({ id, ...sample });
+    navigator.sendBeacon("https://vitals.vercel-insights.com/v1/vitals", body);
+  } catch (e) {
+    // ignore network errors
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1,41 +1,63 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Cyber Security Dictionary</title>
-  <link rel="stylesheet" href="styles.css">
-  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet">
-  <link rel="canonical" id="canonical-link" href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/">
-</head>
-<body>
-  <main class="container">
-    <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav" aria-label="Site links"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
-    <div id="definition-container" style="display: none;"></div>
-    <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
-    <input type="text" id="search" placeholder="Search...">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Cyber Security Dictionary</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="stylesheet" href="styles.css" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      rel="canonical"
+      id="canonical-link"
+      href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/"
+    />
+  </head>
+  <body>
+    <main class="container">
+      <h1>Cyber Security Dictionary</h1>
+      <nav class="site-nav" aria-label="Site links">
+        <a href="templates/guidelines.html">Definition Guidelines</a>
+      </nav>
+      <div id="definition-container" style="display: none"></div>
+      <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
+      <input type="text" id="search" placeholder="Search..." />
 
-    <button id="random-term" type="button" aria-label="Show random term">Random Term</button>
+      <button id="random-term" type="button" aria-label="Show random term">
+        Random Term
+      </button>
 
-    <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">Toggle Dark Mode</button>
-    <input type="checkbox" id="show-favorites" aria-label="Show favorites">
-    <label for="show-favorites">Show Favorites</label>
+      <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">
+        Toggle Dark Mode
+      </button>
+      <input type="checkbox" id="show-favorites" aria-label="Show favorites" />
+      <label for="show-favorites">Show Favorites</label>
 
-    <ul id="terms-list"></ul>
-  </main>
-  <footer class="container" aria-label="Contribute">
-    <p><a href="templates/contribute.html">Contribute</a></p>
-  </footer>
-  <button id="scrollToTopBtn" type="button" aria-label="Scroll to top">↑</button>
+      <ul id="terms-list"></ul>
+    </main>
+    <footer class="container" aria-label="Contribute">
+      <p><a href="templates/contribute.html">Contribute</a></p>
+    </footer>
+    <button id="scrollToTopBtn" type="button" aria-label="Scroll to top">
+      ↑
+    </button>
 
-  <footer aria-label="Project contribution">
-    <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
-  </footer>
-  <script src="script.js"></script>
-  <script src="assets/js/app.js"></script>
-  <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
-  <script src="assets/js/metrics.js"></script>
-</body>
+    <footer aria-label="Project contribution">
+      <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
+    </footer>
+    <script>
+      window.VERCEL_ANALYTICS_ID = "CSDICT-ANALYTICS";
+    </script>
+    <script defer src="script.js"></script>
+    <script defer src="assets/js/app.js"></script>
+    <script
+      defer
+      src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"
+    ></script>
+    <script defer src="assets/js/metrics.js"></script>
+  </body>
 </html>
-

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/",
   "main": "script.js",
   "scripts": {
-    "build": "node scripts/build.js",
+    "build": "node scripts/generate-terms.js",
     "test": "html-validate index.html search.html diagnostics.html && node diagnostics.test.js",
     "watch": "chokidar \"**/*.html\" -c \"npm run build\""
   },

--- a/script.js
+++ b/script.js
@@ -5,7 +5,9 @@ const randomButton = document.getElementById("random-term");
 const alphaNav = document.getElementById("alpha-nav");
 const darkModeToggle = document.getElementById("dark-mode-toggle");
 const showFavoritesToggle = document.getElementById("show-favorites");
-const favorites = new Set(JSON.parse(localStorage.getItem("favorites") || "[]"));
+const favorites = new Set(
+  JSON.parse(localStorage.getItem("favorites") || "[]"),
+);
 const siteUrl = "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/";
 const canonicalLink = document.getElementById("canonical-link");
 
@@ -19,7 +21,10 @@ if (localStorage.getItem("darkMode") === "true") {
 if (darkModeToggle) {
   darkModeToggle.addEventListener("click", () => {
     document.body.classList.toggle("dark-mode");
-    localStorage.setItem("darkMode", document.body.classList.contains("dark-mode"));
+    localStorage.setItem(
+      "darkMode",
+      document.body.classList.contains("dark-mode"),
+    );
   });
 }
 
@@ -43,9 +48,11 @@ function loadTerms() {
       populateTermsList();
 
       if (window.location.hash) {
-        const termFromHash = decodeURIComponent(window.location.hash.substring(1));
+        const termFromHash = decodeURIComponent(
+          window.location.hash.substring(1),
+        );
         const matchedTerm = termsData.terms.find(
-          (t) => t.term.toLowerCase() === termFromHash.toLowerCase()
+          (t) => t.term.toLowerCase() === termFromHash.toLowerCase(),
         );
         if (matchedTerm) {
           displayDefinition(matchedTerm);
@@ -56,7 +63,7 @@ function loadTerms() {
       console.error("Detailed error fetching data:", error);
       definitionContainer.style.display = "block";
       definitionContainer.innerHTML =
-        '<p>Unable to load dictionary data. Please check your connection and try again.</p>' +
+        "<p>Unable to load dictionary data. Please check your connection and try again.</p>" +
         '<button id="retry-fetch">Retry</button>';
       const retryBtn = document.getElementById("retry-fetch");
       if (retryBtn) {
@@ -97,12 +104,16 @@ function toggleFavorite(term) {
 }
 
 function highlightActiveButton(button) {
-  alphaNav.querySelectorAll("button").forEach((btn) => btn.classList.remove("active"));
+  alphaNav
+    .querySelectorAll("button")
+    .forEach((btn) => btn.classList.remove("active"));
   button.classList.add("active");
 }
 
 function buildAlphaNav() {
-  const letters = Array.from(new Set(termsData.terms.map((t) => t.term.charAt(0).toUpperCase()))).sort();
+  const letters = Array.from(
+    new Set(termsData.terms.map((t) => t.term.charAt(0).toUpperCase())),
+  ).sort();
 
   const allButton = document.createElement("button");
   allButton.textContent = "All";
@@ -134,9 +145,13 @@ function populateTermsList() {
     .sort((a, b) => a.term.localeCompare(b.term))
     .forEach((item) => {
       const matchesSearch = item.term.toLowerCase().includes(searchValue);
-      const matchesFavorites = !showFavoritesToggle || !showFavoritesToggle.checked || favorites.has(item.term);
+      const matchesFavorites =
+        !showFavoritesToggle ||
+        !showFavoritesToggle.checked ||
+        favorites.has(item.term);
       const matchesLetter =
-        currentLetterFilter === "All" || item.term.charAt(0).toUpperCase() === currentLetterFilter;
+        currentLetterFilter === "All" ||
+        item.term.charAt(0).toUpperCase() === currentLetterFilter;
       if (matchesSearch && matchesFavorites && matchesLetter) {
         const termDiv = document.createElement("div");
         termDiv.classList.add("dictionary-item");
@@ -180,14 +195,30 @@ function populateTermsList() {
     });
 }
 
-function displayDefinition(term) {
+async function displayDefinition(term) {
   definitionContainer.style.display = "block";
-  definitionContainer.innerHTML = `<h3>${term.term}</h3><p>${term.definition}</p>`;
+  definitionContainer.innerHTML = `<h3>${term.term}</h3>`;
+
+  if (term.mdx) {
+    const { renderMDX } = await import("./assets/js/mdx-block.js");
+    definitionContainer.innerHTML += renderMDX(term.mdx);
+  } else {
+    const content = `<p>${term.definition}</p>`;
+    if (term.definition && term.definition.length > 280) {
+      const { default: expandPane } = await import(
+        "./assets/js/expand-pane.js"
+      );
+      expandPane(definitionContainer, content);
+    } else {
+      definitionContainer.innerHTML += content;
+    }
+  }
+
   window.location.hash = encodeURIComponent(term.term);
   if (canonicalLink) {
     canonicalLink.setAttribute(
       "href",
-      `${siteUrl}#${encodeURIComponent(term.term)}`
+      `${siteUrl}#${encodeURIComponent(term.term)}`,
     );
   }
 }
@@ -195,19 +226,27 @@ function displayDefinition(term) {
 function clearDefinition() {
   definitionContainer.style.display = "none";
   definitionContainer.innerHTML = "";
-  history.replaceState(null, "", window.location.pathname + window.location.search);
+  history.replaceState(
+    null,
+    "",
+    window.location.pathname + window.location.search,
+  );
   if (canonicalLink) {
     canonicalLink.setAttribute("href", siteUrl);
   }
 }
 
 function showRandomTerm() {
-  const randomTerm = termsData.terms[Math.floor(Math.random() * termsData.terms.length)];
+  const randomTerm =
+    termsData.terms[Math.floor(Math.random() * termsData.terms.length)];
   displayDefinition(randomTerm);
 
   const today = new Date().toDateString();
   try {
-    localStorage.setItem("lastRandomTerm", JSON.stringify({ date: today, term: randomTerm }));
+    localStorage.setItem(
+      "lastRandomTerm",
+      JSON.stringify({ date: today, term: randomTerm }),
+    );
   } catch (e) {
     // Ignore storage errors
   }
@@ -249,8 +288,7 @@ window.addEventListener("scroll", () => {
   scrollBtn.style.display = window.scrollY > 200 ? "block" : "none";
 });
 scrollBtn.addEventListener("click", () =>
-  window.scrollTo({ top: 0, behavior: "smooth" })
+  window.scrollTo({ top: 0, behavior: "smooth" }),
 );
 
 definitionContainer.addEventListener("click", clearDefinition);
-

--- a/scripts/generate-terms.js
+++ b/scripts/generate-terms.js
@@ -1,0 +1,45 @@
+const fs = require("fs");
+const path = require("path");
+
+const termsPath = path.join(__dirname, "..", "terms.json");
+const data = JSON.parse(fs.readFileSync(termsPath, "utf8"));
+
+const termsDir = path.join(__dirname, "..", "terms");
+fs.mkdirSync(termsDir, { recursive: true });
+
+const baseUrl =
+  "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms";
+const urls = [];
+
+function slugify(term) {
+  return term
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+for (const term of data.terms) {
+  const slug = slugify(term.term);
+  const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>${term.term}</title>
+  <link rel="canonical" href="${baseUrl}/${slug}.html" />
+</head>
+<body>
+  <h1>${term.term}</h1>
+  <p>${term.definition}</p>
+</body>
+</html>`;
+  fs.writeFileSync(path.join(termsDir, `${slug}.html`), html);
+  urls.push(`${baseUrl}/${slug}.html`);
+}
+
+const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urls.map((u) => `  <url><loc>${u}</loc></url>`).join("\n")}
+</urlset>
+`;
+
+fs.writeFileSync(path.join(__dirname, "..", "sitemap.xml"), sitemap);

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/phishing.html</loc></url>
+  <url><loc>https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/phishing-email.html</loc></url>
+  <url><loc>https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/social-engineering-toolkit-set.html</loc></url>
+  <url><loc>https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/advanced-persistent-threat-apt.html</loc></url>
+  <url><loc>https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/cyber-espionage.html</loc></url>
+  <url><loc>https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/zero-knowledge-proof.html</loc></url>
+  <url><loc>https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/security-operations-center-soc.html</loc></url>
+  <url><loc>https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/data-loss-prevention-dlp.html</loc></url>
+  <url><loc>https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/endpoint-security.html</loc></url>
+  <url><loc>https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/security-token.html</loc></url>
+  <url><loc>https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/network-security.html</loc></url>
+  <url><loc>https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/payload.html</loc></url>
+  <url><loc>https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/cryptography.html</loc></url>
+  <url><loc>https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/social-engineering-attack-vectors.html</loc></url>
+  <url><loc>https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/threat-hunting.html</loc></url>
+  <url><loc>https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/incident-response.html</loc></url>
+  <url><loc>https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/privilege-escalation.html</loc></url>
+  <url><loc>https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/security-assessment.html</loc></url>
+  <url><loc>https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/data-encryption-standard-des.html</loc></url>
+  <url><loc>https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/advanced-encryption-standard-aes.html</loc></url>
+  <url><loc>https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/public-key-infrastructure-pki.html</loc></url>
+  <url><loc>https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/certificate-authority-ca.html</loc></url>
+  <url><loc>https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/secure-sockets-layer-ssl.html</loc></url>
+  <url><loc>https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/transport-layer-security-tls.html</loc></url>
+  <url><loc>https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/key-exchange.html</loc></url>
+  <url><loc>https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/malvertising.html</loc></url>
+  <url><loc>https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/eavesdropping.html</loc></url>
+  <url><loc>https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/identity-theft.html</loc></url>
+  <url><loc>https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/zero-day-vulnerability.html</loc></url>
+  <url><loc>https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/security-patch.html</loc></url>
+  <url><loc>https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/cross-site-scripting-xss.html</loc></url>
+  <url><loc>https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/cross-site-request-forgery-csrf.html</loc></url>
+  <url><loc>https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/phishing-email.html</loc></url>
+</urlset>

--- a/terms/advanced-encryption-standard-aes.html
+++ b/terms/advanced-encryption-standard-aes.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Advanced Encryption Standard (AES)</title>
+    <link
+      rel="canonical"
+      href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/advanced-encryption-standard-aes.html"
+    />
+  </head>
+  <body>
+    <h1>Advanced Encryption Standard (AES)</h1>
+    <p>
+      A widely used symmetric key encryption algorithm known for its security
+      and efficiency.
+    </p>
+  </body>
+</html>

--- a/terms/advanced-persistent-threat-apt.html
+++ b/terms/advanced-persistent-threat-apt.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Advanced Persistent Threat (APT)</title>
+    <link
+      rel="canonical"
+      href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/advanced-persistent-threat-apt.html"
+    />
+  </head>
+  <body>
+    <h1>Advanced Persistent Threat (APT)</h1>
+    <p>
+      A prolonged and targeted cyber attack in which attackers gain and maintain
+      unauthorized access to a network.
+    </p>
+  </body>
+</html>

--- a/terms/certificate-authority-ca.html
+++ b/terms/certificate-authority-ca.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Certificate Authority (CA)</title>
+    <link
+      rel="canonical"
+      href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/certificate-authority-ca.html"
+    />
+  </head>
+  <body>
+    <h1>Certificate Authority (CA)</h1>
+    <p>
+      An entity responsible for issuing and managing digital certificates used
+      in PKI.
+    </p>
+  </body>
+</html>

--- a/terms/cross-site-request-forgery-csrf.html
+++ b/terms/cross-site-request-forgery-csrf.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Cross-Site Request Forgery (CSRF)</title>
+    <link
+      rel="canonical"
+      href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/cross-site-request-forgery-csrf.html"
+    />
+  </head>
+  <body>
+    <h1>Cross-Site Request Forgery (CSRF)</h1>
+    <p>
+      An attack that tricks a user into unknowingly submitting a malicious
+      request on a trusted website.
+    </p>
+  </body>
+</html>

--- a/terms/cross-site-scripting-xss.html
+++ b/terms/cross-site-scripting-xss.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Cross-Site Scripting (XSS)</title>
+    <link
+      rel="canonical"
+      href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/cross-site-scripting-xss.html"
+    />
+  </head>
+  <body>
+    <h1>Cross-Site Scripting (XSS)</h1>
+    <p>
+      A type of web vulnerability where attackers inject malicious scripts into
+      web pages viewed by other users.
+    </p>
+  </body>
+</html>

--- a/terms/cryptography.html
+++ b/terms/cryptography.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Cryptography</title>
+    <link
+      rel="canonical"
+      href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/cryptography.html"
+    />
+  </head>
+  <body>
+    <h1>Cryptography</h1>
+    <p>
+      The practice of secure communication by converting plaintext into
+      ciphertext and vice versa.
+    </p>
+  </body>
+</html>

--- a/terms/cyber-espionage.html
+++ b/terms/cyber-espionage.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Cyber Espionage</title>
+    <link
+      rel="canonical"
+      href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/cyber-espionage.html"
+    />
+  </head>
+  <body>
+    <h1>Cyber Espionage</h1>
+    <p>
+      The use of cyber techniques to steal sensitive information from
+      governments, organizations, or individuals.
+    </p>
+  </body>
+</html>

--- a/terms/data-encryption-standard-des.html
+++ b/terms/data-encryption-standard-des.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Data Encryption Standard (DES)</title>
+    <link
+      rel="canonical"
+      href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/data-encryption-standard-des.html"
+    />
+  </head>
+  <body>
+    <h1>Data Encryption Standard (DES)</h1>
+    <p>
+      An early symmetric key encryption algorithm used to secure electronic
+      data.
+    </p>
+  </body>
+</html>

--- a/terms/data-loss-prevention-dlp.html
+++ b/terms/data-loss-prevention-dlp.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Data Loss Prevention (DLP)</title>
+    <link
+      rel="canonical"
+      href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/data-loss-prevention-dlp.html"
+    />
+  </head>
+  <body>
+    <h1>Data Loss Prevention (DLP)</h1>
+    <p>
+      A strategy and set of tools to prevent the unauthorized loss or leakage of
+      sensitive data.
+    </p>
+  </body>
+</html>

--- a/terms/eavesdropping.html
+++ b/terms/eavesdropping.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Eavesdropping</title>
+    <link
+      rel="canonical"
+      href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/eavesdropping.html"
+    />
+  </head>
+  <body>
+    <h1>Eavesdropping</h1>
+    <p>
+      Unauthorized interception and monitoring of private communications, often
+      done surreptitiously.
+    </p>
+  </body>
+</html>

--- a/terms/endpoint-security.html
+++ b/terms/endpoint-security.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Endpoint Security</title>
+    <link
+      rel="canonical"
+      href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/endpoint-security.html"
+    />
+  </head>
+  <body>
+    <h1>Endpoint Security</h1>
+    <p>
+      The protection of devices like laptops, desktops, and smartphones from
+      various security threats.
+    </p>
+  </body>
+</html>

--- a/terms/identity-theft.html
+++ b/terms/identity-theft.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Identity Theft</title>
+    <link
+      rel="canonical"
+      href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/identity-theft.html"
+    />
+  </head>
+  <body>
+    <h1>Identity Theft</h1>
+    <p>
+      The fraudulent acquisition and use of an individual's personal information
+      to impersonate them for malicious purposes.
+    </p>
+  </body>
+</html>

--- a/terms/incident-response.html
+++ b/terms/incident-response.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Incident Response</title>
+    <link
+      rel="canonical"
+      href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/incident-response.html"
+    />
+  </head>
+  <body>
+    <h1>Incident Response</h1>
+    <p>
+      The process of managing and mitigating the impact of a cybersecurity
+      incident or breach.
+    </p>
+  </body>
+</html>

--- a/terms/key-exchange.html
+++ b/terms/key-exchange.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Key Exchange</title>
+    <link
+      rel="canonical"
+      href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/key-exchange.html"
+    />
+  </head>
+  <body>
+    <h1>Key Exchange</h1>
+    <p>
+      The process of securely sharing encryption keys between parties to
+      establish a secure communication channel.
+    </p>
+  </body>
+</html>

--- a/terms/malvertising.html
+++ b/terms/malvertising.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Malvertising</title>
+    <link
+      rel="canonical"
+      href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/malvertising.html"
+    />
+  </head>
+  <body>
+    <h1>Malvertising</h1>
+    <p>
+      Malicious online advertisements that deliver malware or lead to malicious
+      websites.
+    </p>
+  </body>
+</html>

--- a/terms/network-security.html
+++ b/terms/network-security.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Network Security</title>
+    <link
+      rel="canonical"
+      href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/network-security.html"
+    />
+  </head>
+  <body>
+    <h1>Network Security</h1>
+    <p>
+      The protection of network infrastructure and data from unauthorized access
+      or attacks.
+    </p>
+  </body>
+</html>

--- a/terms/payload.html
+++ b/terms/payload.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Payload</title>
+    <link
+      rel="canonical"
+      href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/payload.html"
+    />
+  </head>
+  <body>
+    <h1>Payload</h1>
+    <p>
+      The part of a malware or exploit that performs malicious actions on a
+      victim's system.
+    </p>
+  </body>
+</html>

--- a/terms/phishing-email.html
+++ b/terms/phishing-email.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Phishing Email</title>
+    <link
+      rel="canonical"
+      href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/phishing-email.html"
+    />
+  </head>
+  <body>
+    <h1>Phishing Email</h1>
+    <p>
+      An email sent by attackers that appears legitimate but aims to trick
+      recipients into revealing sensitive information or performing actions.
+    </p>
+  </body>
+</html>

--- a/terms/phishing.html
+++ b/terms/phishing.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Phishing</title>
+    <link
+      rel="canonical"
+      href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/phishing.html"
+    />
+  </head>
+  <body>
+    <h1>Phishing</h1>
+    <p>
+      An attempt to trick individuals into revealing sensitive information
+      through fraudulent emails, websites, or messages.
+    </p>
+  </body>
+</html>

--- a/terms/privilege-escalation.html
+++ b/terms/privilege-escalation.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Privilege Escalation</title>
+    <link
+      rel="canonical"
+      href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/privilege-escalation.html"
+    />
+  </head>
+  <body>
+    <h1>Privilege Escalation</h1>
+    <p>
+      The act of gaining higher levels of access or permissions in a system or
+      network than originally granted.
+    </p>
+  </body>
+</html>

--- a/terms/public-key-infrastructure-pki.html
+++ b/terms/public-key-infrastructure-pki.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Public Key Infrastructure (PKI)</title>
+    <link
+      rel="canonical"
+      href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/public-key-infrastructure-pki.html"
+    />
+  </head>
+  <body>
+    <h1>Public Key Infrastructure (PKI)</h1>
+    <p>
+      A system for managing digital certificates and public-private key pairs
+      used in asymmetric encryption.
+    </p>
+  </body>
+</html>

--- a/terms/secure-sockets-layer-ssl.html
+++ b/terms/secure-sockets-layer-ssl.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Secure Sockets Layer (SSL)</title>
+    <link
+      rel="canonical"
+      href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/secure-sockets-layer-ssl.html"
+    />
+  </head>
+  <body>
+    <h1>Secure Sockets Layer (SSL)</h1>
+    <p>
+      An older cryptographic protocol that provides secure communication over a
+      computer network.
+    </p>
+  </body>
+</html>

--- a/terms/security-assessment.html
+++ b/terms/security-assessment.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Security Assessment</title>
+    <link
+      rel="canonical"
+      href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/security-assessment.html"
+    />
+  </head>
+  <body>
+    <h1>Security Assessment</h1>
+    <p>
+      A systematic evaluation of an organization's security measures to identify
+      vulnerabilities and weaknesses.
+    </p>
+  </body>
+</html>

--- a/terms/security-operations-center-soc.html
+++ b/terms/security-operations-center-soc.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Security Operations Center (SOC)</title>
+    <link
+      rel="canonical"
+      href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/security-operations-center-soc.html"
+    />
+  </head>
+  <body>
+    <h1>Security Operations Center (SOC)</h1>
+    <p>
+      A centralized unit that monitors, detects, and responds to cybersecurity
+      incidents and threats in real-time.
+    </p>
+  </body>
+</html>

--- a/terms/security-patch.html
+++ b/terms/security-patch.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Security Patch</title>
+    <link
+      rel="canonical"
+      href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/security-patch.html"
+    />
+  </head>
+  <body>
+    <h1>Security Patch</h1>
+    <p>
+      An update released by software vendors to fix security vulnerabilities in
+      their products.
+    </p>
+  </body>
+</html>

--- a/terms/security-token.html
+++ b/terms/security-token.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Security Token</title>
+    <link
+      rel="canonical"
+      href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/security-token.html"
+    />
+  </head>
+  <body>
+    <h1>Security Token</h1>
+    <p>
+      A physical or digital device used to authenticate users or provide
+      one-time passwords for secure access.
+    </p>
+  </body>
+</html>

--- a/terms/social-engineering-attack-vectors.html
+++ b/terms/social-engineering-attack-vectors.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Social Engineering Attack Vectors</title>
+    <link
+      rel="canonical"
+      href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/social-engineering-attack-vectors.html"
+    />
+  </head>
+  <body>
+    <h1>Social Engineering Attack Vectors</h1>
+    <p>
+      Different methods and techniques used in social engineering attacks to
+      manipulate victims.
+    </p>
+  </body>
+</html>

--- a/terms/social-engineering-toolkit-set.html
+++ b/terms/social-engineering-toolkit-set.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Social Engineering Toolkit (SET)</title>
+    <link
+      rel="canonical"
+      href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/social-engineering-toolkit-set.html"
+    />
+  </head>
+  <body>
+    <h1>Social Engineering Toolkit (SET)</h1>
+    <p>
+      A framework for simulating social engineering attacks, helping
+      organizations test their security awareness.
+    </p>
+  </body>
+</html>

--- a/terms/threat-hunting.html
+++ b/terms/threat-hunting.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Threat Hunting</title>
+    <link
+      rel="canonical"
+      href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/threat-hunting.html"
+    />
+  </head>
+  <body>
+    <h1>Threat Hunting</h1>
+    <p>
+      Proactively searching for and identifying cyber threats that have evaded
+      traditional security measures.
+    </p>
+  </body>
+</html>

--- a/terms/transport-layer-security-tls.html
+++ b/terms/transport-layer-security-tls.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Transport Layer Security (TLS)</title>
+    <link
+      rel="canonical"
+      href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/transport-layer-security-tls.html"
+    />
+  </head>
+  <body>
+    <h1>Transport Layer Security (TLS)</h1>
+    <p>
+      A more secure successor to SSL, providing encryption and authentication
+      for secure communication.
+    </p>
+  </body>
+</html>

--- a/terms/zero-day-vulnerability.html
+++ b/terms/zero-day-vulnerability.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Zero-Day Vulnerability</title>
+    <link
+      rel="canonical"
+      href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/zero-day-vulnerability.html"
+    />
+  </head>
+  <body>
+    <h1>Zero-Day Vulnerability</h1>
+    <p>
+      A software vulnerability that is not yet known to the vendor or the
+      public, making it highly valuable to attackers.
+    </p>
+  </body>
+</html>

--- a/terms/zero-knowledge-proof.html
+++ b/terms/zero-knowledge-proof.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Zero-Knowledge Proof</title>
+    <link
+      rel="canonical"
+      href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms/zero-knowledge-proof.html"
+    />
+  </head>
+  <body>
+    <h1>Zero-Knowledge Proof</h1>
+    <p>
+      A cryptographic method that allows a party to prove knowledge of a secret
+      without revealing the secret itself.
+    </p>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- generate individual term pages and sitemap at build time
- lazily import `ExpandPane` and MDX renderer to keep term view lightweight
- send Web Vitals to Vercel analytics and defer heavy assets for faster LCP

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b4e54948588328ae7b543e46add7b8