### PR TITLE
Add tag chip filtering to MiniSearch results

### DIFF
--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -1,53 +1,96 @@
-(function(){
+(function () {
   const resultsContainer = document.getElementById('results');
   const searchInput = document.getElementById('search-box');
-  let terms = [];
+  const chipContainer = document.getElementById('chip-container');
+  const selectedChips = new Set();
+  let miniSearch;
+  let documents = [];
 
   document.addEventListener('DOMContentLoaded', () => {
     const baseUrl = window.__BASE_URL__ || '';
     fetch(`${baseUrl}/terms.json`)
-      .then(r => r.ok ? r.json() : Promise.reject(r.statusText))
-      .then(data => {
-        // terms.json may either be an array or object with terms property
-        terms = Array.isArray(data) ? data : (data.terms || []);
+      .then((r) => (r.ok ? r.json() : Promise.reject(r.statusText)))
+      .then((data) => {
+        const terms = Array.isArray(data) ? data : data.terms || [];
+        documents = terms.map((t, idx) => ({
+          id: idx,
+          name: t.name || t.term || '',
+          definition: t.definition || '',
+          category: t.category || '',
+          tags: t.tags || [],
+          synonyms: t.synonyms || []
+        }));
+
+        miniSearch = new MiniSearch({
+          idField: 'id',
+          fields: ['name', 'definition', 'category', 'tags', 'synonyms'],
+          storeFields: ['name', 'definition', 'category', 'tags', 'synonyms']
+        });
+        miniSearch.addAll(documents);
+        renderChips();
       })
-      .catch(err => {
+      .catch((err) => {
         console.error('Failed to load terms.json', err);
       });
 
     searchInput.addEventListener('input', handleSearch);
   });
 
-  function handleSearch(){
-    const query = searchInput.value.trim().toLowerCase();
+  function renderChips() {
+    if (!chipContainer) return;
+    const categories = new Set();
+    documents.forEach((doc) => {
+      if (Array.isArray(doc.tags)) {
+        doc.tags.forEach((t) => categories.add(t));
+      }
+      if (doc.category) {
+        categories.add(doc.category);
+      }
+    });
+
+    Array.from(categories)
+      .sort()
+      .forEach((cat) => {
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'chip';
+        btn.textContent = cat;
+        btn.addEventListener('click', () => {
+          if (selectedChips.has(cat)) {
+            selectedChips.delete(cat);
+            btn.classList.remove('selected');
+          } else {
+            selectedChips.add(cat);
+            btn.classList.add('selected');
+          }
+          handleSearch();
+        });
+        chipContainer.appendChild(btn);
+      });
+  }
+
+  function handleSearch() {
+    const query = searchInput.value.trim();
     resultsContainer.innerHTML = '';
-    if(!query){
+    if (!query) {
       return;
     }
-    const matches = terms
-      .map(term => ({ term, score: score(term, query) }))
-      .filter(item => item.score > 0)
-      .sort((a,b) => b.score - a.score);
-
-    matches.forEach(({ term }) => {
-      resultsContainer.appendChild(renderCard(term));
+    const filters = Array.from(selectedChips);
+    const results = miniSearch.search(query, {
+      prefix: true,
+      filter: (result) => {
+        if (filters.length === 0) return true;
+        const tags = result.tags || [];
+        const cat = result.category ? [result.category] : [];
+        return tags.concat(cat).some((t) => filters.includes(t));
+      }
+    });
+    results.forEach((res) => {
+      resultsContainer.appendChild(renderCard(res));
     });
   }
 
-  function score(term, query){
-    let s = 0;
-    const name = (term.name || term.term || '').toLowerCase();
-    const def = (term.definition || '').toLowerCase();
-    const category = (term.category || '').toLowerCase();
-    const syns = (term.synonyms || []).map(s=>s.toLowerCase());
-    if(name.includes(query)) s += 3;
-    if(def.includes(query)) s += 1;
-    if(category.includes(query)) s += 1;
-    if(syns.some(syn => syn.includes(query))) s += 2;
-    return s;
-  }
-
-  function renderCard(term){
+  function renderCard(term) {
     const card = document.createElement('div');
     card.className = 'result-card';
 
@@ -55,7 +98,7 @@
     title.textContent = term.name || term.term || '';
     card.appendChild(title);
 
-    if(term.category){
+    if (term.category) {
       const cat = document.createElement('p');
       cat.className = 'category';
       cat.textContent = term.category;
@@ -66,7 +109,7 @@
     def.textContent = term.definition || '';
     card.appendChild(def);
 
-    if(term.synonyms && term.synonyms.length){
+    if (term.synonyms && term.synonyms.length) {
       const syn = document.createElement('p');
       syn.className = 'synonyms';
       syn.textContent = `Synonyms: ${term.synonyms.join(', ')}`;
@@ -75,3 +118,4 @@
     return card;
   }
 })();
+

--- a/search.html
+++ b/search.html
@@ -10,11 +10,13 @@
   <main class="container">
     <h1>Search</h1>
     <input id="search-box" type="text" placeholder="Search terms...">
+    <div id="chip-container" class="chip-container"></div>
     <div id="results"></div>
   </main>
   <script>
     window.__BASE_URL__ = window.__BASE_URL__ || '';
   </script>
+  <script src="https://unpkg.com/minisearch@6.1.0/dist/umd/index.min.js"></script>
   <script src="assets/js/search.js"></script>
   <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
   <script src="assets/js/metrics.js"></script>

--- a/styles.css
+++ b/styles.css
@@ -111,6 +111,41 @@ body.dark-mode mark {
   min-height: 44px;
 }
 
+/* Chip styles for search filters */
+.chip-container {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  margin: 10px 0;
+}
+
+.chip {
+  background-color: #eee;
+  border: 1px solid #ccc;
+  border-radius: 16px;
+  padding: 6px 12px;
+  cursor: pointer;
+  font-size: 14px;
+  min-height: 32px;
+}
+
+.chip.selected {
+  background-color: #007bff;
+  border-color: #007bff;
+  color: #fff;
+}
+
+body.dark-mode .chip {
+  background-color: #333;
+  border-color: #555;
+  color: #fff;
+}
+
+body.dark-mode .chip.selected {
+  background-color: #007bff;
+  border-color: #007bff;
+}
+
 
 /* Controls styling */
 #random-term {


### PR DESCRIPTION
## Summary
- add category filter chips to search UI
- integrate MiniSearch and filter results by selected chips
- style chips for light and dark modes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4e79d3bac8328bdbaab8c47c2a186