### PR TITLE
Add anagram search page

### DIFF
--- a/anagrams.html
+++ b/anagrams.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Anagrams</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <main class="container">
+    <h1>Anagrams</h1>
+    <input id="anagram-input" type="text" placeholder="Enter letters...">
+    <div id="anagram-results"></div>
+  </main>
+  <script>
+    window.__BASE_URL__ = window.__BASE_URL__ || '';
+  </script>
+  <script src="assets/js/anagrams.js"></script>
+  <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
+  <script src="assets/js/metrics.js"></script>
+</body>
+</html>

--- a/assets/js/anagrams.js
+++ b/assets/js/anagrams.js
@@ -1,0 +1,59 @@
+(function(){
+  const resultsContainer = document.getElementById('anagram-results');
+  const input = document.getElementById('anagram-input');
+  let terms = [];
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const baseUrl = window.__BASE_URL__ || '';
+    fetch(`${baseUrl}/terms.json`)
+      .then(r => r.ok ? r.json() : Promise.reject(r.statusText))
+      .then(data => {
+        const rawTerms = Array.isArray(data) ? data : (data.terms || []);
+        terms = rawTerms.map(t => ({ ...t, normalized: normalize(t.term || t.name || '') }));
+      })
+      .catch(err => {
+        console.error('Failed to load terms.json', err);
+      });
+
+    input.addEventListener('input', handleInput);
+  });
+
+  function normalize(str){
+    return (str || '')
+      .toLowerCase()
+      .replace(/[^a-z]/g, '')
+      .split('')
+      .sort()
+      .join('');
+  }
+
+  function handleInput(){
+    const query = input.value.trim();
+    resultsContainer.innerHTML = '';
+    if(!query){
+      return;
+    }
+    const normalizedQuery = normalize(query);
+    const matches = terms.filter(t => t.normalized === normalizedQuery);
+    matches.forEach(match => {
+      resultsContainer.appendChild(renderCard(match));
+    });
+  }
+
+  function renderCard(term){
+    const card = document.createElement('div');
+    card.className = 'result-card';
+
+    const title = document.createElement('h3');
+    title.textContent = term.term || term.name || '';
+    card.appendChild(title);
+
+    if(term.definition){
+      const def = document.createElement('p');
+      def.textContent = term.definition;
+      card.appendChild(def);
+    }
+
+    return card;
+  }
+})();

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 <body>
   <main class="container">
     <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav" aria-label="Site links"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
+    <nav class="site-nav" aria-label="Site links"><a href="templates/guidelines.html">Definition Guidelines</a> <a href="anagrams.html">Anagrams</a></nav>
     <div id="definition-container" style="display: none;"></div>
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "script.js",
   "scripts": {
     "build": "node scripts/build.js",
-    "test": "html-validate index.html search.html diagnostics.html && node diagnostics.test.js",
+    "test": "html-validate index.html search.html diagnostics.html anagrams.html && node diagnostics.test.js",
     "watch": "chokidar \"**/*.html\" -c \"npm run build\""
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
- add `/anagrams` page with input UI
- implement client-side anagram finder against terms.json
- validate new page in test pipeline

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5237a6a448328a5ef5c7abcdcba34