### PR TITLE
Remove duplicate term and enforce uniqueness in dictionary

### DIFF
--- a/check-duplicates.js
+++ b/check-duplicates.js
@@ -1,0 +1,19 @@
+const fs = require('fs');
+
+const terms = JSON.parse(fs.readFileSync('terms.json', 'utf8')).terms;
+const seen = new Set();
+const duplicates = new Set();
+
+for (const { term } of terms) {
+  if (seen.has(term)) {
+    duplicates.add(term);
+  } else {
+    seen.add(term);
+  }
+}
+
+if (duplicates.size > 0) {
+  console.error(`Duplicate terms found: ${Array.from(duplicates).join(', ')}`);
+  process.exit(1);
+}
+

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "description": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/",
   "main": "script.js",
   "scripts": {
+    "prebuild": "node check-duplicates.js",
+    "pretest": "node check-duplicates.js",
     "build": "node scripts/build.js",
     "test": "html-validate index.html search.html diagnostics.html && node diagnostics.test.js",
     "watch": "chokidar \"**/*.html\" -c \"npm run build\""

--- a/terms.json
+++ b/terms.json
@@ -127,10 +127,6 @@
     {
       "term": "Cross-Site Request Forgery (CSRF)",
       "definition": "An attack that tricks a user into unknowingly submitting a malicious request on a trusted website."
-    },
-    {
-      "term": "Phishing Email",
-      "definition": "An email sent by attackers that appears legitimate but aims to trick recipients into revealing sensitive information or performing actions."
     }
   ]
 }


### PR DESCRIPTION
## Summary
- remove duplicate "Phishing Email" entry in `terms.json`
- add `check-duplicates.js` to detect repeated terms
- run duplicate check before build and tests via `package.json`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4f8c36b688328bd72d460e71dfe22