### PR TITLE
Document term template and citation policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,11 +6,43 @@ Thank you for taking the time to contribute to the Cyber Security Dictionary!
 
 1. **Open an issue**
    - Use the ["New term" issue template](.github/ISSUE_TEMPLATE/new-term.yml).
-   - Include the term, a clear definition, and optional sources.
+   - Include the term, a clear definition, and at least one reputable source.
 2. **Submit a pull request**
-   - Fork the repository and update `data.json` with your term.
+   - Fork the repository and update `data/terms.yaml` with your term.
    - Reference the issue in your pull request.
    - Ensure any related documentation is updated.
+
+### Term template
+
+Add your entry to `data/terms.yaml` using the following structure:
+
+```yaml
+- name: Example Term
+  slug: example-term
+  definition: >-
+    Concise, original explanation of the concept.
+  category: Category Name
+  synonyms:
+    - Optional synonym
+  see_also:
+    - RelatedTerm
+  sources:
+    - https://example.org/reference
+```
+
+- `name`: term as it should appear.
+- `slug`: URL-friendly version of the name.
+- `definition`: one- to two-sentence description written in your own words.
+- `category`: grouping to help with browsing.
+- `synonyms`: optional list of alternative names.
+- `see_also`: optional list of related terms.
+- `sources`: list of references that informed the definition.
+
+### Citation policy
+
+Definitions must be original and supported by credible references.
+List every source in the `sources` array as a full URL or citation.
+Avoid copying text directly; if you quote, use quotation marks and attribute the source.
 
 ## Pull request checklist
 

--- a/templates/guidelines.html
+++ b/templates/guidelines.html
@@ -1,16 +1,48 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Definition Guidelines</title>
-  <link rel="stylesheet" href="../styles.css">
-</head>
-<body>
-  <main class="container">
-    <h1>Definition Guidelines</h1>
-    <p>Each entry in this dictionary should offer an original explanation of a term rather than copying text from other sources.</p>
-    <p>Write definitions in your own words and back them with reputable sources. Include citations or links to the materials that informed your description.</p>
-  </main>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Definition Guidelines</title>
+    <link rel="stylesheet" href="../styles.css" />
+  </head>
+  <body>
+    <main class="container">
+      <h1>Definition Guidelines</h1>
+      <p>
+        Each entry in this dictionary should offer an original explanation of a
+        term rather than copying text from other sources.
+      </p>
+      <p>
+        Write definitions in your own words and back them with reputable
+        sources. Include citations or links to the materials that informed your
+        description.
+      </p>
+
+      <h2>Term template</h2>
+      <p>
+        Add new entries to <code>data/terms.yaml</code> using the structure
+        below:
+      </p>
+      <pre><code>- name: Example Term
+  slug: example-term
+  definition: >-
+    Concise, original explanation of the concept.
+  category: Category Name
+  synonyms:
+    - Optional synonym
+  see_also:
+    - RelatedTerm
+  sources:
+    - https://example.org/reference</code></pre>
+
+      <h2>Citation policy</h2>
+      <p>
+        Every term must cite at least one reliable source. List references in
+        the <code>sources</code> field as full URLs or standard citations. Avoid
+        copying text directly; paraphrase in your own words and clearly
+        attribute any quotations.
+      </p>
+    </main>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- clarify contribution instructions with a YAML term template and field descriptions
- document citation policy requiring reputable sources in each term
- mirror template and policy in the website guidelines page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b50d0552fc83288ae2402b5026482c