### PR TITLE
Add configurable Content Security Policy reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,10 @@ https://alex-unnippillil.github.io/CyberSecuirtyDictionary/
 
 ## Security
 For information on reporting vulnerabilities, please see our [Security Policy](SECURITY.md).
+
+### CSP Violation Reporting
+The site uses a Content Security Policy that reports violations to
+[`https://alex-unnippillil.github.io/CyberSecuirtyDictionary/report`](https://alex-unnippillil.github.io/CyberSecuirtyDictionary/report).
+Set the environment variable `NEXT_PUBLIC_CSP_REPORT_ONLY=true` during the build
+to emit a `Content-Security-Policy-Report-Only` header instead of enforcing the
+policy. This is useful while fine-tuning the policy without blocking content.

--- a/build.sh
+++ b/build.sh
@@ -12,3 +12,6 @@ Contact: mailto:security@example.com
 TXT
 
 echo "Generated .well-known/security.txt"
+
+# Update HTML files to use report-only CSP if requested
+node scripts/enable-csp-report-only.js

--- a/diagnostics.html
+++ b/diagnostics.html
@@ -1,11 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Diagnostics</title>
-  <link rel="stylesheet" href="styles.css">
-</head>
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://unpkg.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; connect-src 'self'; report-uri https://alex-unnippillil.github.io/CyberSecuirtyDictionary/report">
+    <title>Diagnostics</title>
+    <link rel="stylesheet" href="styles.css">
+  </head>
 <body>
   <main class="container">
     <h1>Performance Diagnostics</h1>

--- a/index.html
+++ b/index.html
@@ -1,12 +1,13 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Cyber Security Dictionary</title>
-  <link rel="stylesheet" href="styles.css">
-  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet">
-  <link rel="canonical" id="canonical-link" href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://unpkg.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; connect-src 'self'; report-uri https://alex-unnippillil.github.io/CyberSecuirtyDictionary/report">
+    <title>Cyber Security Dictionary</title>
+    <link rel="stylesheet" href="styles.css">
+    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet">
+    <link rel="canonical" id="canonical-link" href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/">
 </head>
 <body>
   <main class="container">

--- a/layout.html
+++ b/layout.html
@@ -1,11 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Cyber Security Dictionary</title>
-  <link rel="stylesheet" href="styles.css">
-  <meta property="og:title" content="Cyber Security Dictionary">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://unpkg.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; connect-src 'self'; report-uri https://alex-unnippillil.github.io/CyberSecuirtyDictionary/report">
+    <title>Cyber Security Dictionary</title>
+    <link rel="stylesheet" href="styles.css">
+    <meta property="og:title" content="Cyber Security Dictionary">
   <meta property="og:description" content="An interactive dictionary for cyber security terms.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/">

--- a/scripts/enable-csp-report-only.js
+++ b/scripts/enable-csp-report-only.js
@@ -1,0 +1,16 @@
+const fs = require('fs');
+const path = require('path');
+
+const reportOnly = process.env.NEXT_PUBLIC_CSP_REPORT_ONLY === 'true';
+if (!reportOnly) {
+  process.exit(0);
+}
+
+const files = ['index.html', 'search.html', 'diagnostics.html', 'layout.html'];
+for (const file of files) {
+  const filePath = path.join(__dirname, '..', file);
+  if (!fs.existsSync(filePath)) continue;
+  const html = fs.readFileSync(filePath, 'utf8');
+  const updated = html.replace(/Content-Security-Policy/gi, 'Content-Security-Policy-Report-Only');
+  fs.writeFileSync(filePath, updated);
+}

--- a/search.html
+++ b/search.html
@@ -1,11 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Search</title>
-  <link rel="stylesheet" href="styles.css">
-</head>
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://unpkg.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; connect-src 'self'; report-uri https://alex-unnippillil.github.io/CyberSecuirtyDictionary/report">
+    <title>Search</title>
+    <link rel="stylesheet" href="styles.css">
+  </head>
 <body>
   <main class="container">
     <h1>Search</h1>


### PR DESCRIPTION
## Summary
- add CSP meta tag with violation reporting endpoint to site pages
- document how to trigger report-only mode via `NEXT_PUBLIC_CSP_REPORT_ONLY`
- convert CSP to `Content-Security-Policy-Report-Only` during build when requested

## Testing
- `npm test`
- `./build.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b4e7971600832896adc5246edee719