### PR TITLE
feat: retry fetch with jitter

### DIFF
--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -1,75 +1,105 @@
-(function(){
-  const resultsContainer = document.getElementById('results');
-  const searchInput = document.getElementById('search-box');
+(function () {
+  const resultsContainer = document.getElementById("results");
+  const searchInput = document.getElementById("search-box");
   let terms = [];
 
-  document.addEventListener('DOMContentLoaded', () => {
-    const baseUrl = window.__BASE_URL__ || '';
-    fetch(`${baseUrl}/terms.json`)
-      .then(r => r.ok ? r.json() : Promise.reject(r.statusText))
-      .then(data => {
+  async function fetchWithRetry(
+    input,
+    init = {},
+    maxAttempts = 3,
+    baseDelay = 500,
+    cap = 10000,
+  ) {
+    let attempt = 0;
+    let delay = baseDelay;
+    let lastError;
+    while (attempt < maxAttempts) {
+      try {
+        const res = await fetch(input, init);
+        if (res.status !== 429 && res.status < 500) {
+          return res;
+        }
+        lastError = new Error(`HTTP error! status: ${res.status}`);
+      } catch (err) {
+        lastError = err;
+      }
+      attempt++;
+      if (attempt >= maxAttempts) {
+        throw lastError;
+      }
+      const jitter = Math.random() * (delay * 3 - baseDelay) + baseDelay;
+      delay = Math.min(cap, jitter);
+      await new Promise((r) => setTimeout(r, delay));
+    }
+  }
+
+  document.addEventListener("DOMContentLoaded", () => {
+    const baseUrl = window.__BASE_URL__ || "";
+    fetchWithRetry(`${baseUrl}/terms.json`)
+      .then((r) => (r.ok ? r.json() : Promise.reject(r.statusText)))
+      .then((data) => {
         // terms.json may either be an array or object with terms property
-        terms = Array.isArray(data) ? data : (data.terms || []);
+        terms = Array.isArray(data) ? data : data.terms || [];
       })
-      .catch(err => {
-        console.error('Failed to load terms.json', err);
+      .catch((err) => {
+        console.error("Failed to load terms.json", err);
       });
 
-    searchInput.addEventListener('input', handleSearch);
+    searchInput.addEventListener("input", handleSearch);
   });
 
-  function handleSearch(){
+  function handleSearch() {
     const query = searchInput.value.trim().toLowerCase();
-    resultsContainer.innerHTML = '';
-    if(!query){
+    resultsContainer.innerHTML = "";
+    if (!query) {
       return;
     }
     const matches = terms
-      .map(term => ({ term, score: score(term, query) }))
-      .filter(item => item.score > 0)
-      .sort((a,b) => b.score - a.score);
+      .map((term) => ({ term, score: score(term, query) }))
+      .filter((item) => item.score > 0)
+      .sort((a, b) => b.score - a.score);
 
     matches.forEach(({ term }) => {
       resultsContainer.appendChild(renderCard(term));
     });
   }
 
-  function score(term, query){
+  function score(term, query) {
     let s = 0;
-    const name = (term.name || term.term || '').toLowerCase();
-    const def = (term.definition || '').toLowerCase();
-    const category = (term.category || '').toLowerCase();
-    const syns = (term.synonyms || []).map(s=>s.toLowerCase());
-    if(name.includes(query)) s += 3;
-    if(def.includes(query)) s += 1;
-    if(category.includes(query)) s += 1;
-    if(syns.some(syn => syn.includes(query))) s += 2;
+    const name = (term.name || term.term || "").toLowerCase();
+    const def = (term.definition || "").toLowerCase();
+    const category = (term.category || "").toLowerCase();
+    const syns = (term.synonyms || []).map((s) => s.toLowerCase());
+    if (name.includes(query)) s += 3;
+    if (def.includes(query)) s += 1;
+    if (category.includes(query)) s += 1;
+    if (syns.some((syn) => syn.includes(query))) s += 2;
     return s;
   }
 
-  function renderCard(term){
-    const card = document.createElement('div');
-    card.className = 'result-card';
+  function renderCard(term) {
+    const card = document.createElement("div");
+    card.className = "result-card";
 
-    const title = document.createElement('h3');
-    title.textContent = term.name || term.term || '';
+    const title = document.createElement("h3");
+    title.textContent = term.name || term.term || "";
     card.appendChild(title);
 
-    if(term.category){
-      const cat = document.createElement('p');
-      cat.className = 'category';
+    if (term.category) {
+      const cat = document.createElement("p");
+      cat.className = "category";
       cat.textContent = term.category;
       card.appendChild(cat);
     }
 
-    const def = document.createElement('p');
-    def.textContent = term.definition || '';
+    const def = document.createElement("p");
+    def.textContent = term.definition || "";
     card.appendChild(def);
 
-    if(term.synonyms && term.synonyms.length){
-      const syn = document.createElement('p');
-      syn.className = 'synonyms';
-      syn.textContent = `Synonyms: ${term.synonyms.join(', ')}`;
+    if (term.synonyms && term.synonyms.length) {
+      const syn = document.createElement("p");
+      syn.className = "synonyms";
+      syn.textContent = `Synonyms: ${term.synonyms.join(", ")}`;
       card.appendChild(syn);
     }
     return card;

--- a/script.js
+++ b/script.js
@@ -5,12 +5,44 @@ const randomButton = document.getElementById("random-term");
 const alphaNav = document.getElementById("alpha-nav");
 const darkModeToggle = document.getElementById("dark-mode-toggle");
 const showFavoritesToggle = document.getElementById("show-favorites");
-const favorites = new Set(JSON.parse(localStorage.getItem("favorites") || "[]"));
+const favorites = new Set(
+  JSON.parse(localStorage.getItem("favorites") || "[]"),
+);
 const siteUrl = "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/";
 const canonicalLink = document.getElementById("canonical-link");
 
 let currentLetterFilter = "All";
 let termsData = { terms: [] };
+
+async function fetchWithRetry(
+  input,
+  init = {},
+  maxAttempts = 3,
+  baseDelay = 500,
+  cap = 10000,
+) {
+  let attempt = 0;
+  let delay = baseDelay;
+  let lastError;
+  while (attempt < maxAttempts) {
+    try {
+      const res = await fetch(input, init);
+      if (res.status !== 429 && res.status < 500) {
+        return res;
+      }
+      lastError = new Error(`HTTP error! status: ${res.status}`);
+    } catch (err) {
+      lastError = err;
+    }
+    attempt++;
+    if (attempt >= maxAttempts) {
+      throw lastError;
+    }
+    const jitter = Math.random() * (delay * 3 - baseDelay) + baseDelay;
+    delay = Math.min(cap, jitter);
+    await new Promise((r) => setTimeout(r, delay));
+  }
+}
 
 if (localStorage.getItem("darkMode") === "true") {
   document.body.classList.add("dark-mode");
@@ -19,7 +51,10 @@ if (localStorage.getItem("darkMode") === "true") {
 if (darkModeToggle) {
   darkModeToggle.addEventListener("click", () => {
     document.body.classList.toggle("dark-mode");
-    localStorage.setItem("darkMode", document.body.classList.contains("dark-mode"));
+    localStorage.setItem(
+      "darkMode",
+      document.body.classList.contains("dark-mode"),
+    );
   });
 }
 
@@ -28,7 +63,7 @@ window.addEventListener("DOMContentLoaded", () => {
 });
 
 function loadTerms() {
-  fetch("terms.json")
+  fetchWithRetry("terms.json")
     .then((response) => {
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);
@@ -43,9 +78,11 @@ function loadTerms() {
       populateTermsList();
 
       if (window.location.hash) {
-        const termFromHash = decodeURIComponent(window.location.hash.substring(1));
+        const termFromHash = decodeURIComponent(
+          window.location.hash.substring(1),
+        );
         const matchedTerm = termsData.terms.find(
-          (t) => t.term.toLowerCase() === termFromHash.toLowerCase()
+          (t) => t.term.toLowerCase() === termFromHash.toLowerCase(),
         );
         if (matchedTerm) {
           displayDefinition(matchedTerm);
@@ -56,7 +93,7 @@ function loadTerms() {
       console.error("Detailed error fetching data:", error);
       definitionContainer.style.display = "block";
       definitionContainer.innerHTML =
-        '<p>Unable to load dictionary data. Please check your connection and try again.</p>' +
+        "<p>Unable to load dictionary data. Please check your connection and try again.</p>" +
         '<button id="retry-fetch">Retry</button>';
       const retryBtn = document.getElementById("retry-fetch");
       if (retryBtn) {
@@ -97,12 +134,16 @@ function toggleFavorite(term) {
 }
 
 function highlightActiveButton(button) {
-  alphaNav.querySelectorAll("button").forEach((btn) => btn.classList.remove("active"));
+  alphaNav
+    .querySelectorAll("button")
+    .forEach((btn) => btn.classList.remove("active"));
   button.classList.add("active");
 }
 
 function buildAlphaNav() {
-  const letters = Array.from(new Set(termsData.terms.map((t) => t.term.charAt(0).toUpperCase()))).sort();
+  const letters = Array.from(
+    new Set(termsData.terms.map((t) => t.term.charAt(0).toUpperCase())),
+  ).sort();
 
   const allButton = document.createElement("button");
   allButton.textContent = "All";
@@ -134,9 +175,13 @@ function populateTermsList() {
     .sort((a, b) => a.term.localeCompare(b.term))
     .forEach((item) => {
       const matchesSearch = item.term.toLowerCase().includes(searchValue);
-      const matchesFavorites = !showFavoritesToggle || !showFavoritesToggle.checked || favorites.has(item.term);
+      const matchesFavorites =
+        !showFavoritesToggle ||
+        !showFavoritesToggle.checked ||
+        favorites.has(item.term);
       const matchesLetter =
-        currentLetterFilter === "All" || item.term.charAt(0).toUpperCase() === currentLetterFilter;
+        currentLetterFilter === "All" ||
+        item.term.charAt(0).toUpperCase() === currentLetterFilter;
       if (matchesSearch && matchesFavorites && matchesLetter) {
         const termDiv = document.createElement("div");
         termDiv.classList.add("dictionary-item");
@@ -187,7 +232,7 @@ function displayDefinition(term) {
   if (canonicalLink) {
     canonicalLink.setAttribute(
       "href",
-      `${siteUrl}#${encodeURIComponent(term.term)}`
+      `${siteUrl}#${encodeURIComponent(term.term)}`,
     );
   }
 }
@@ -195,19 +240,27 @@ function displayDefinition(term) {
 function clearDefinition() {
   definitionContainer.style.display = "none";
   definitionContainer.innerHTML = "";
-  history.replaceState(null, "", window.location.pathname + window.location.search);
+  history.replaceState(
+    null,
+    "",
+    window.location.pathname + window.location.search,
+  );
   if (canonicalLink) {
     canonicalLink.setAttribute("href", siteUrl);
   }
 }
 
 function showRandomTerm() {
-  const randomTerm = termsData.terms[Math.floor(Math.random() * termsData.terms.length)];
+  const randomTerm =
+    termsData.terms[Math.floor(Math.random() * termsData.terms.length)];
   displayDefinition(randomTerm);
 
   const today = new Date().toDateString();
   try {
-    localStorage.setItem("lastRandomTerm", JSON.stringify({ date: today, term: randomTerm }));
+    localStorage.setItem(
+      "lastRandomTerm",
+      JSON.stringify({ date: today, term: randomTerm }),
+    );
   } catch (e) {
     // Ignore storage errors
   }
@@ -249,8 +302,7 @@ window.addEventListener("scroll", () => {
   scrollBtn.style.display = window.scrollY > 200 ? "block" : "none";
 });
 scrollBtn.addEventListener("click", () =>
-  window.scrollTo({ top: 0, behavior: "smooth" })
+  window.scrollTo({ top: 0, behavior: "smooth" }),
 );
 
 definitionContainer.addEventListener("click", clearDefinition);
-

--- a/sw.js
+++ b/sw.js
@@ -1,36 +1,72 @@
-const CACHE_NAME = 'csd-cache-v1';
+const CACHE_NAME = "csd-cache-v1";
 const URLS_TO_CACHE = [
-  '/',
-  '/index.html',
-  '/styles.css',
-  '/script.js',
-  '/data.json'
+  "/",
+  "/index.html",
+  "/styles.css",
+  "/script.js",
+  "/data.json",
 ];
 
-self.addEventListener('install', event => {
+async function fetchWithRetry(
+  input,
+  init = {},
+  maxAttempts = 3,
+  baseDelay = 500,
+  cap = 10000,
+) {
+  let attempt = 0;
+  let delay = baseDelay;
+  let lastError;
+  while (attempt < maxAttempts) {
+    try {
+      const res = await fetch(input, init);
+      if (res.status !== 429 && res.status < 500) {
+        return res;
+      }
+      lastError = new Error(`HTTP error! status: ${res.status}`);
+    } catch (err) {
+      lastError = err;
+    }
+    attempt++;
+    if (attempt >= maxAttempts) {
+      throw lastError;
+    }
+    const jitter = Math.random() * (delay * 3 - baseDelay) + baseDelay;
+    delay = Math.min(cap, jitter);
+    await new Promise((r) => setTimeout(r, delay));
+  }
+}
+
+self.addEventListener("install", (event) => {
   event.waitUntil(
-    caches.open(CACHE_NAME).then(cache => cache.addAll(URLS_TO_CACHE))
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(URLS_TO_CACHE)),
   );
 });
 
-self.addEventListener('activate', event => {
+self.addEventListener("activate", (event) => {
   event.waitUntil(
-    caches.keys().then(keys =>
-      Promise.all(
-        keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key))
-      )
-    )
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(
+          keys
+            .filter((key) => key !== CACHE_NAME)
+            .map((key) => caches.delete(key)),
+        ),
+      ),
   );
 });
 
-self.addEventListener('fetch', event => {
+self.addEventListener("fetch", (event) => {
   event.respondWith(
-    caches.match(event.request).then(response =>
-      response || fetch(event.request).catch(() => {
-        if (event.request.mode === 'navigate') {
-          return caches.match('/index.html');
-        }
-      })
-    )
+    caches.match(event.request).then(
+      (response) =>
+        response ||
+        fetchWithRetry(event.request).catch(() => {
+          if (event.request.mode === "navigate") {
+            return caches.match("/index.html");
+          }
+        }),
+    ),
   );
 });


### PR DESCRIPTION
## Summary
- wrap fetch calls with `fetchWithRetry` to retry on 429 or 5xx responses using decorrelated jitter
- limit attempts to three and surface errors when retries fail

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4e79772ac832895baf95199f63ec3