### PR TITLE
Add source preference toggle on settings page

### DIFF
--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+const SOURCES = ['NIST', 'OWASP', 'MITRE'];
+
+export default function SettingsPage() {
+  const [preferred, setPreferred] = useState<string | null>(null);
+
+  // Load preference from localStorage
+  useEffect(() => {
+    const stored = localStorage.getItem('preferredSource');
+    if (stored && SOURCES.includes(stored)) {
+      setPreferred(stored);
+    }
+  }, []);
+
+  const handleToggle = (source: string) => {
+    const next = preferred === source ? null : source;
+    setPreferred(next);
+    if (next) {
+      localStorage.setItem('preferredSource', next);
+    } else {
+      localStorage.removeItem('preferredSource');
+    }
+  };
+
+  const orderedSources = preferred
+    ? [preferred, ...SOURCES.filter((s) => s !== preferred)]
+    : SOURCES;
+
+  // Persist ordered sources
+  useEffect(() => {
+    localStorage.setItem('sourceOrder', JSON.stringify(orderedSources));
+  }, [orderedSources]);
+
+  return (
+    <main>
+      <h1>Settings</h1>
+      <section>
+        <h2>Source Preference</h2>
+        {SOURCES.map((source) => (
+          <label key={source} style={{ display: 'block', marginBottom: '0.5rem' }}>
+            <input
+              type="checkbox"
+              checked={preferred === source}
+              onChange={() => handleToggle(source)}
+            />
+            Prefer {source}
+          </label>
+        ))}
+      </section>
+      <section>
+        <h2>Current Source Order</h2>
+        <ol>
+          {orderedSources.map((source) => (
+            <li key={source}>{source}</li>
+          ))}
+        </ol>
+      </section>
+    </main>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add settings page with ability to prefer NIST/OWASP/MITRE and store order

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b50cf530a88328b1d7578e7df063ff