### PR TITLE
Add IP-based token bucket rate limiter

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,0 +1,59 @@
+const http = require('http');
+const path = require('path');
+const fs = require('fs');
+
+// In-memory token buckets keyed by IP
+const buckets = new Map();
+const MAX_TOKENS = 100; // max requests per interval
+const INTERVAL_MS = 60 * 1000; // refill interval
+
+function rateLimit(req, res) {
+  const ip = req.headers['x-forwarded-for'] || req.socket.remoteAddress;
+  const now = Date.now();
+  let bucket = buckets.get(ip);
+
+  if (!bucket) {
+    bucket = { tokens: MAX_TOKENS, last: now };
+    buckets.set(ip, bucket);
+  } else {
+    const elapsed = now - bucket.last;
+    const refill = (elapsed / INTERVAL_MS) * MAX_TOKENS;
+    bucket.tokens = Math.min(MAX_TOKENS, bucket.tokens + refill);
+    bucket.last = now;
+  }
+
+  if (bucket.tokens < 1) {
+    console.log(`Rate limit exceeded for IP ${ip}`);
+    res.writeHead(429, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Too Many Requests' }));
+    return false;
+  }
+
+  bucket.tokens -= 1;
+  return true;
+}
+
+function serveStatic(req, res) {
+  let filePath = path.join(__dirname, req.url === '/' ? 'index.html' : req.url);
+  fs.readFile(filePath, (err, data) => {
+    if (err) {
+      res.writeHead(404);
+      res.end('Not Found');
+    } else {
+      res.writeHead(200);
+      res.end(data);
+    }
+  });
+}
+
+const server = http.createServer((req, res) => {
+  if (!rateLimit(req, res)) {
+    return;
+  }
+  serveStatic(req, res);
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- Implement basic HTTP server with in-memory token bucket keyed by IP
- Return 429 JSON and log when rate limit exceeded

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4e799d9c8832880028ef65d8bc040