### PR TITLE
feat: add search page and term card

### DIFF
--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -1,0 +1,25 @@
+import TermCard from "../../components/search/TermCard";
+import termsData from "../../terms.json";
+
+type Term = {
+  term: string;
+  definition: string;
+  tags?: string[];
+};
+
+export default function SearchPage() {
+  const { terms } = termsData as { terms: Term[] };
+
+  return (
+    <main>
+      {terms.map((t) => (
+        <TermCard
+          key={t.term}
+          title={t.term}
+          definition={t.definition}
+          tags={t.tags || []}
+        />
+      ))}
+    </main>
+  );
+}

--- a/components/search/TermCard.tsx
+++ b/components/search/TermCard.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+
+type TermCardProps = {
+  title: string;
+  definition: string;
+  tags?: string[];
+};
+
+const TermCard: React.FC<TermCardProps> = ({ title, definition, tags = [] }) => (
+  <div className="term-card">
+    <h2>{title}</h2>
+    <p>{definition}</p>
+    {tags.length > 0 && (
+      <ul className="term-tags">
+        {tags.map((tag) => (
+          <li key={tag}>{tag}</li>
+        ))}
+      </ul>
+    )}
+  </div>
+);
+
+export default TermCard;


### PR DESCRIPTION
## Summary
- add TermCard component showing title, definition, and tags
- add search page rendering dictionary terms with TermCard

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b50ca1416c8328a4916332c13d1be7