### PR TITLE
feat: add default security headers

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,31 @@
+const securityHeaders = [
+  {
+    key: "Strict-Transport-Security",
+    value: "max-age=63072000; includeSubDomains; preload",
+  },
+  {
+    key: "Referrer-Policy",
+    value: "no-referrer",
+  },
+  {
+    key: "X-Content-Type-Options",
+    value: "nosniff",
+  },
+  {
+    key: "Permissions-Policy",
+    value: "geolocation=(), microphone=(), camera=()",
+  },
+];
+
+const nextConfig = {
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: securityHeaders,
+      },
+    ];
+  },
+};
+
+export default nextConfig;


### PR DESCRIPTION
## Summary
- add `headers()` in Next config to set Strict-Transport-Security, Referrer-Policy, X-Content-Type-Options, and Permissions-Policy

## Testing
- `npm test`
- `curl -I http://localhost:3000`
- `curl -I http://localhost:3000/api/hello`


------
https://chatgpt.com/codex/tasks/task_e_68b4e78d99f0832892d43ee35fea1381