### PR TITLE
feat: add search API and combobox

### DIFF
--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -1,0 +1,9 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { search } from '../../../lib/search/runtime';
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const q = searchParams.get('q') || '';
+  const hits = search(q);
+  return NextResponse.json({ hits });
+}

--- a/components/search/SearchBar.tsx
+++ b/components/search/SearchBar.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import * as React from 'react';
+import * as Combobox from '@radix-ui/react-combobox';
+
+interface Hit {
+  term: string;
+  definition: string;
+}
+
+export default function SearchBar() {
+  const [open, setOpen] = React.useState(false);
+  const [query, setQuery] = React.useState('');
+  const [results, setResults] = React.useState<Hit[]>([]);
+
+  React.useEffect(() => {
+    if (!query) {
+      setResults([]);
+      return;
+    }
+    const controller = new AbortController();
+    fetch(`/api/search?q=${encodeURIComponent(query)}`, { signal: controller.signal })
+      .then((res) => res.json())
+      .then((data) => setResults(data.hits || []))
+      .catch(() => {});
+    return () => controller.abort();
+  }, [query]);
+
+  return (
+    <Combobox.Root open={open} onOpenChange={setOpen}>
+      <Combobox.Trigger className="w-full">
+        <Combobox.Input
+          placeholder="Search terms..."
+          onChange={(e) => setQuery(e.target.value)}
+          className="w-full rounded-md border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+        />
+      </Combobox.Trigger>
+      <Combobox.Content className="mt-1 max-h-60 w-full overflow-auto rounded-md border bg-white shadow-md">
+        {results.length === 0 ? (
+          <div className="p-2 text-sm text-gray-500">No results</div>
+        ) : (
+          results.map((hit) => (
+            <Combobox.Item
+              key={hit.term}
+              value={hit.term}
+              className="cursor-pointer px-3 py-2 focus:bg-blue-100 focus:outline-none"
+            >
+              {hit.term}
+            </Combobox.Item>
+          ))
+        )}
+      </Combobox.Content>
+    </Combobox.Root>
+  );
+}

--- a/lib/search/build-index.ts
+++ b/lib/search/build-index.ts
@@ -1,0 +1,20 @@
+export interface Term {
+  term: string;
+  definition: string;
+}
+
+export interface SearchableTerm extends Term {
+  tokens: string[];
+}
+
+function tokenize(value: string): string[] {
+  return value
+    .toLowerCase()
+    .split(/\s+/)
+    .map((token) => token.replace(/[^a-z0-9]/g, ""))
+    .filter(Boolean);
+}
+
+export function buildIndex(allTerms: Term[]): SearchableTerm[] {
+  return allTerms.map((t) => ({ ...t, tokens: tokenize(t.term) }));
+}

--- a/lib/search/runtime.ts
+++ b/lib/search/runtime.ts
@@ -1,0 +1,19 @@
+import termsData from '../../terms.json';
+import { buildIndex, SearchableTerm, Term } from './build-index';
+
+const allTerms: Term[] = (termsData as { terms: Term[] }).terms;
+const index: SearchableTerm[] = buildIndex(allTerms);
+
+export interface SearchHit {
+  term: string;
+  definition: string;
+}
+
+export function search(query: string, limit = 10): SearchHit[] {
+  const q = query.toLowerCase().trim();
+  if (!q) return [];
+  return index
+    .filter((item) => item.term.toLowerCase().includes(q))
+    .slice(0, limit)
+    .map(({ term, definition }) => ({ term, definition }));
+}


### PR DESCRIPTION
## Summary
- build tokenized search index from dictionary terms
- expose API route for lightweight term lookups
- add combobox search bar wired to API with accessible focus styles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4e6e5eae88328a9dddd0e352fa479