### PR TITLE
feat: add related word drawer

### DIFF
--- a/components/RelatedWords.tsx
+++ b/components/RelatedWords.tsx
@@ -1,0 +1,32 @@
+import React, { useState } from "react";
+import SideDrawer from "./SideDrawer";
+
+interface RelatedWordsProps {
+  /** List of words related to the current term */
+  words: string[];
+}
+
+/**
+ * Renders a collection of chips for related words. Clicking a chip opens a
+ * SideDrawer with a mini definition fetched from `/api/word/summary`.
+ */
+const RelatedWords: React.FC<RelatedWordsProps> = ({ words }) => {
+  const [selected, setSelected] = useState<string | null>(null);
+
+  if (!words || words.length === 0) return null;
+
+  return (
+    <div className="related-words">
+      <div className="chips">
+        {words.map((w) => (
+          <button key={w} className="chip" onClick={() => setSelected(w)}>
+            {w}
+          </button>
+        ))}
+      </div>
+      <SideDrawer word={selected} onClose={() => setSelected(null)} />
+    </div>
+  );
+};
+
+export default RelatedWords;

--- a/components/SideDrawer.tsx
+++ b/components/SideDrawer.tsx
@@ -1,0 +1,58 @@
+import React, { useEffect, useState } from "react";
+
+interface SideDrawerProps {
+  /** Word currently selected; when null the drawer is hidden */
+  word: string | null;
+  /** Called when the drawer should be closed */
+  onClose: () => void;
+}
+
+/**
+ * SideDrawer fetches and displays a mini definition for a given word.
+ * It is shown whenever `word` is not null.
+ */
+const SideDrawer: React.FC<SideDrawerProps> = ({ word, onClose }) => {
+  const [definition, setDefinition] = useState<string>("");
+
+  useEffect(() => {
+    if (!word) {
+      setDefinition("");
+      return;
+    }
+
+    let cancelled = false;
+    // Fetch the mini definition for the selected word
+    fetch(`/api/word/summary?word=${encodeURIComponent(word)}`)
+      .then((res) => res.json())
+      .then((data) => {
+        if (!cancelled) {
+          setDefinition(
+            data.summary || data.definition || "No definition available.",
+          );
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setDefinition("Failed to fetch definition.");
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [word]);
+
+  if (!word) return null;
+
+  return (
+    <aside className="side-drawer">
+      <button className="close" onClick={onClose} aria-label="Close">
+        ×
+      </button>
+      <h2>{word}</h2>
+      <p>{definition}</p>
+    </aside>
+  );
+};
+
+export default SideDrawer;


### PR DESCRIPTION
## Summary
- add SideDrawer component that fetches mini definition of a word
- add RelatedWords component rendering chips to open SideDrawer

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b52331e7788328a980866afae1dc66