### PR TITLE
feat: add settings page with persistent preferences

### DIFF
--- a/app/(site)/settings/page.tsx
+++ b/app/(site)/settings/page.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import React from 'react';
+import { useSettings } from '../../../lib/settings';
+
+const SettingsPage: React.FC = () => {
+  const { settings, update } = useSettings();
+
+  return (
+    <main>
+      <h1>Settings</h1>
+      <section>
+        <label>
+          <input
+            type="checkbox"
+            checked={settings.darkMode}
+            onChange={(e) => update({ darkMode: e.target.checked })}
+          />
+          Dark mode
+        </label>
+      </section>
+      <section>
+        <label>
+          Font scale
+          <input
+            type="range"
+            min="0.8"
+            max="1.5"
+            step="0.1"
+            value={settings.fontScale}
+            onChange={(e) => update({ fontScale: parseFloat(e.target.value) })}
+          />
+        </label>
+      </section>
+      <section>
+        <label>
+          <input
+            type="checkbox"
+            checked={settings.density === 'compact'}
+            onChange={(e) =>
+              update({ density: e.target.checked ? 'compact' : 'comfortable' })
+            }
+          />
+          Compact density
+        </label>
+      </section>
+      <section>
+        <label>
+          Source preference
+          <select
+            value={settings.source}
+            onChange={(e) => update({ source: e.target.value })}
+          >
+            <option value="all">All</option>
+            <option value="official">Official</option>
+            <option value="community">Community</option>
+          </select>
+        </label>
+      </section>
+      <section>
+        <label>
+          <input
+            type="checkbox"
+            checked={settings.history}
+            onChange={(e) => update({ history: e.target.checked })}
+          />
+          Enable history
+        </label>
+      </section>
+      <section>
+        <label>
+          <input
+            type="checkbox"
+            checked={settings.favorites}
+            onChange={(e) => update({ favorites: e.target.checked })}
+          />
+          Enable favorites
+        </label>
+      </section>
+    </main>
+  );
+};
+
+export default SettingsPage;

--- a/lib/settings.ts
+++ b/lib/settings.ts
@@ -1,0 +1,78 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+export type Settings = {
+  darkMode: boolean;
+  fontScale: number;
+  density: 'comfortable' | 'compact';
+  source: string;
+  history: boolean;
+  favorites: boolean;
+};
+
+const defaultSettings: Settings = {
+  darkMode: false,
+  fontScale: 1,
+  density: 'comfortable',
+  source: 'all',
+  history: true,
+  favorites: true,
+};
+
+type SettingsContextValue = {
+  settings: Settings;
+  update: (changes: Partial<Settings>) => void;
+};
+
+const SettingsContext = createContext<SettingsContextValue>({
+  settings: defaultSettings,
+  update: () => {},
+});
+
+function useLocalStorageSettings(): [Settings, React.Dispatch<React.SetStateAction<Settings>>] {
+  const [settings, setSettings] = useState<Settings>(() => {
+    if (typeof window === 'undefined') return defaultSettings;
+    try {
+      const raw = localStorage.getItem('settings');
+      return raw ? { ...defaultSettings, ...JSON.parse(raw) } : defaultSettings;
+    } catch {
+      return defaultSettings;
+    }
+  });
+
+  useEffect(() => {
+    try {
+      localStorage.setItem('settings', JSON.stringify(settings));
+    } catch {
+      // ignore
+    }
+  }, [settings]);
+
+  return [settings, setSettings];
+}
+
+export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [settings, setSettings] = useLocalStorageSettings();
+
+  useEffect(() => {
+    const root = document.documentElement;
+    root.style.setProperty('--font-scale', settings.fontScale.toString());
+    root.style.setProperty('--density', settings.density);
+    if (settings.darkMode) {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+    }
+  }, [settings]);
+
+  const update = (changes: Partial<Settings>) => {
+    setSettings((prev) => ({ ...prev, ...changes }));
+  };
+
+  return (
+    <SettingsContext.Provider value={{ settings, update }}>
+      {children}
+    </SettingsContext.Provider>
+  );
+};
+
+export const useSettings = () => useContext(SettingsContext);


### PR DESCRIPTION
## Summary
- add settings page with toggles for dark mode, font scale, density, source, history, and favorites
- create settings hook with localStorage persistence and global CSS variable updates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4e6e97704832894fd5d6ced3aba07