### PR TITLE
feat: add content API for terms

### DIFF
--- a/lib/content/api.ts
+++ b/lib/content/api.ts
@@ -1,0 +1,35 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { load } from 'js-yaml';
+
+export interface Term {
+  name: string;
+  slug: string;
+  definition: string;
+  category?: string;
+  synonyms?: string[];
+  see_also?: string[];
+  sources?: string[];
+}
+
+let cachedTerms: Term[] | null = null;
+
+function loadTerms(): Term[] {
+  if (cachedTerms) {
+    return cachedTerms;
+  }
+  const filePath = path.join(__dirname, '../../data/terms.yaml');
+  const file = fs.readFileSync(filePath, 'utf8');
+  const loaded = load(file) as Term[] | { terms: Term[] };
+  const terms = Array.isArray(loaded) ? loaded : (loaded as { terms: Term[] }).terms;
+  cachedTerms = terms;
+  return terms;
+}
+
+export function getAllTerms(): Term[] {
+  return loadTerms();
+}
+
+export function getTermBySlug(slug: string): Term | undefined {
+  return loadTerms().find((t) => t.slug === slug);
+}


### PR DESCRIPTION
## Summary
- add typed Term interface and API functions to load all terms or a single term by slug

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b50c9a7ea4832891348d67cbb20060