### PR TITLE
feat: add AI context generator

### DIFF
--- a/lib/ai/context.ts
+++ b/lib/ai/context.ts
@@ -1,0 +1,28 @@
+export interface TermFrontMatter {
+  name?: string;
+  term?: string;
+  definition?: string;
+  category?: string;
+  synonyms?: string[];
+  see_also?: string[];
+  sources?: string[];
+  [key: string]: any;
+}
+
+/**
+ * Build a concise context string for a term from its MDX front matter.
+ */
+export function toContext(term: TermFrontMatter): string {
+  const parts: string[] = [];
+
+  const title = term.name || term.term;
+  if (title) parts.push(title);
+  if (term.definition) parts.push(term.definition);
+  if (term.category) parts.push(`Category: ${term.category}`);
+  if (term.synonyms && term.synonyms.length)
+    parts.push(`Synonyms: ${term.synonyms.join(", ")}`);
+  if (term.see_also && term.see_also.length)
+    parts.push(`See also: ${term.see_also.join(", ")}`);
+
+  return parts.join(" | ");
+}


### PR DESCRIPTION
## Summary
- add `toContext` utility to build concise context strings from MDX front matter

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b50cb6649c832895f2f11646b39da2