### PR TITLE
fix: cache updated terms file

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@ const URLS_TO_CACHE = [
   '/index.html',
   '/styles.css',
   '/script.js',
-  '/data.json'
+  '/terms.json'
 ];
 
 self.addEventListener('install', event => {


### PR DESCRIPTION
## Summary
- fix service worker to cache `terms.json`

## Testing
- `npm test`
- `npm run build` *(fails: Error: Cannot find module '/workspace/CyberSecuirtyDictionary/scripts/build.js')*

------
https://chatgpt.com/codex/tasks/task_e_68b4f8c5601083288c9ccaeea2a4e293