### PR TITLE
Add term page with sources and related terms

### DIFF
--- a/app/(site)/term/[slug]/RelatedTerms.tsx
+++ b/app/(site)/term/[slug]/RelatedTerms.tsx
@@ -1,0 +1,26 @@
+import Link from "next/link";
+import { allTerms } from "contentlayer/generated";
+
+interface RelatedTermsProps {
+  slugs?: string[];
+}
+
+export default function RelatedTerms({ slugs }: RelatedTermsProps) {
+  if (!slugs || slugs.length === 0) return null;
+  return (
+    <section aria-labelledby="related-terms-heading">
+      <h2 id="related-terms-heading">Related Terms</h2>
+      <ul>
+        {slugs.map((slug) => {
+          const term = allTerms.find((t) => t.slug === slug);
+          const title = term?.title ?? slug;
+          return (
+            <li key={slug}>
+              <Link href={`/term/${slug}`}>{title}</Link>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}

--- a/app/(site)/term/[slug]/page.tsx
+++ b/app/(site)/term/[slug]/page.tsx
@@ -1,0 +1,78 @@
+import { allTerms } from "contentlayer/generated";
+import { notFound } from "next/navigation";
+import { Metadata } from "next";
+import { useMDXComponent } from "next-contentlayer/hooks";
+import RelatedTerms from "./RelatedTerms";
+
+interface PageProps {
+  params: { slug: string };
+}
+
+export async function generateMetadata({
+  params,
+}: PageProps): Promise<Metadata> {
+  const term = allTerms.find((t) => t.slug === params.slug);
+  if (!term) {
+    return { title: "Term not found" };
+  }
+  return {
+    title: term.title,
+    description: term.shortDefinition,
+  };
+}
+
+export default function TermPage({ params }: PageProps) {
+  const term = allTerms.find((t) => t.slug === params.slug);
+  if (!term) notFound();
+  const MDXContent = useMDXComponent(term.body.code);
+  return (
+    <article>
+      <header>
+        <h1>{term.title}</h1>
+        {term.shortDefinition && <p>{term.shortDefinition}</p>}
+      </header>
+      <MDXContent />
+      {term.sources && term.sources.length > 0 && (
+        <section aria-labelledby="sources-heading">
+          <h2 id="sources-heading">Sources</h2>
+          <ul>
+            {term.sources.map((source) => (
+              <li key={source.url}>
+                <a href={source.url}>{source.name || source.url}</a>
+                {source.attack && (
+                  <span>
+                    {" "}
+                    (
+                    <a
+                      href={source.attack}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      ATT&CK
+                    </a>
+                    )
+                  </span>
+                )}
+                {source.owasp && (
+                  <span>
+                    {" "}
+                    (
+                    <a
+                      href={source.owasp}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      OWASP
+                    </a>
+                    )
+                  </span>
+                )}
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+      <RelatedTerms slugs={term.seeAlso} />
+    </article>
+  );
+}


### PR DESCRIPTION
## Summary
- add term page that fetches contentlayer TermDoc, renders MDX, sources with ATT&CK/OWASP mappings, and related terms
- add RelatedTerms component to show seeAlso links

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4e6e670f48328add3e36450b6562e