### PR TITLE
docs: add optional feature backlog

### DIFF
--- a/OPTIONAL_FEATURES_BACKLOG.md
+++ b/OPTIONAL_FEATURES_BACKLOG.md
@@ -1,0 +1,12 @@
+# Optional Feature Backlog
+
+These items track potential enhancements. Priorities reflect community interest and maintainer capacity.
+
+| Feature | Description | Priority | Rationale |
+| --- | --- | --- | --- |
+| Compare diffs | Enable side-by-side comparison of different dictionary releases. | Medium | Requested occasionally; moderate effort. |
+| CSV/YAML import | Allow bulk addition of terms using CSV or YAML files. | High | Frequently requested and relatively straightforward. |
+| Cytoscape topic graph | Visualize term relationships with Cytoscape. | Low | Specialized interest and high implementation effort. |
+| Progressive Web App (PWA) | Package the site as a PWA for offline access. | Medium | Some interest; moderate effort required. |
+
+Backlog items are reviewed each release cycle for possible promotion to the main roadmap.


### PR DESCRIPTION
## Summary
- add project board backlog for optional features like compare diffs, CSV/YAML import, Cytoscape topic graph, and PWA
- note prioritization based on community interest and capacity and review each release cycle for roadmap consideration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4e54fc268832882b5027a68d0c84c