### PR TITLE
feat: add AI expander with streaming chat

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,0 +1,65 @@
+import { NextRequest } from 'next/server';
+import { streamText } from 'ai';
+import { openai } from '@ai-sdk/openai';
+
+export const runtime = 'edge';
+
+// System prompts used for various modes of the AI expander
+const SYSTEM_PROMPTS: Record<string, string> = {
+  expander:
+    'You are a cybersecurity term expander. Provide clear, concise explanations and cite canonical sources such as NIST, OWASP or Wikipedia.',
+  coach:
+    'You are a cybersecurity study coach. Offer guidance, examples and cite canonical sources when applicable.',
+  mapper:
+    'You are a cybersecurity concept mapper. Describe relationships between terms and cite canonical sources.',
+};
+
+const CANONICAL_HOSTS = [
+  'nvd.nist.gov',
+  'csrc.nist.gov',
+  'owasp.org',
+  'en.wikipedia.org',
+];
+
+function isCanonical(url: string): boolean {
+  try {
+    const host = new URL(url).hostname;
+    return CANONICAL_HOSTS.some((allowed) => host.endsWith(allowed));
+  } catch {
+    return false;
+  }
+}
+
+export async function POST(req: NextRequest) {
+  const { messages = [], mode = 'expander' } = await req.json();
+
+  const system = SYSTEM_PROMPTS[mode] ?? SYSTEM_PROMPTS.expander;
+
+  const result = await streamText({
+    model: openai('gpt-4o-mini'),
+    system,
+    messages,
+  });
+
+  // Wrap the AI stream to filter out any non-canonical citation links
+  const filtered = new ReadableStream({
+    async start(controller) {
+      for await (const chunk of result.stream) {
+        if (chunk.type === 'citation') {
+          if (isCanonical(chunk.url)) {
+            controller.enqueue(JSON.stringify(chunk));
+          }
+          continue;
+        }
+        controller.enqueue(chunk.toString());
+      }
+      controller.close();
+    },
+  });
+
+  return new Response(filtered, {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+    },
+  });
+}

--- a/components/ai/AIExpander.tsx
+++ b/components/ai/AIExpander.tsx
@@ -1,0 +1,96 @@
+import { useState } from 'react';
+import { useChat, Message } from 'ai/react';
+
+const CANONICAL_HOSTS = [
+  'nvd.nist.gov',
+  'csrc.nist.gov',
+  'owasp.org',
+  'en.wikipedia.org',
+];
+
+function isCanonical(url: string): boolean {
+  try {
+    const host = new URL(url).hostname;
+    return CANONICAL_HOSTS.some((allowed) => host.endsWith(allowed));
+  } catch {
+    return false;
+  }
+}
+
+const PROMPTS = ['expander', 'coach', 'mapper'] as const;
+
+type Mode = (typeof PROMPTS)[number];
+
+export default function AIExpander() {
+  const [open, setOpen] = useState(false);
+  const [mode, setMode] = useState<Mode>('expander');
+
+  const { messages, input, handleInputChange, handleSubmit, isLoading } = useChat({
+    api: '/api/chat',
+    body: { mode },
+  });
+
+  return (
+    <div className="ai-expander">
+      <button onClick={() => setOpen(true)}>Ask AI</button>
+      {open && (
+        <div className="drawer">
+          <div className="drawer-header">
+            <strong>AI Assistant</strong>
+            <button onClick={() => setOpen(false)}>Close</button>
+          </div>
+          <div className="prompt-chips">
+            {PROMPTS.map((p) => (
+              <button
+                key={p}
+                className={mode === p ? 'active' : ''}
+                onClick={() => setMode(p)}
+              >
+                {p}
+              </button>
+            ))}
+          </div>
+          <div className="chat-messages">
+            {messages.map((m) => (
+              <div key={m.id} className={`msg msg-${m.role}`}>
+                {renderMessage(m)}
+              </div>
+            ))}
+          </div>
+          <form onSubmit={handleSubmit} className="chat-input">
+            <input
+              value={input}
+              onChange={handleInputChange}
+              placeholder="Ask a question"
+            />
+            <button type="submit" disabled={isLoading}>
+              Send
+            </button>
+          </form>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function renderMessage(message: Message) {
+  const content: any = (message as any).content;
+  if (typeof content === 'string') {
+    return content;
+  }
+  return content.map((part: any, idx: number) => {
+    if (part.type === 'text') {
+      return <span key={idx}>{part.text}</span>;
+    }
+    if (part.type === 'citation' && part.url && isCanonical(part.url)) {
+      return (
+        <sup key={idx} className="citation">
+          <a href={part.url} target="_blank" rel="noreferrer">
+            {part.title || part.url}
+          </a>
+        </sup>
+      );
+    }
+    return null;
+  });
+}


### PR DESCRIPTION
## Summary
- add Edge runtime chat API with streaming responses and canonical citation gating
- add AIExpander drawer component with prompt chips and citation rendering

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4e6e711188328b2b14cbdde65613a