### PR TITLE
Add customizable settings page

### DIFF
--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+export default function SettingsPage() {
+  const [darkMode, setDarkMode] = useState(false);
+  const [fontSize, setFontSize] = useState("medium");
+  const [density, setDensity] = useState("comfortable");
+  const [preferredSources, setPreferredSources] = useState<string[]>([]);
+
+  useEffect(() => {
+    const saved = localStorage.getItem("settings");
+    if (saved) {
+      try {
+        const parsed = JSON.parse(saved);
+        setDarkMode(parsed.darkMode ?? false);
+        setFontSize(parsed.fontSize ?? "medium");
+        setDensity(parsed.density ?? "comfortable");
+        setPreferredSources(parsed.preferredSources ?? []);
+      } catch {
+        // ignore parse errors
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    const data = { darkMode, fontSize, density, preferredSources };
+    localStorage.setItem("settings", JSON.stringify(data));
+    document.documentElement.classList.toggle("dark", darkMode);
+    document.documentElement.style.fontSize =
+      fontSize === "small" ? "14px" : fontSize === "large" ? "18px" : "16px";
+  }, [darkMode, fontSize, density, preferredSources]);
+
+  const toggleSource = (src: string) => {
+    setPreferredSources((prev) =>
+      prev.includes(src) ? prev.filter((s) => s !== src) : [...prev, src],
+    );
+  };
+
+  return (
+    <main className="p-4 space-y-6">
+      <h1 className="text-2xl font-bold">Settings</h1>
+
+      <section>
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={darkMode}
+            onChange={(e) => setDarkMode(e.target.checked)}
+          />
+          Dark mode
+        </label>
+      </section>
+
+      <section>
+        <label className="flex flex-col gap-2">
+          <span>Font size</span>
+          <select
+            value={fontSize}
+            onChange={(e) => setFontSize(e.target.value)}
+          >
+            <option value="small">Small</option>
+            <option value="medium">Medium</option>
+            <option value="large">Large</option>
+          </select>
+        </label>
+      </section>
+
+      <section>
+        <label className="flex flex-col gap-2">
+          <span>Density</span>
+          <select value={density} onChange={(e) => setDensity(e.target.value)}>
+            <option value="comfortable">Comfortable</option>
+            <option value="compact">Compact</option>
+          </select>
+        </label>
+      </section>
+
+      <section className="space-y-2">
+        <div>Preferred sources</div>
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={preferredSources.includes("internal")}
+            onChange={() => toggleSource("internal")}
+          />
+          Internal
+        </label>
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={preferredSources.includes("external")}
+            onChange={() => toggleSource("external")}
+          />
+          External
+        </label>
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add new `app/settings` page for user preferences
- support toggles for dark mode, font size, density, and preferred sources

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b50cba1c20832885bdfb8f1a9c5c05