### PR TITLE
feat: add search suggestions

### DIFF
--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useSearchParams } from 'next/navigation';
+
+interface Term {
+  term: string;
+  definition: string;
+}
+
+interface SearchResponse {
+  results: Term[];
+  suggestions: string[];
+}
+
+export default function SearchPage() {
+  const searchParams = useSearchParams();
+  const query = searchParams.get('q') || '';
+  const [data, setData] = useState<SearchResponse | null>(null);
+
+  useEffect(() => {
+    if (!query) return;
+    fetch(`/api/search?q=${encodeURIComponent(query)}`)
+      .then((res) => res.json())
+      .then(setData)
+      .catch(() => setData({ results: [], suggestions: [] }));
+  }, [query]);
+
+  const results = data?.results || [];
+  const suggestions = data?.suggestions || [];
+
+  return (
+    <div>
+      {suggestions.length > 0 && (
+        <div className="suggestions">
+          <p>Did you mean:</p>
+          <ul>
+            {suggestions.map((s) => (
+              <li key={s}>
+                <Link href={`/search?q=${encodeURIComponent(s)}`}>{s}</Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      <ul>
+        {results.map((r) => (
+          <li key={r.term}>
+            <strong>{r.term}</strong>: {r.definition}
+          </li>
+        ))}
+        {results.length === 0 && <li>No results found.</li>}
+      </ul>
+    </div>
+  );
+}
+

--- a/pages/api/search.ts
+++ b/pages/api/search.ts
@@ -1,0 +1,70 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import termsData from '../../terms.json';
+
+interface Term {
+  term: string;
+  definition: string;
+}
+
+interface SearchResponse {
+  results: Term[];
+  suggestions: string[];
+}
+
+// Simple Levenshtein distance implementation for suggestion ranking
+function levenshtein(a: string, b: string): number {
+  const matrix: number[][] = Array.from({ length: b.length + 1 }, () => []);
+
+  for (let i = 0; i <= b.length; i++) {
+    matrix[i][0] = i;
+  }
+  for (let j = 0; j <= a.length; j++) {
+    matrix[0][j] = j;
+  }
+
+  for (let i = 1; i <= b.length; i++) {
+    for (let j = 1; j <= a.length; j++) {
+      if (b[i - 1] === a[j - 1]) {
+        matrix[i][j] = matrix[i - 1][j - 1];
+      } else {
+        matrix[i][j] = Math.min(
+          matrix[i - 1][j - 1] + 1,
+          matrix[i][j - 1] + 1,
+          matrix[i - 1][j] + 1
+        );
+      }
+    }
+  }
+
+  return matrix[b.length][a.length];
+}
+
+export default function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<SearchResponse>
+) {
+  const query = String(req.query.q || '').trim().toLowerCase();
+  const terms: Term[] = (termsData as any).terms || [];
+
+  if (!query) {
+    res.status(200).json({ results: [], suggestions: [] });
+    return;
+  }
+
+  const results = terms.filter((t) =>
+    t.term.toLowerCase().includes(query)
+  );
+  const exact = terms.find((t) => t.term.toLowerCase() === query);
+
+  let suggestions: string[] = [];
+  if (!exact) {
+    suggestions = terms
+      .map((t) => ({ term: t.term, distance: levenshtein(query, t.term.toLowerCase()) }))
+      .sort((a, b) => a.distance - b.distance)
+      .slice(0, 5)
+      .map((s) => s.term);
+  }
+
+  res.status(200).json({ results, suggestions });
+}
+


### PR DESCRIPTION
## Summary
- add API endpoint that includes suggested terms when no exact match
- show correction links above search results

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b523247d188328b6a6999323f5648e