### PR TITLE
Add security headers and CSP configuration

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,33 @@
+const AI_PROVIDER_DOMAIN = 'https://api.openai.com';
+
+const securityHeaders = [
+  { key: 'X-Content-Type-Options', value: 'nosniff' },
+  { key: 'Referrer-Policy', value: 'no-referrer' },
+  { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
+];
+
+const csp = [
+  "default-src 'self'",
+  "script-src 'self'",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data:",
+  `connect-src ${AI_PROVIDER_DOMAIN}`,
+  "font-src 'self'",
+  "object-src 'none'",
+  "base-uri 'self'",
+  "frame-ancestors 'none'",
+].join('; ');
+
+module.exports = {
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: [
+          ...securityHeaders,
+          { key: 'Content-Security-Policy', value: csp },
+        ],
+      },
+    ];
+  },
+};


### PR DESCRIPTION
## Summary
- Add Next.js config defining security headers for X-Content-Type-Options, Referrer-Policy, and Permissions-Policy
- Introduce CSP restricting connections to the AI provider domain
- Expose headers function serving security headers and CSP

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4e549f0408328bdd78ceb2821c40a