### PR TITLE
Add pronunciation player with waveform and rate control

### DIFF
--- a/components/audio/PronunciationPlayer.tsx
+++ b/components/audio/PronunciationPlayer.tsx
@@ -1,0 +1,90 @@
+import React, { useEffect, useRef, useState } from "react";
+import WaveSurfer from "wavesurfer.js";
+
+type PronunciationPlayerProps = {
+  src: string;
+};
+
+const PronunciationPlayer: React.FC<PronunciationPlayerProps> = ({ src }) => {
+  const audioRef = useRef<HTMLAudioElement>(null);
+  const waveformRef = useRef<HTMLDivElement>(null);
+  const wavesurferRef = useRef<WaveSurfer | null>(null);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [rate, setRate] = useState(1);
+
+  useEffect(() => {
+    if (waveformRef.current && audioRef.current && !wavesurferRef.current) {
+      wavesurferRef.current = WaveSurfer.create({
+        container: waveformRef.current,
+        waveColor: "#ccc",
+        progressColor: "#555",
+        height: 40,
+        responsive: true,
+        cursorWidth: 0,
+        interact: false,
+        backend: "MediaElement",
+        media: audioRef.current,
+      });
+
+      wavesurferRef.current.on("finish", () => setIsPlaying(false));
+    }
+
+    return () => {
+      wavesurferRef.current?.destroy();
+      wavesurferRef.current = null;
+    };
+  }, [src]);
+
+  useEffect(() => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    const handlePlay = () => setIsPlaying(true);
+    const handlePause = () => setIsPlaying(false);
+    audio.addEventListener("play", handlePlay);
+    audio.addEventListener("pause", handlePause);
+    return () => {
+      audio.removeEventListener("play", handlePlay);
+      audio.removeEventListener("pause", handlePause);
+    };
+  }, []);
+
+  const togglePlay = () => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    if (audio.paused) {
+      audio.play();
+    } else {
+      audio.pause();
+    }
+  };
+
+  const handleRateChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const newRate = parseFloat(e.target.value);
+    setRate(newRate);
+    if (audioRef.current) audioRef.current.playbackRate = newRate;
+    wavesurferRef.current?.setPlaybackRate(newRate);
+  };
+
+  return (
+    <div className="pronunciation-player">
+      <audio ref={audioRef} src={src} preload="auto" />
+      <div ref={waveformRef} className="pronunciation-player__waveform" />
+      <div className="pronunciation-player__controls">
+        <button onClick={togglePlay}>{isPlaying ? "Pause" : "Play"}</button>
+        <label>
+          Speed:
+          <select value={rate} onChange={handleRateChange}>
+            <option value="0.5">0.5x</option>
+            <option value="0.75">0.75x</option>
+            <option value="1">1x</option>
+            <option value="1.25">1.25x</option>
+            <option value="1.5">1.5x</option>
+            <option value="2">2x</option>
+          </select>
+        </label>
+      </div>
+    </div>
+  );
+};
+
+export default PronunciationPlayer;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "cybersecuirtydictionary",
       "version": "1.0.0",
       "license": "ISC",
+      "dependencies": {
+        "wavesurfer.js": "^7.10.1"
+      },
       "devDependencies": {
         "chokidar-cli": "^3.0.0",
         "html-validate": "^10.0.0",
@@ -2110,6 +2113,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/wavesurfer.js": {
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/wavesurfer.js/-/wavesurfer.js-7.10.1.tgz",
+      "integrity": "sha512-tF1ptFCAi8SAqKbM1e7705zouLC3z4ulXCg15kSP5dQ7VDV30Q3x/xFRcuVIYTT5+jB/PdkhiBRCfsMshZG1Ug==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
+  "dependencies": {
+    "wavesurfer.js": "^7.10.1"
+  },
   "devDependencies": {
     "chokidar-cli": "^3.0.0",
     "html-validate": "^10.0.0",


### PR DESCRIPTION
## Summary
- add `PronunciationPlayer` React component using `<audio>` with play/pause controls
- support playback-speed selection and visualize audio with `wavesurfer.js`
- install `wavesurfer.js` dependency

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5232da6948328a3de72ca52823887