### PR TITLE
feat: enable voice input for search

### DIFF
--- a/SearchBox.tsx
+++ b/SearchBox.tsx
@@ -1,0 +1,50 @@
+import React, { useState } from "react";
+
+const SpeechRecognition =
+  (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition;
+
+export default function SearchBox() {
+  const [query, setQuery] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const handleMicClick = () => {
+    if (!SpeechRecognition) {
+      setError("Speech recognition not supported in this browser.");
+      return;
+    }
+    try {
+      const recognition = new SpeechRecognition();
+      recognition.onresult = (event: SpeechRecognitionEvent) => {
+        const transcript = event.results[0][0].transcript;
+        setQuery(transcript);
+        setError(null);
+      };
+      recognition.onerror = () => {
+        setError("Unable to process speech.");
+      };
+      recognition.start();
+    } catch (err) {
+      console.error(err);
+      setError("Could not access microphone.");
+    }
+  };
+
+  return (
+    <div className="search-box">
+      <input
+        type="text"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        placeholder="Search terms..."
+      />
+      <button
+        type="button"
+        onClick={handleMicClick}
+        aria-label="Use voice search"
+      >
+        🎤
+      </button>
+      {error && <p className="error">{error}</p>}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add SearchBox component with speech recognition integration
- show microphone icon and capture speech to fill search input
- provide fallback error messages when speech is unsupported or fails

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b52327c1648328b918b4c932bb3db7