### PR TITLE
feat: add search bar component

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,10 @@
+import SearchBar from "../components/search/SearchBar";
+
+export default function Home() {
+  return (
+    <main>
+      <h1>Cyber Security Dictionary</h1>
+      <SearchBar />
+    </main>
+  );
+}

--- a/components/search/SearchBar.tsx
+++ b/components/search/SearchBar.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { ChangeEvent } from "react";
+
+export default function SearchBar() {
+  const router = useRouter();
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const query = e.target.value.trim();
+    if (query) {
+      router.push(`/search?q=${encodeURIComponent(query)}`);
+    } else {
+      router.push("/search");
+    }
+  };
+
+  return (
+    <input
+      type="text"
+      placeholder="Search terms..."
+      onChange={handleChange}
+      aria-label="Search terms"
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- add client-side SearchBar component navigating to `/search`
- include SearchBar on home page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b50ca45e7883289e14c9d791eee9eb