### PR TITLE
feat: add related terms component

### DIFF
--- a/components/term/RelatedTerms.tsx
+++ b/components/term/RelatedTerms.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+
+export interface RelatedTerm {
+  /** Slug used to build link to the term page */
+  slug: string;
+  /** Human readable term name */
+  name: string;
+}
+
+interface RelatedTermsProps {
+  /** Terms related to the current entry */
+  relatedTerms?: RelatedTerm[];
+}
+
+/**
+ * Displays a list of related terms for an entry.
+ *
+ * Related terms are rendered as pill-shaped links that lead to
+ * their respective term pages. If no related terms are supplied,
+ * nothing is rendered.
+ */
+const RelatedTerms: React.FC<RelatedTermsProps> = ({ relatedTerms }) => {
+  if (!relatedTerms || relatedTerms.length === 0) return null;
+
+  return (
+    <section className="related-terms">
+      <h2 className="related-terms__heading">See also</h2>
+      <ul className="related-terms__list">
+        {relatedTerms.map((term) => (
+          <li key={term.slug} className="related-terms__item">
+            <a href={`/terms/${term.slug}`} className="related-terms__pill">
+              {term.name}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+};
+
+export default RelatedTerms;


### PR DESCRIPTION
## Summary
- add React `RelatedTerms` component for rendering related term pills

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b50cb070448328a95712814abd82dd