### PR TITLE
feat: add random term button component

### DIFF
--- a/components/search/RandomTerm.tsx
+++ b/components/search/RandomTerm.tsx
@@ -1,0 +1,41 @@
+import React, { useEffect, useState } from 'react';
+
+type Term = {
+  term?: string;
+  name?: string;
+};
+
+/**
+ * Renders a button that navigates the user to a random term from `terms.json`.
+ */
+const RandomTerm: React.FC = () => {
+  const [terms, setTerms] = useState<Term[]>([]);
+
+  useEffect(() => {
+    fetch('/terms.json')
+      .then(res => res.json())
+      .then(data => {
+        const list = Array.isArray(data) ? data : data.terms || [];
+        setTerms(list);
+      })
+      .catch(() => setTerms([]));
+  }, []);
+
+  const handleClick = () => {
+    if (!terms.length) return;
+    const random = terms[Math.floor(Math.random() * terms.length)];
+    const name = random.term || random.name || '';
+    if (name) {
+      window.location.href = `#${encodeURIComponent(name)}`;
+    }
+  };
+
+  return (
+    <button type="button" onClick={handleClick} aria-label="Random term">
+      Random Term
+    </button>
+  );
+};
+
+export default RandomTerm;
+


### PR DESCRIPTION
## Summary
- add React RandomTerm button component to navigate to a random term

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b50cf87a8083289be38eeb838ac83d