### PR TITLE
feat: add sitemap generation

### DIFF
--- a/app/sitemap-images.xml/route.ts
+++ b/app/sitemap-images.xml/route.ts
@@ -1,0 +1,34 @@
+import termsData from '../../terms.json';
+import siteConfig from '../../site.config.json';
+
+export async function GET() {
+  const baseUrl: string = siteConfig.siteUrl;
+  const imagesXml = (termsData.terms || [])
+    .filter((item: { term: string; image?: string }) => Boolean(item.image))
+    .map((item: { term: string; image: string }) => {
+      const loc = `${baseUrl}#${encodeURIComponent(item.term)}`;
+      const imgUrl = item.image.startsWith('http') ? item.image : `${baseUrl}${item.image}`;
+      return [
+        '\n  <url>',
+        `\n    <loc>${loc}</loc>`,
+        '\n    <image:image>',
+        `\n      <image:loc>${imgUrl}</image:loc>`,
+        `\n      <image:title>${item.term}</image:title>`,
+        '\n    </image:image>',
+        '\n  </url>',
+      ].join('');
+    })
+    .join('');
+
+  const body =
+    '<?xml version="1.0" encoding="UTF-8"?>' +
+    '\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">' +
+    imagesXml +
+    '\n</urlset>';
+
+  return new Response(body, {
+    headers: {
+      'Content-Type': 'application/xml',
+    },
+  });
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,20 @@
+import type { MetadataRoute } from 'next';
+import termsData from '../terms.json';
+import siteConfig from '../site.config.json';
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const baseUrl: string = siteConfig.siteUrl;
+
+  const termUrls = (termsData.terms || []).map((item: { term: string }) => ({
+    url: `${baseUrl}#${encodeURIComponent(item.term)}`,
+    lastModified: new Date().toISOString(),
+  }));
+
+  return [
+    {
+      url: baseUrl,
+      lastModified: new Date().toISOString(),
+    },
+    ...termUrls,
+  ];
+}


### PR DESCRIPTION
## Summary
- add Next.js sitemap emitting URLs for all dictionary terms
- expose custom route for image sitemap XML

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4e79d88b88328b6fc0b47c521df6a