### PR TITLE
Add Collocations component

### DIFF
--- a/components/Collocations.tsx
+++ b/components/Collocations.tsx
@@ -1,0 +1,41 @@
+import React, { useState } from 'react';
+
+export interface Collocation {
+  term: string;
+  count: number;
+  examples: string[];
+}
+
+interface Props {
+  collocations: Collocation[];
+}
+
+const Collocations: React.FC<Props> = ({ collocations }) => {
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+
+  const toggle = (term: string) => {
+    setExpanded(prev => ({ ...prev, [term]: !prev[term] }));
+  };
+
+  return (
+    <div className="collocations">
+      {collocations.map(({ term, count, examples }) => (
+        <div key={term} className="collocation">
+          <button className="chip" onClick={() => toggle(term)}>
+            <span className="label">{term}</span>
+            <span className="count">{count}</span>
+          </button>
+          {expanded[term] && (
+            <ul className="examples">
+              {examples.map((ex, i) => (
+                <li key={i}>{ex}</li>
+              ))}
+            </ul>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default Collocations;


### PR DESCRIPTION
## Summary
- add reusable `Collocations` React component to display collocation chips with counts and expandable example lists

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5233122e08328ab6f40380d929627