### PR TITLE
Add CSP middleware with nonce for inline scripts

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,23 @@
+import { headers } from 'next/headers';
+import React from 'react';
+
+type Props = {
+  children: React.ReactNode;
+};
+
+export default function RootLayout({ children }: Props) {
+  const nonce = headers().get('x-nonce') || undefined;
+  return (
+    <html lang="en">
+      <body>
+        {children}
+        <script
+          nonce={nonce}
+          dangerouslySetInnerHTML={{
+            __html: "console.log('nonce applied');"
+          }}
+        />
+      </body>
+    </html>
+  );
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,36 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import crypto from 'crypto';
+
+export function middleware(request: NextRequest) {
+  const nonce = crypto.randomBytes(16).toString('base64');
+
+  const csp = [
+    "default-src 'self'",
+    "base-uri 'self'",
+    "object-src 'none'",
+    "script-src 'self' 'strict-dynamic' 'nonce-" + nonce + "'",
+    "style-src 'self'",
+    "img-src 'self' data:",
+    "connect-src 'self'",
+    "font-src 'self'",
+    "frame-ancestors 'none'",
+    'upgrade-insecure-requests'
+  ].join('; ');
+
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set('x-nonce', nonce);
+
+  const response = NextResponse.next({
+    request: {
+      headers: requestHeaders
+    }
+  });
+  response.headers.set('Content-Security-Policy', csp);
+
+  return response;
+}
+
+export const config = {
+  matcher: '/:path*'
+};


### PR DESCRIPTION
## Summary
- Generate per-request nonce and strict Content-Security-Policy header in middleware
- Read nonce in root layout and apply to inline scripts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4e79652b08328b4197d24512c4c1b