### PR TITLE
feat: add OG card route handler

### DIFF
--- a/og-card.js
+++ b/og-card.js
@@ -1,0 +1,57 @@
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+// Load term data from YAML file
+const termsPath = path.join(__dirname, 'data', 'terms.yaml');
+const terms = yaml.load(fs.readFileSync(termsPath, 'utf8'));
+
+function slugify(term) {
+  return term
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+/**
+ * Route handler that returns an SVG Open Graph card for a term.
+ * The card displays the term title and any associated tags (category or tags field).
+ *
+ * @param {Object} req - Request-like object. Supported fields: params.slug or query.slug
+ * @param {Object} res - Response-like object. Must implement setHeader() and end().
+ */
+function ogCardHandler(req, res) {
+  const slug =
+    (req && req.params && req.params.slug) ||
+    (req && req.query && (req.query.slug || req.query.term));
+
+  const term = terms.find(t => t.slug === slug || slugify(t.name) === slug);
+
+  if (!term) {
+    res.statusCode = 404;
+    res.setHeader && res.setHeader('Content-Type', 'text/plain');
+    res.end('Term not found');
+    return;
+  }
+
+  const tags = [];
+  if (Array.isArray(term.tags)) {
+    tags.push(...term.tags);
+  }
+  if (term.category) {
+    tags.push(term.category);
+  }
+
+  const tagText = tags.join(', ');
+  const svg = `<?xml version="1.0" encoding="UTF-8"?>\n` +
+    `<svg width="1200" height="630" viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">\n` +
+    `  <rect width="1200" height="630" fill="#0d1b2a"/>\n` +
+    `  <text x="60" y="200" font-size="72" font-family="Arial, Helvetica, sans-serif" fill="#ffffff">${term.name}</text>\n` +
+    `  <text x="60" y="300" font-size="36" font-family="Arial, Helvetica, sans-serif" fill="#66fcf1">${tagText}</text>\n` +
+    `</svg>`;
+
+  res.setHeader && res.setHeader('Content-Type', 'image/svg+xml');
+  res.end(svg);
+}
+
+module.exports = ogCardHandler;

--- a/og-card.test.js
+++ b/og-card.test.js
@@ -1,0 +1,20 @@
+const handler = require('./og-card');
+
+function runTest() {
+  let body = '';
+  const res = {
+    setHeader: () => {},
+    end: chunk => {
+      if (chunk) body += chunk;
+    },
+  };
+
+  handler({ params: { slug: 'cve' } }, res);
+
+  if (!body.includes('CVE') || !body.includes('Vulnerability Tracking')) {
+    throw new Error('OG card did not render term title and tags');
+  }
+  console.log('OG card route test passed');
+}
+
+runTest();

--- a/og-image-meta.test.js
+++ b/og-image-meta.test.js
@@ -1,0 +1,17 @@
+const fs = require('fs');
+const { JSDOM } = require('jsdom');
+
+function runTest() {
+  const html = fs.readFileSync('layout.html', 'utf8');
+  const dom = new JSDOM(html);
+  const doc = dom.window.document;
+  const expected = 'https://github.com/Alex-Unnippillil/CyberSecuirtyDictionary/assets/24538548/c5a54c56-babb-485d-b01c-4fdfb186325b';
+  const ogImg = doc.querySelector('meta[property="og:image"]');
+  const twImg = doc.querySelector('meta[name="twitter:image"]');
+  if (!ogImg || ogImg.content !== expected || !twImg || twImg.content !== expected) {
+    throw new Error('Branded image not referenced in OG/Twitter tags');
+  }
+  console.log('OG image metadata test passed');
+}
+
+runTest();

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "script.js",
   "scripts": {
     "build": "node scripts/build.js",
-    "test": "html-validate index.html search.html diagnostics.html && node diagnostics.test.js",
+    "test": "html-validate index.html search.html diagnostics.html && node diagnostics.test.js && node og-card.test.js && node og-image-meta.test.js",
     "watch": "chokidar \"**/*.html\" -c \"npm run build\""
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
- add route handler that renders an SVG OG card with term title and tags
- verify OG and Twitter metadata use branded image
- test OG card rendering and meta tags

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4e79f2b34832887edb955543e0d02