### PR TITLE
feat: add register toggle to PosTabs

### DIFF
--- a/assets/js/PosTabs.tsx
+++ b/assets/js/PosTabs.tsx
@@ -1,0 +1,31 @@
+import React, { useState } from "react";
+
+export interface PosTabsProps {
+  registers: string[];
+  fetchDefinition: (register: string) => void;
+}
+
+const PosTabs: React.FC<PosTabsProps> = ({ registers, fetchDefinition }) => {
+  const [active, setActive] = useState(registers[0] ?? "");
+
+  const handleSelect = (register: string) => {
+    setActive(register);
+    fetchDefinition(register);
+  };
+
+  return (
+    <div className="pos-tabs">
+      {registers.map((register) => (
+        <button
+          key={register}
+          className={register === active ? "active" : ""}
+          onClick={() => handleSelect(register)}
+        >
+          {register}
+        </button>
+      ))}
+    </div>
+  );
+};
+
+export default PosTabs;


### PR DESCRIPTION
## Summary
- add React PosTabs component that toggles registers and forwards selection to definition fetch

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5237e2ed08328af92e0437882752f