### PR TITLE
Document environment variables and expose public config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Example environment configuration
+NEXT_PUBLIC_SITE_NAME=Cyber Security Dictionary
+NEXT_PUBLIC_AI_MODELS=gpt-4o-mini
+AI_PROVIDER=openai
+AI_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 node_modules/
+
+# Local environment variables
+.env
+.env.local

--- a/README.md
+++ b/README.md
@@ -4,3 +4,14 @@ https://alex-unnippillil.github.io/CyberSecuirtyDictionary/
 
 ## Security
 For information on reporting vulnerabilities, please see our [Security Policy](SECURITY.md).
+
+## Environment Variables
+
+The site can be customized through environment variables. Configure these in your Vercel project settings:
+
+- `NEXT_PUBLIC_SITE_NAME`
+- `NEXT_PUBLIC_AI_MODELS`
+- `AI_PROVIDER`
+- `AI_API_KEY`
+
+For local development, copy `.env.example` to `.env` and update the values. Variables prefixed with `NEXT_PUBLIC_` are exposed to client-side code via `assets/js/env-config.js`.

--- a/assets/js/env-config.js
+++ b/assets/js/env-config.js
@@ -1,0 +1,1 @@
+window.env = {"NEXT_PUBLIC_SITE_NAME":"","NEXT_PUBLIC_AI_MODELS":""};

--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
   <footer aria-label="Project contribution">
     <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
   </footer>
+  <script src="assets/js/env-config.js"></script>
   <script src="script.js"></script>
   <script src="assets/js/app.js"></script>
   <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/",
   "main": "script.js",
   "scripts": {
-    "build": "node scripts/build.js",
+    "build": "node build.js && node scripts/generate-env.js",
+    "generate-env": "node scripts/generate-env.js",
     "test": "html-validate index.html search.html diagnostics.html && node diagnostics.test.js",
     "watch": "chokidar \"**/*.html\" -c \"npm run build\""
   },

--- a/script.js
+++ b/script.js
@@ -9,6 +9,14 @@ const favorites = new Set(JSON.parse(localStorage.getItem("favorites") || "[]"))
 const siteUrl = "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/";
 const canonicalLink = document.getElementById("canonical-link");
 
+const siteName = (window.env && window.env.NEXT_PUBLIC_SITE_NAME) || "Cyber Security Dictionary";
+document.title = siteName;
+const headerEl = document.querySelector("h1");
+if (headerEl) {
+  headerEl.textContent = siteName;
+}
+const aiModels = (window.env && window.env.NEXT_PUBLIC_AI_MODELS) || "";
+
 let currentLetterFilter = "All";
 let termsData = { terms: [] };
 

--- a/scripts/generate-env.js
+++ b/scripts/generate-env.js
@@ -1,0 +1,11 @@
+const fs = require('fs');
+const path = require('path');
+
+const config = {
+  NEXT_PUBLIC_SITE_NAME: process.env.NEXT_PUBLIC_SITE_NAME || '',
+  NEXT_PUBLIC_AI_MODELS: process.env.NEXT_PUBLIC_AI_MODELS || ''
+};
+
+const outputPath = path.join(__dirname, '..', 'assets', 'js', 'env-config.js');
+fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+fs.writeFileSync(outputPath, `window.env = ${JSON.stringify(config)};`);


### PR DESCRIPTION
## Summary
- document required environment variables and how to configure them
- generate `env-config.js` so NEXT_PUBLIC vars are available client-side
- add `.env.example` and ignore local secrets

## Testing
- `npm test`
- `npm run generate-env`

------
https://chatgpt.com/codex/tasks/task_e_68b4e54a80d08328bc91975777958fed