### PR TITLE
feat: add fuzzy search toggle

### DIFF
--- a/api/search.ts
+++ b/api/search.ts
@@ -1,0 +1,15 @@
+/**
+ * Performs a search request against the backend API. The fuzzy flag is
+ * forwarded to the backend via the query string to enable or disable fuzzy
+ * matching server-side.
+ */
+export async function search(term: string, fuzzy: boolean = false) {
+  const params = new URLSearchParams({ q: term });
+  params.set('fuzzy', fuzzy ? 'true' : 'false');
+  const response = await fetch(`/api/search?${params.toString()}`);
+  if (!response.ok) {
+    throw new Error('Search request failed');
+  }
+  return response.json();
+}
+

--- a/components/SearchBox.tsx
+++ b/components/SearchBox.tsx
@@ -1,0 +1,39 @@
+import React, { useState, useEffect } from 'react';
+
+/**
+ * SearchBox component with fuzzy search toggle. The toggle state is persisted
+ * to the URL query string as `fuzzy=true|false` so that the setting can be
+ * shared or refreshed without losing state.
+ */
+export default function SearchBox() {
+  // Initialise fuzzy state from current query string
+  const initialParams = typeof window !== 'undefined' ? new URLSearchParams(window.location.search) : new URLSearchParams();
+  const [fuzzy, setFuzzy] = useState(initialParams.get('fuzzy') === 'true');
+
+  // Persist fuzzy state to the query string whenever it changes
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const params = new URLSearchParams(window.location.search);
+    if (fuzzy) {
+      params.set('fuzzy', 'true');
+    } else {
+      params.set('fuzzy', 'false');
+    }
+    const newUrl = `${window.location.pathname}?${params.toString()}`;
+    window.history.replaceState(null, '', newUrl);
+  }, [fuzzy]);
+
+  return (
+    <div className="search-box">
+      <input id="search-box" type="text" />
+      <button
+        type="button"
+        onClick={() => setFuzzy((prev) => !prev)}
+        aria-pressed={fuzzy}
+      >
+        {fuzzy ? 'Disable fuzzy' : 'Enable fuzzy'}
+      </button>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add SearchBox React component with fuzzy search toggle stored in query params
- send fuzzy flag to backend from search API helper

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b52324f59883289daab631e6f24221