### PR TITLE
feat: add inflection table component

### DIFF
--- a/components/InflectionTable.tsx
+++ b/components/InflectionTable.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+
+interface Entry {
+  inflections?: Record<string, string>;
+}
+
+interface Props {
+  entry: Entry;
+}
+
+export default function InflectionTable({ entry }: Props) {
+  const { inflections } = entry;
+
+  if (!inflections || Object.keys(inflections).length === 0) {
+    return null;
+  }
+
+  const copyToClipboard = (value: string) => {
+    navigator.clipboard.writeText(value).catch(() => {
+      /* ignore errors */
+    });
+  };
+
+  return (
+    <table className="inflection-table">
+      <tbody>
+        {Object.entries(inflections).map(([label, value]) => (
+          <tr key={label}>
+            <th>{label}</th>
+            <td>
+              {value}
+              <button
+                type="button"
+                onClick={() => copyToClipboard(value)}
+                aria-label={`Copy ${value}`}
+              >
+                Copy
+              </button>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}


### PR DESCRIPTION
## Summary
- add `InflectionTable` React component that renders inflection rows with copy-to-clipboard buttons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5233519748328a62874a7d72b50c7