### PR TITLE
Add interactive quiz component with dual modes

### DIFF
--- a/assets/js/quiz.js
+++ b/assets/js/quiz.js
@@ -1,0 +1,106 @@
+(function () {
+  const modeTermDefBtn = document.getElementById('mode-term-def');
+  const modeDefTermBtn = document.getElementById('mode-def-term');
+  const quizEl = document.getElementById('quiz');
+  const questionEl = document.getElementById('question');
+  const optionsEl = document.getElementById('options');
+  const feedbackEl = document.getElementById('feedback');
+  const scoreEl = document.getElementById('score');
+  const nextBtn = document.getElementById('next');
+
+  let terms = [];
+  let mode = '';
+  let current = null;
+  let score = 0;
+  let total = 0;
+
+  function getPartOfSpeech(term) {
+    const firstWord = term.trim().split(/\s+/)[0];
+    return /ing$/i.test(firstWord) ? 'verb' : 'noun';
+  }
+
+  async function loadTerms() {
+    const response = await fetch('terms.json');
+    const data = await response.json();
+    terms = data.terms.map((t) => ({ ...t, pos: getPartOfSpeech(t.term) }));
+  }
+
+  function shuffle(arr) {
+    for (let i = arr.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [arr[i], arr[j]] = [arr[j], arr[i]];
+    }
+    return arr;
+  }
+
+  function pickQuestion() {
+    current = terms[Math.floor(Math.random() * terms.length)];
+    const samePos = terms.filter((t) => t.pos === current.pos && t !== current);
+    shuffle(samePos);
+    const distractors = samePos.slice(0, 3);
+    while (distractors.length < 3) {
+      const candidate = terms[Math.floor(Math.random() * terms.length)];
+      if (candidate !== current && !distractors.includes(candidate)) {
+        distractors.push(candidate);
+      }
+    }
+    const options = shuffle([...distractors, current]);
+
+    questionEl.textContent =
+      mode === 'term-to-definition' ? current.term : current.definition;
+    optionsEl.innerHTML = '';
+    options.forEach((opt) => {
+      const text = mode === 'term-to-definition' ? opt.definition : opt.term;
+      const btn = document.createElement('button');
+      btn.textContent = text;
+      btn.className = 'quiz-option';
+      btn.addEventListener('click', () => handleAnswer(btn, opt === current));
+      optionsEl.appendChild(btn);
+    });
+    feedbackEl.textContent = '';
+    nextBtn.style.display = 'none';
+    scoreEl.textContent = `Score: ${score}/${total}`;
+  }
+
+  function handleAnswer(button, correct) {
+    Array.from(optionsEl.querySelectorAll('button')).forEach((b) => {
+      b.disabled = true;
+    });
+    if (correct) {
+      button.classList.add('correct');
+      feedbackEl.textContent = 'Correct!';
+      score++;
+    } else {
+      button.classList.add('incorrect');
+      const correctText =
+        mode === 'term-to-definition' ? current.definition : current.term;
+      feedbackEl.textContent =
+        mode === 'term-to-definition'
+          ? `Incorrect! The correct definition is: ${current.definition}`
+          : `Incorrect! The correct term is: ${current.term}`;
+      Array.from(optionsEl.querySelectorAll('button')).forEach((b) => {
+        if (b.textContent === correctText) {
+          b.classList.add('correct');
+        }
+      });
+    }
+    total++;
+    scoreEl.textContent = `Score: ${score}/${total}`;
+    nextBtn.style.display = 'block';
+  }
+
+  async function start(selectedMode) {
+    mode = selectedMode;
+    score = 0;
+    total = 0;
+    quizEl.style.display = 'block';
+    if (!terms.length) {
+      await loadTerms();
+    }
+    pickQuestion();
+  }
+
+  modeTermDefBtn.addEventListener('click', () => start('term-to-definition'));
+  modeDefTermBtn.addEventListener('click', () => start('definition-to-term'));
+  nextBtn.addEventListener('click', pickQuestion);
+})();

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 <body>
   <main class="container">
     <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav" aria-label="Site links"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
+    <nav class="site-nav" aria-label="Site links"><a href="templates/guidelines.html">Definition Guidelines</a> <a href="quiz.html">Quiz</a></nav>
     <div id="definition-container" style="display: none;"></div>
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">

--- a/quiz.html
+++ b/quiz.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Quiz</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <main class="container">
+    <h1>Quiz</h1>
+    <div id="mode-select">
+      <button id="mode-term-def" type="button">Term to Definition</button>
+      <button id="mode-def-term" type="button">Definition to Term</button>
+    </div>
+    <div id="quiz" style="display: none;">
+      <p id="question"></p>
+      <div id="options"></div>
+      <p id="feedback"></p>
+      <p id="score">Score: 0/0</p>
+      <button id="next" type="button" style="display: none;">Next</button>
+    </div>
+  </main>
+  <script>
+    window.__BASE_URL__ = window.__BASE_URL__ || '';
+  </script>
+  <script src="assets/js/quiz.js"></script>
+  <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
+  <script src="assets/js/metrics.js"></script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -347,3 +347,16 @@ body.dark-mode #alpha-nav button.active {
     font-size: 14px;
   }
 }
+
+.quiz-option {
+  display: block;
+  margin: 8px 0;
+}
+
+.quiz-option.correct {
+  background-color: #c8e6c9;
+}
+
+.quiz-option.incorrect {
+  background-color: #ffcdd2;
+}


### PR DESCRIPTION
## Summary
- Add dedicated quiz page with term-to-definition and definition-to-term modes
- Implement quiz logic including same-part-of-speech distractors and scoring
- Style and link quiz into navigation

## Testing
- `npm test`
- `npx html-validate quiz.html`


------
https://chatgpt.com/codex/tasks/task_e_68b523859aec8328ad28011d24556f1d