### PR TITLE
Add Sentry Replay integration with low sampling rates

### DIFF
--- a/assets/js/sentry.js
+++ b/assets/js/sentry.js
@@ -1,0 +1,8 @@
+if (window.Sentry) {
+  window.Sentry.init({
+    dsn: 'https://examplePublicKey@o0.ingest.sentry.io/0',
+    integrations: [window.Sentry.replayIntegration()],
+    replaysSessionSampleRate: 0.1,
+    replaysOnErrorSampleRate: 0.1,
+  });
+}

--- a/diagnostics.html
+++ b/diagnostics.html
@@ -5,6 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Diagnostics</title>
   <link rel="stylesheet" href="styles.css">
+  <script src="https://browser.sentry-cdn.com/7.120.0/bundle.tracing.replay.min.js"></script>
+  <script src="assets/js/sentry.js"></script>
 </head>
 <body>
   <main class="container">

--- a/index.html
+++ b/index.html
@@ -7,6 +7,8 @@
   <link rel="stylesheet" href="styles.css">
   <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet">
   <link rel="canonical" id="canonical-link" href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/">
+  <script src="https://browser.sentry-cdn.com/7.120.0/bundle.tracing.replay.min.js"></script>
+  <script src="assets/js/sentry.js"></script>
 </head>
 <body>
   <main class="container">

--- a/layout.html
+++ b/layout.html
@@ -15,6 +15,8 @@
   <meta name="twitter:description" content="An interactive dictionary for cyber security terms.">
   <meta name="twitter:url" content="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/">
   <meta name="twitter:image" content="https://github.com/Alex-Unnippillil/CyberSecuirtyDictionary/assets/24538548/c5a54c56-babb-485d-b01c-4fdfb186325b">
+  <script src="https://browser.sentry-cdn.com/7.120.0/bundle.tracing.replay.min.js"></script>
+  <script src="assets/js/sentry.js"></script>
 </head>
 <body>
   <main class="container">

--- a/search.html
+++ b/search.html
@@ -5,6 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Search</title>
   <link rel="stylesheet" href="styles.css">
+  <script src="https://browser.sentry-cdn.com/7.120.0/bundle.tracing.replay.min.js"></script>
+  <script src="assets/js/sentry.js"></script>
 </head>
 <body>
   <main class="container">

--- a/templates/about.html
+++ b/templates/about.html
@@ -3,6 +3,8 @@
 <head>
   <meta charset="UTF-8" />
   <title>About</title>
+  <script src="https://browser.sentry-cdn.com/7.120.0/bundle.tracing.replay.min.js"></script>
+  <script src="../assets/js/sentry.js"></script>
 </head>
 <body>
   <h1>About this project</h1>

--- a/templates/contribute.html
+++ b/templates/contribute.html
@@ -6,6 +6,8 @@
   <title>Contributing - Cyber Security Dictionary</title>
   <link rel="stylesheet" href="../styles.css">
   <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet">
+  <script src="https://browser.sentry-cdn.com/7.120.0/bundle.tracing.replay.min.js"></script>
+  <script src="../assets/js/sentry.js"></script>
 </head>
 <body>
   <main class="container">

--- a/templates/guidelines.html
+++ b/templates/guidelines.html
@@ -5,6 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Definition Guidelines</title>
   <link rel="stylesheet" href="../styles.css">
+  <script src="https://browser.sentry-cdn.com/7.120.0/bundle.tracing.replay.min.js"></script>
+  <script src="../assets/js/sentry.js"></script>
 </head>
 <body>
   <main class="container">

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -22,6 +22,9 @@
   <link rel="icon" href="{{ favicon_url }}" />
   <link rel="stylesheet" href="{{ stylesheet_url }}" />
 
+  <script src="https://browser.sentry-cdn.com/7.120.0/bundle.tracing.replay.min.js"></script>
+  <script src="{{ base_url }}/assets/js/sentry.js"></script>
+
   <script>
     const BASE_URL = "{{ base_url }}";
   </script>


### PR DESCRIPTION
## Summary
- Initialize Sentry Replay with low sampling rates
- Load Sentry Replay script across site pages

## Testing
- `npm test`
- Attempted to query Sentry Replay API but received unauthorized response (no credentials)


------
https://chatgpt.com/codex/tasks/task_e_68b4e79b92688328b469a6bf22a569c4