### PR TITLE
Enable fuzzy prefix search

### DIFF
--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -1,75 +1,76 @@
-(function(){
-  const resultsContainer = document.getElementById('results');
-  const searchInput = document.getElementById('search-box');
-  let terms = [];
+(function () {
+  const resultsContainer = document.getElementById("results");
+  const searchInput = document.getElementById("search-box");
+  let miniSearch;
 
-  document.addEventListener('DOMContentLoaded', () => {
-    const baseUrl = window.__BASE_URL__ || '';
+  document.addEventListener("DOMContentLoaded", () => {
+    const baseUrl = window.__BASE_URL__ || "";
     fetch(`${baseUrl}/terms.json`)
-      .then(r => r.ok ? r.json() : Promise.reject(r.statusText))
-      .then(data => {
-        // terms.json may either be an array or object with terms property
-        terms = Array.isArray(data) ? data : (data.terms || []);
+      .then((r) => (r.ok ? r.json() : Promise.reject(r.statusText)))
+      .then((data) => {
+        const terms = Array.isArray(data) ? data : data.terms || [];
+        miniSearch = new MiniSearch({
+          fields: ["title", "definition", "category", "synonyms"],
+          storeFields: ["title", "definition", "category", "synonyms"],
+          searchOptions: {
+            prefix: true,
+            fuzzy: 0.2,
+            boost: { title: 2 },
+          },
+        });
+
+        const docs = terms.map((t, i) => ({
+          id: i,
+          title: t.name || t.term || "",
+          definition: t.definition || "",
+          category: t.category || "",
+          synonyms: t.synonyms || [],
+        }));
+
+        miniSearch.addAll(docs);
       })
-      .catch(err => {
-        console.error('Failed to load terms.json', err);
+      .catch((err) => {
+        console.error("Failed to load terms.json", err);
       });
 
-    searchInput.addEventListener('input', handleSearch);
+    searchInput.addEventListener("input", handleSearch);
   });
 
-  function handleSearch(){
-    const query = searchInput.value.trim().toLowerCase();
-    resultsContainer.innerHTML = '';
-    if(!query){
+  function handleSearch() {
+    const query = searchInput.value.trim();
+    resultsContainer.innerHTML = "";
+    if (!query || !miniSearch) {
       return;
     }
-    const matches = terms
-      .map(term => ({ term, score: score(term, query) }))
-      .filter(item => item.score > 0)
-      .sort((a,b) => b.score - a.score);
-
-    matches.forEach(({ term }) => {
-      resultsContainer.appendChild(renderCard(term));
+    const matches = miniSearch.search(query);
+    matches.forEach((result) => {
+      resultsContainer.appendChild(renderCard(result));
     });
   }
 
-  function score(term, query){
-    let s = 0;
-    const name = (term.name || term.term || '').toLowerCase();
-    const def = (term.definition || '').toLowerCase();
-    const category = (term.category || '').toLowerCase();
-    const syns = (term.synonyms || []).map(s=>s.toLowerCase());
-    if(name.includes(query)) s += 3;
-    if(def.includes(query)) s += 1;
-    if(category.includes(query)) s += 1;
-    if(syns.some(syn => syn.includes(query))) s += 2;
-    return s;
-  }
+  function renderCard(term) {
+    const card = document.createElement("div");
+    card.className = "result-card";
 
-  function renderCard(term){
-    const card = document.createElement('div');
-    card.className = 'result-card';
-
-    const title = document.createElement('h3');
-    title.textContent = term.name || term.term || '';
+    const title = document.createElement("h3");
+    title.textContent = term.title || "";
     card.appendChild(title);
 
-    if(term.category){
-      const cat = document.createElement('p');
-      cat.className = 'category';
+    if (term.category) {
+      const cat = document.createElement("p");
+      cat.className = "category";
       cat.textContent = term.category;
       card.appendChild(cat);
     }
 
-    const def = document.createElement('p');
-    def.textContent = term.definition || '';
+    const def = document.createElement("p");
+    def.textContent = term.definition || "";
     card.appendChild(def);
 
-    if(term.synonyms && term.synonyms.length){
-      const syn = document.createElement('p');
-      syn.className = 'synonyms';
-      syn.textContent = `Synonyms: ${term.synonyms.join(', ')}`;
+    if (term.synonyms && term.synonyms.length) {
+      const syn = document.createElement("p");
+      syn.className = "synonyms";
+      syn.textContent = `Synonyms: ${term.synonyms.join(", ")}`;
       card.appendChild(syn);
     }
     return card;

--- a/search.html
+++ b/search.html
@@ -1,22 +1,23 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Search</title>
-  <link rel="stylesheet" href="styles.css">
-</head>
-<body>
-  <main class="container">
-    <h1>Search</h1>
-    <input id="search-box" type="text" placeholder="Search terms...">
-    <div id="results"></div>
-  </main>
-  <script>
-    window.__BASE_URL__ = window.__BASE_URL__ || '';
-  </script>
-  <script src="assets/js/search.js"></script>
-  <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
-  <script src="assets/js/metrics.js"></script>
-</body>
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Search</title>
+    <link rel="stylesheet" href="styles.css">
+  </head>
+  <body>
+    <main class="container">
+      <h1>Search</h1>
+      <input id="search-box" type="text" placeholder="Search terms...">
+      <div id="results"></div>
+    </main>
+    <script>
+      window.__BASE_URL__ = window.__BASE_URL__ || "";
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/minisearch@6.3.0/dist/umd/index.min.js"></script>
+    <script src="assets/js/search.js"></script>
+    <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
+    <script src="assets/js/metrics.js"></script>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- integrate MiniSearch for search page
- enable prefix and fuzzy search with boosted title matches

## Testing
- `npm test`
- `node -e "const MiniSearch=require('minisearch');let ms=new MiniSearch({fields:['title'],storeFields:['title'],searchOptions:{prefix:true,fuzzy:0.2}});ms.add({id:1,title:'Phishing'});console.log(ms.search('phising')[0].title);"`


------
https://chatgpt.com/codex/tasks/task_e_68b4e79cea0483289656e035bb316876