### PR TITLE
Add part-of-speech tabs for word pages with SWR fetching

### DIFF
--- a/components/PosTabs.tsx
+++ b/components/PosTabs.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { useState } from 'react';
+import useSWR from 'swr';
+
+const partsOfSpeech = ['noun', 'verb', 'adjective', 'adverb'];
+
+const fetcher = (url: string) => fetch(url).then((res) => res.json());
+
+interface PosTabsProps {
+  slug: string;
+}
+
+export default function PosTabs({ slug }: PosTabsProps) {
+  const [active, setActive] = useState(partsOfSpeech[0]);
+
+  return (
+    <div>
+      <div className="pos-tabs">
+        {partsOfSpeech.map((pos) => (
+          <button
+            key={pos}
+            onClick={() => setActive(pos)}
+            disabled={active === pos}
+          >
+            {pos}
+          </button>
+        ))}
+      </div>
+      <div className="pos-content">
+        {partsOfSpeech.map((pos) => {
+          const { data, error } = useSWR(
+            `/api/word/${slug}/${pos}`,
+            fetcher
+          );
+          if (pos !== active) return null;
+          if (error) return <p>Failed to load {pos}</p>;
+          if (!data) return <p>Loading {pos}...</p>;
+          return (
+            <pre key={pos}>{JSON.stringify(data, null, 2)}</pre>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+

--- a/word/[slug]/page.tsx
+++ b/word/[slug]/page.tsx
@@ -1,0 +1,17 @@
+import PosTabs from '../../components/PosTabs';
+
+interface WordPageProps {
+  params: {
+    slug: string;
+  };
+}
+
+export default function WordPage({ params }: WordPageProps) {
+  return (
+    <div>
+      <h1>{params.slug}</h1>
+      <PosTabs slug={params.slug} />
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add `PosTabs` component to render tabs for parts of speech and fetch data with `useSWR`
- render `PosTabs` in dynamic word page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5232e20cc8328873fda609d9c2ab8