### PR TITLE
Add A-Z index page with term filtering

### DIFF
--- a/app/a-z/page.tsx
+++ b/app/a-z/page.tsx
@@ -1,0 +1,7 @@
+import AZIndex from "../../components/search/AZIndex";
+import termsData from "../../terms.json";
+
+export default function AZPage() {
+  return <AZIndex terms={termsData.terms} />;
+}
+

--- a/components/search/AZIndex.tsx
+++ b/components/search/AZIndex.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useState } from "react";
+
+interface Term {
+  term: string;
+  definition: string;
+}
+
+interface Props {
+  terms: Term[];
+}
+
+const letters = Array.from({ length: 26 }, (_, i) =>
+  String.fromCharCode(65 + i)
+);
+
+export default function AZIndex({ terms }: Props) {
+  const [filter, setFilter] = useState<string | null>(null);
+
+  const filtered = filter
+    ? terms.filter((t) => t.term.toUpperCase().startsWith(filter))
+    : terms;
+
+  return (
+    <div>
+      <nav className="az-index">
+        {letters.map((l) => (
+          <button
+            key={l}
+            type="button"
+            onClick={() => setFilter(l)}
+            className={filter === l ? "active" : ""}
+            aria-pressed={filter === l}
+          >
+            {l}
+          </button>
+        ))}
+      </nav>
+      <ul className="term-list">
+        {filtered.map((t) => (
+          <li key={t.term}>
+            <strong>{t.term}</strong>: {t.definition}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- create AZIndex component with clickable alphabet to filter terms by initial
- add /a-z page rendering AZIndex with existing term data

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b50cae595883289fad972394ff9415