### PR TITLE
feat: add share button component

### DIFF
--- a/components/term/ShareButton.tsx
+++ b/components/term/ShareButton.tsx
@@ -1,0 +1,51 @@
+import React, { useState } from "react";
+
+/**
+ * ShareButton copies the current page's canonical URL to the clipboard
+ * and shows a temporary toast notification.
+ */
+const ShareButton: React.FC = () => {
+  const [visible, setVisible] = useState(false);
+
+  const copyCanonical = async () => {
+    const canonical = document.querySelector<HTMLLinkElement>(
+      'link[rel="canonical"]',
+    );
+    const url = canonical?.href || window.location.href;
+
+    try {
+      await navigator.clipboard.writeText(url);
+      setVisible(true);
+      setTimeout(() => setVisible(false), 2000);
+    } catch (err) {
+      console.error("Unable to copy URL", err);
+    }
+  };
+
+  return (
+    <>
+      <button onClick={copyCanonical} aria-label="Share term">
+        Share
+      </button>
+      {visible && (
+        <div
+          role="status"
+          style={{
+            position: "fixed",
+            bottom: "1rem",
+            left: "50%",
+            transform: "translateX(-50%)",
+            background: "#333",
+            color: "#fff",
+            padding: "0.5rem 1rem",
+            borderRadius: "4px",
+          }}
+        >
+          Link copied to clipboard
+        </div>
+      )}
+    </>
+  );
+};
+
+export default ShareButton;


### PR DESCRIPTION
## Summary
- add ShareButton component to copy canonical URL to clipboard and show toast

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b50cd27f108328a19b84d8edea9928