### PR TITLE
feat: stream chat responses

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,0 +1,29 @@
+import { streamText } from 'ai';
+import { createOpenAI } from '@ai-sdk/openai';
+
+// Initialize OpenAI client using the API key from environment variables.
+const openai = createOpenAI({
+  apiKey: process.env.OPENAI_API_KEY || ''
+});
+
+// Handle POST requests to the chat endpoint. This uses the `streamText`
+// helper to stream tokens from the model and return partial results as
+// they are generated.
+export async function POST(req: Request): Promise<Response> {
+  try {
+    const { messages } = await req.json();
+
+    const result = await streamText({
+      model: openai('gpt-4o-mini'),
+      messages,
+    });
+
+    // Convert the stream into a `Response` object that emits Server-Sent
+    // Events. Each event contains partial model output so the caller can
+    // render tokens incrementally.
+    return result.toDataStreamResponse();
+  } catch (error) {
+    console.error('Chat streaming failed', error);
+    return new Response('Failed to generate chat response', { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- add chat API route that streams partial model responses with `streamText`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b50cb4a6548328924ee460a7283a44