### PR TITLE
feat: add search history hook and panel

### DIFF
--- a/components/search/HistoryPanel.tsx
+++ b/components/search/HistoryPanel.tsx
@@ -1,0 +1,40 @@
+import React, { useState } from "react";
+import useSearchHistory from "../../hooks/useSearchHistory";
+
+type Props = {
+  authenticated?: boolean;
+  onSelect?: (query: string) => void;
+};
+
+export function HistoryPanel({ authenticated = false, onSelect }: Props) {
+  const { history, clearHistory } = useSearchHistory(authenticated);
+  const [open, setOpen] = useState(false);
+
+  if (!history.length) return null;
+
+  return (
+    <div className="history-panel">
+      <button className="toggle" onClick={() => setOpen((v) => !v)}>
+        {open ? "Hide" : "Show"} Search History
+      </button>
+      {open && (
+        <div className="history-list">
+          <ul>
+            {history.map((item, i) => (
+              <li key={i}>
+                <button type="button" onClick={() => onSelect?.(item)}>
+                  {item}
+                </button>
+              </li>
+            ))}
+          </ul>
+          <button className="clear" onClick={clearHistory}>
+            Clear
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default HistoryPanel;

--- a/hooks/useSearchHistory.ts
+++ b/hooks/useSearchHistory.ts
@@ -1,0 +1,74 @@
+import { useEffect, useState } from "react";
+
+const STORAGE_KEY = "searchHistory";
+
+function unique(arr: string[]): string[] {
+  return Array.from(new Set(arr));
+}
+
+export function useSearchHistory(authenticated: boolean = false) {
+  const [history, setHistory] = useState<string[]>([]);
+
+  // Load from localStorage on first mount
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (raw) {
+        const parsed = JSON.parse(raw);
+        if (Array.isArray(parsed)) {
+          setHistory(parsed);
+        }
+      }
+    } catch {
+      /* ignore */
+    }
+  }, []);
+
+  // If authenticated, merge server history
+  useEffect(() => {
+    if (!authenticated) return;
+    fetch("/api/history")
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (data && Array.isArray(data.history)) {
+          setHistory((prev) => unique([...data.history, ...prev]));
+        }
+      })
+      .catch(() => {
+        /* ignore network errors */
+      });
+  }, [authenticated]);
+
+  // Persist and optionally sync to server
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(history));
+    } catch {
+      /* ignore */
+    }
+    if (!authenticated) return;
+    fetch("/api/history", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ history }),
+    }).catch(() => {
+      /* ignore network errors */
+    });
+  }, [history, authenticated]);
+
+  const addQuery = (query: string) => {
+    const q = query.trim();
+    if (!q) return;
+    setHistory((prev) => {
+      const next = prev.filter((h) => h !== q);
+      next.unshift(q);
+      return next.slice(0, 50);
+    });
+  };
+
+  const clearHistory = () => setHistory([]);
+
+  return { history, addQuery, clearHistory };
+}
+
+export default useSearchHistory;


### PR DESCRIPTION
## Summary
- track search history in localStorage with optional server sync
- show collapsible history list with clear option

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b523267aec8328a02f08742ea1f3f0