### PR TITLE
Add keyboard shortcuts for search and help

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { ReactNode, useEffect } from "react";
+import { registerShortcuts } from "../lib/ui/shortcuts";
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  useEffect(() => {
+    const unregister = registerShortcuts(
+      () => document.getElementById("search")?.focus(),
+      () => document.getElementById("help")?.classList.remove("hidden"),
+    );
+    return unregister;
+  }, []);
+
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/lib/ui/shortcuts.ts
+++ b/lib/ui/shortcuts.ts
@@ -1,0 +1,24 @@
+export function registerShortcuts(
+  focusSearch: () => void,
+  openHelp: () => void,
+): () => void {
+  function handler(event: KeyboardEvent): void {
+    const target = event.target as HTMLElement | null;
+    const isInput =
+      target &&
+      (target.tagName === "INPUT" ||
+        target.tagName === "TEXTAREA" ||
+        target.isContentEditable);
+    if (isInput) return;
+
+    if (event.key === "/") {
+      event.preventDefault();
+      focusSearch();
+    } else if (event.key === "?" || (event.shiftKey && event.key === "/")) {
+      event.preventDefault();
+      openHelp();
+    }
+  }
+  window.addEventListener("keydown", handler);
+  return () => window.removeEventListener("keydown", handler);
+}


### PR DESCRIPTION
## Summary
- implement generic keyboard shortcuts utility
- add RootLayout that wires up `/` to focus search and `?` to open help

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b50cd52ba48328ae6b38be65f48dea