### PR TITLE
Add listening quiz with pronunciation audio and fuzzy answer checking

### DIFF
--- a/assets/js/listening-quiz.js
+++ b/assets/js/listening-quiz.js
@@ -1,0 +1,86 @@
+// Listening quiz script
+let terms = [];
+let currentTerm = null;
+
+function loadTerms() {
+  return fetch("../terms.json")
+    .then((res) => res.json())
+    .then((data) => {
+      terms = data.terms || [];
+    });
+}
+
+function getRandomTerm() {
+  if (!terms.length) return null;
+  const index = Math.floor(Math.random() * terms.length);
+  return terms[index].term;
+}
+
+function speakTerm(term) {
+  if (!term) return;
+  const utterance = new SpeechSynthesisUtterance(term);
+  speechSynthesis.speak(utterance);
+}
+
+function levenshtein(a, b) {
+  const matrix = Array.from({ length: b.length + 1 }, (_, i) => [i]);
+  for (let j = 0; j <= a.length; j++) {
+    matrix[0][j] = j;
+  }
+  for (let i = 1; i <= b.length; i++) {
+    for (let j = 1; j <= a.length; j++) {
+      if (b[i - 1] === a[j - 1]) {
+        matrix[i][j] = matrix[i - 1][j - 1];
+      } else {
+        matrix[i][j] = Math.min(
+          matrix[i - 1][j] + 1,
+          matrix[i][j - 1] + 1,
+          matrix[i - 1][j - 1] + 1,
+        );
+      }
+    }
+  }
+  return matrix[b.length][a.length];
+}
+
+function newQuestion() {
+  currentTerm = getRandomTerm();
+  speakTerm(currentTerm);
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  const playBtn = document.getElementById("play-audio");
+  const submitBtn = document.getElementById("submit");
+  const answerInput = document.getElementById("answer");
+  const feedback = document.getElementById("feedback");
+
+  loadTerms().then(() => {
+    newQuestion();
+  });
+
+  playBtn.addEventListener("click", () => {
+    if (!currentTerm) {
+      newQuestion();
+    } else {
+      speakTerm(currentTerm);
+    }
+  });
+
+  submitBtn.addEventListener("click", () => {
+    if (!currentTerm) return;
+    const guess = answerInput.value.trim();
+    const distance = levenshtein(
+      guess.toLowerCase(),
+      currentTerm.toLowerCase(),
+    );
+    if (distance === 0) {
+      feedback.textContent = "Correct!";
+    } else if (distance <= 2) {
+      feedback.textContent = `Close! The term was "${currentTerm}".`;
+    } else {
+      feedback.textContent = `Incorrect. The term was "${currentTerm}".`;
+    }
+    answerInput.value = "";
+    currentTerm = null;
+  });
+});

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "script.js",
   "scripts": {
     "build": "node scripts/build.js",
-    "test": "html-validate index.html search.html diagnostics.html && node diagnostics.test.js",
+    "test": "html-validate index.html search.html diagnostics.html quiz/listening.html && node diagnostics.test.js",
     "watch": "chokidar \"**/*.html\" -c \"npm run build\""
   },
   "keywords": [],

--- a/quiz/listening.html
+++ b/quiz/listening.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" >
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" >
+    <title>Listening Quiz</title>
+    <link rel="stylesheet" href="../styles.css" >
+  </head>
+  <body>
+    <main class="container">
+      <h1>Listening Quiz</h1>
+      <button id="play-audio" type="button">Play Term</button>
+      <input id="answer" type="text" placeholder="Type the term..." >
+      <button id="submit" type="button">Submit</button>
+      <p id="feedback"></p>
+    </main>
+    <script src="../assets/js/listening-quiz.js"></script>
+    <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
+    <script src="../assets/js/metrics.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add listening quiz page that plays random terms using speech synthesis
- compare user input with Levenshtein distance to allow close matches
- extend tests to cover new quiz page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b52384ba7c83289c15aef69c1e9713