### PR TITLE
Add MDX-backed term pages with source links

### DIFF
--- a/app/term/[slug]/page.tsx
+++ b/app/term/[slug]/page.tsx
@@ -1,0 +1,29 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { notFound } from 'next/navigation';
+import matter from 'gray-matter';
+import TermPage from '@/components/term/TermPage';
+
+interface PageProps {
+  params: { slug: string };
+}
+
+export default async function Page({ params }: PageProps) {
+  const filePath = path.join(process.cwd(), 'terms', `${params.slug}.mdx`);
+  let file: string;
+  try {
+    file = await fs.readFile(filePath, 'utf8');
+  } catch {
+    notFound();
+  }
+  const { content, data } = matter(file!);
+  return <TermPage title={data.title ?? params.slug} body={content} sources={data.sources} />;
+}
+
+export async function generateStaticParams() {
+  const dir = path.join(process.cwd(), 'terms');
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  return entries
+    .filter((e) => e.isFile() && e.name.endsWith('.mdx'))
+    .map((e) => ({ slug: e.name.replace(/\.mdx$/, '') }));
+}

--- a/components/term/TermPage.tsx
+++ b/components/term/TermPage.tsx
@@ -1,0 +1,49 @@
+import { MDXRemote } from 'next-mdx-remote/rsc';
+
+interface SourceLinks {
+  nist?: string;
+  owasp?: string;
+  attack?: string;
+}
+
+interface TermPageProps {
+  title: string;
+  body: string;
+  sources?: SourceLinks;
+}
+
+/**
+ * Renders a security term page including MDX content and optional sources.
+ */
+export default function TermPage({ title, body, sources }: TermPageProps) {
+  const hasSources = sources && (sources.nist || sources.owasp || sources.attack);
+
+  return (
+    <article className="term">
+      <h1>{title}</h1>
+      <MDXRemote source={body} />
+      {hasSources && (
+        <section className="sources">
+          <h2>Sources</h2>
+          <ul>
+            {sources?.nist && (
+              <li>
+                NIST: <a href={sources.nist}>{sources.nist}</a>
+              </li>
+            )}
+            {sources?.owasp && (
+              <li>
+                OWASP: <a href={sources.owasp}>{sources.owasp}</a>
+              </li>
+            )}
+            {sources?.attack && (
+              <li>
+                ATT&CK: <a href={sources.attack}>{sources.attack}</a>
+              </li>
+            )}
+          </ul>
+        </section>
+      )}
+    </article>
+  );
+}


### PR DESCRIPTION
## Summary
- create dynamic term page at `app/term/[slug]/page.tsx`
- add `TermPage` component rendering MDX content and optional NIST/OWASP/ATT&CK sources

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b50d161d9c8328b97d4043ead2b919