### PR TITLE
feat: add text highlighting utility

### DIFF
--- a/components/results/DefinitionItem.tsx
+++ b/components/results/DefinitionItem.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import highlight from "../../lib/highlight";
+
+interface DefinitionItemProps {
+  term: string;
+  definition: string;
+  match?: string;
+}
+
+export default function DefinitionItem({
+  term,
+  definition,
+  match,
+}: DefinitionItemProps) {
+  const title = match ? highlight(term, match) : term;
+  const body = match ? highlight(definition, match) : definition;
+
+  return (
+    <div className="definition-item">
+      <h3 dangerouslySetInnerHTML={{ __html: title }} />
+      <p dangerouslySetInnerHTML={{ __html: body }} />
+    </div>
+  );
+}

--- a/lib/highlight.ts
+++ b/lib/highlight.ts
@@ -1,0 +1,6 @@
+export default function highlight(text: string, query: string): string {
+  if (!query) return text;
+  const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const regex = new RegExp(`(${escaped})`, "gi");
+  return text.replace(regex, "<mark>$1</mark>");
+}


### PR DESCRIPTION
## Summary
- highlight text matches using `<mark>` tags
- add result component that applies new highlighter

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b52326111c832889ba926c565ef52d