### PR TITLE
Add global SearchBox with cancellable debounced queries

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import SearchBox from '../components/search/SearchBox';
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>
+        <SearchBox />
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/components/Spinner.tsx
+++ b/components/Spinner.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function Spinner() {
+  return (
+    <div role="status" aria-label="loading" className="spinner">
+      Loading...
+    </div>
+  );
+}

--- a/components/search/SearchBox.tsx
+++ b/components/search/SearchBox.tsx
@@ -1,0 +1,47 @@
+import React, { useState, useEffect } from 'react';
+import Spinner from '../Spinner';
+import { search } from '../../lib/api/search';
+
+export default function SearchBox() {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<any[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!query) {
+      setResults([]);
+      return;
+    }
+
+    const handle = setTimeout(() => {
+      setLoading(true);
+      search(query)
+        .then((data) => setResults(data))
+        .catch(() => {})
+        .finally(() => setLoading(false));
+    }, 300);
+
+    return () => {
+      clearTimeout(handle);
+    };
+  }, [query]);
+
+  return (
+    <div>
+      <input
+        type="text"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        placeholder="Search..."
+      />
+      {loading && <Spinner />}
+      {results.length > 0 && (
+        <ul>
+          {results.map((item, idx) => (
+            <li key={idx}>{String(item)}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/lib/api/search.ts
+++ b/lib/api/search.ts
@@ -1,0 +1,21 @@
+let controller: AbortController | null = null;
+
+export async function search(query: string): Promise<any> {
+  if (controller) {
+    controller.abort();
+  }
+
+  controller = new AbortController();
+
+  try {
+    const response = await fetch(`/api/search?q=${encodeURIComponent(query)}`, {
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      throw new Error(`Request failed with status ${response.status}`);
+    }
+    return await response.json();
+  } finally {
+    controller = null;
+  }
+}


### PR DESCRIPTION
## Summary
- add SearchBox component with 300ms debounce and loading spinner
- implement cancellable search API using `AbortController`
- mount SearchBox in root layout for global access

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b52323ce388328b3b0b8ca88e7b849