### PR TITLE
Add rhymes API route and display component

### DIFF
--- a/api/rhymes.js
+++ b/api/rhymes.js
@@ -1,0 +1,21 @@
+export default async function handler(req, res) {
+  const { slug } = req.query || {};
+  if (!slug) {
+    res.status(400).json({ error: "Missing slug" });
+    return;
+  }
+
+  try {
+    const response = await fetch(
+      `https://api.datamuse.com/words?rel_rhy=${encodeURIComponent(slug)}&md=s`,
+    );
+    if (!response.ok) {
+      res.status(502).json({ error: "Failed to fetch rhymes" });
+      return;
+    }
+    const data = await response.json();
+    res.status(200).json(data);
+  } catch (err) {
+    res.status(500).json({ error: "Unexpected error" });
+  }
+}

--- a/components/Rhymes.tsx
+++ b/components/Rhymes.tsx
@@ -1,0 +1,51 @@
+import { useEffect, useState } from "react";
+
+interface Rhyme {
+  word: string;
+  numSyllables?: number;
+}
+
+export default function Rhymes({ slug }: { slug: string }) {
+  const [groups, setGroups] = useState<Record<number, string[]>>({});
+
+  useEffect(() => {
+    if (!slug) {
+      setGroups({});
+      return;
+    }
+
+    fetch(`/api/rhymes?slug=${encodeURIComponent(slug)}`)
+      .then((res) => res.json())
+      .then((data: Rhyme[]) => {
+        const grouped: Record<number, string[]> = {};
+        data.forEach(({ word, numSyllables = 0 }) => {
+          if (!grouped[numSyllables]) {
+            grouped[numSyllables] = [];
+          }
+          grouped[numSyllables].push(word);
+        });
+        setGroups(grouped);
+      })
+      .catch(() => setGroups({}));
+  }, [slug]);
+
+  return (
+    <div>
+      {Object.keys(groups)
+        .map((k) => parseInt(k, 10))
+        .sort((a, b) => a - b)
+        .map((count) => (
+          <div key={count}>
+            <h3>
+              {count} syllable{count === 1 ? "" : "s"}
+            </h3>
+            <ul>
+              {groups[count].map((word) => (
+                <li key={word}>{word}</li>
+              ))}
+            </ul>
+          </div>
+        ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `/api/rhymes` endpoint to retrieve rhyming words from Datamuse
- create `Rhymes` component that groups results by syllable count

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b52336855c8328b733e71e8fc00ad2