### PR TITLE
feat: render idiom chips with hover previews

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -25,7 +25,7 @@ body {
 
 h1 {
   text-align: center;
-  font-family: 'Cinzel', serif;
+  font-family: "Cinzel", serif;
   font-weight: 700;
   font-size: 48px;
   margin-bottom: 20px;
@@ -110,7 +110,6 @@ body.dark-mode mark {
   box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
   min-height: 44px;
 }
-
 
 /* Controls styling */
 #random-term {
@@ -206,7 +205,9 @@ label {
   border-radius: 4px;
   padding: 10px;
   cursor: pointer;
-  transition: background-color 0.2s, color 0.2s;
+  transition:
+    background-color 0.2s,
+    color 0.2s;
   min-width: 44px;
   min-height: 44px;
 }
@@ -240,6 +241,45 @@ label {
 
 #scrollToTopBtn:hover {
   background-color: #0056b3;
+}
+
+/* Idiom chip styles */
+.idioms-container {
+  margin-top: 10px;
+}
+
+.idiom-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
+.idiom-chip {
+  display: inline-block;
+  padding: 4px 8px;
+  background-color: #eee;
+  border-radius: 16px;
+  cursor: pointer;
+  text-decoration: none;
+  color: #333;
+  position: relative;
+}
+
+.idiom-chip:hover {
+  background-color: #ddd;
+}
+
+.idiom-hover {
+  position: absolute;
+  top: 120%;
+  left: 0;
+  z-index: 10;
+  background-color: #fff;
+  color: #333;
+  border: 1px solid #ccc;
+  padding: 8px;
+  max-width: 200px;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
 }
 
 /* Dark Mode styles */
@@ -324,6 +364,21 @@ body.dark-mode #alpha-nav button:focus {
 body.dark-mode #alpha-nav button.active {
   background-color: #007bff;
   border-color: #007bff;
+}
+
+body.dark-mode .idiom-chip {
+  background-color: #333;
+  color: #fff;
+}
+
+body.dark-mode .idiom-chip:hover {
+  background-color: #444;
+}
+
+body.dark-mode .idiom-hover {
+  background-color: #1e1e1e;
+  color: #fff;
+  border-color: #555;
 }
 
 @media (max-width: 480px) {


### PR DESCRIPTION
## Summary
- parse idiom entries and build slug mapping
- render idiom chips with hover-card previews linking to `/word/[slug]`
- style idiom chips and hover cards with dark mode support

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5237c220c832888062c4b18a9f9ec