### PR TITLE
feat: add localStorage prefs helper

### DIFF
--- a/lib/ui/prefs.js
+++ b/lib/ui/prefs.js
@@ -1,0 +1,44 @@
+'use strict';
+const STORAGE_KEY = 'user-prefs';
+function loadPrefs() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    return typeof parsed === 'object' && parsed ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+function savePrefs(prefs) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(prefs));
+  } catch {
+    // Ignore storage errors (e.g. quota exceeded, unavailable)
+  }
+}
+function getPref(key, fallback) {
+  const prefs = loadPrefs();
+  return Object.prototype.hasOwnProperty.call(prefs, key)
+    ? prefs[key]
+    : fallback;
+}
+function setPref(key, value) {
+  const prefs = loadPrefs();
+  prefs[key] = value;
+  savePrefs(prefs);
+}
+function clearPrefs() {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // Ignore storage errors
+  }
+}
+module.exports = {
+  loadPrefs,
+  savePrefs,
+  getPref,
+  setPref,
+  clearPrefs,
+};

--- a/lib/ui/prefs.ts
+++ b/lib/ui/prefs.ts
@@ -1,0 +1,62 @@
+export type Prefs = Record<string, unknown>;
+
+const STORAGE_KEY = 'user-prefs';
+
+/**
+ * Load all preferences from localStorage. Any parse errors result
+ * in an empty object so callers never have to handle exceptions.
+ */
+export function loadPrefs(): Prefs {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    return typeof parsed === 'object' && parsed ? (parsed as Prefs) : {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Persist the provided preferences object to localStorage.
+ * Errors are silently ignored to keep the UI responsive.
+ */
+export function savePrefs(prefs: Prefs): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(prefs));
+  } catch {
+    // Ignore storage errors (e.g. quota exceeded, unavailable)
+  }
+}
+
+/**
+ * Retrieve a single preference value. If the preference is absent,
+ * the optional fallback value is returned.
+ */
+export function getPref<T = unknown>(key: string, fallback?: T): T | undefined {
+  const prefs = loadPrefs();
+  return Object.prototype.hasOwnProperty.call(prefs, key)
+    ? (prefs[key] as T)
+    : fallback;
+}
+
+/**
+ * Update a single preference value in localStorage. Existing
+ * preferences are merged with the provided key/value pair.
+ */
+export function setPref<T = unknown>(key: string, value: T): void {
+  const prefs = loadPrefs();
+  (prefs as any)[key] = value;
+  savePrefs(prefs);
+}
+
+/**
+ * Remove all stored preferences.
+ */
+export function clearPrefs(): void {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // Ignore storage errors
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "script.js",
   "scripts": {
     "build": "node scripts/build.js",
-    "test": "html-validate index.html search.html diagnostics.html && node diagnostics.test.js",
+    "test": "html-validate index.html search.html diagnostics.html && node diagnostics.test.js && node prefs.test.js",
     "watch": "chokidar \"**/*.html\" -c \"npm run build\""
   },
   "keywords": [],

--- a/prefs.test.js
+++ b/prefs.test.js
@@ -1,0 +1,30 @@
+const { JSDOM } = require('jsdom');
+
+// Set up a DOM with localStorage for the prefs module
+const dom = new JSDOM('', { url: 'https://example.com' });
+global.localStorage = dom.window.localStorage;
+
+const {
+  loadPrefs,
+  savePrefs,
+  getPref,
+  setPref,
+  clearPrefs,
+} = require('./lib/ui/prefs.js');
+
+clearPrefs();
+const original = { theme: 'dark', fontSize: 14 };
+savePrefs(original);
+const loaded = loadPrefs();
+if (JSON.stringify(loaded) !== JSON.stringify(original)) {
+  console.error('Loaded preferences did not match saved preferences');
+  process.exit(1);
+}
+
+setPref('theme', 'light');
+if (getPref('theme') !== 'light') {
+  console.error('Preference did not round-trip through storage');
+  process.exit(1);
+}
+
+console.log('Prefs round-trip test passed');


### PR DESCRIPTION
## Summary
- add `lib/ui/prefs.ts` for loading, saving, and updating user preferences in `localStorage`
- cover helper with a simple jsdom-based test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b50cbbafb4832886d27a1955612fa0