### PR TITLE
Add Node.js runtime export for chat route

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,0 +1,6 @@
+export const runtime = 'nodejs';
+
+// Placeholder API route.
+export async function POST(request: Request) {
+  return new Response('Not Implemented', { status: 501 });
+}


### PR DESCRIPTION
## Summary
- ensure chat route explicitly exports Node.js runtime
- add placeholder POST handler for chat route

## Testing
- `npm test >/tmp/test.log && tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_68b50cfa7f388328b341eddcf8b3a3a1