### PR TITLE
feat: track user streaks and display badges

### DIFF
--- a/components/profile/Badges.tsx
+++ b/components/profile/Badges.tsx
@@ -1,0 +1,42 @@
+import React, { useEffect, useState } from 'react';
+
+interface Badge {
+  id: string;
+  label: string;
+}
+
+const BADGE_LABELS: Record<string, string> = {
+  '3-day-streak': '3-Day Streak',
+  '7-day-streak': '7-Day Streak',
+  '30-day-streak': '30-Day Streak',
+};
+
+export default function Badges() {
+  const [badges, setBadges] = useState<Badge[]>([]);
+
+  useEffect(() => {
+    try {
+      const profile = JSON.parse(localStorage.getItem('userProfile') || '{}');
+      const storedBadges: string[] = profile.badges || [];
+      setBadges(
+        storedBadges.map((id: string) => ({ id, label: BADGE_LABELS[id] || id }))
+      );
+    } catch {
+      setBadges([]);
+    }
+  }, []);
+
+  if (badges.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="badges">
+      {badges.map((b) => (
+        <span key={b.id} className="badge">
+          {b.label}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/script.js
+++ b/script.js
@@ -9,6 +9,56 @@ const favorites = new Set(JSON.parse(localStorage.getItem("favorites") || "[]"))
 const siteUrl = "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/";
 const canonicalLink = document.getElementById("canonical-link");
 
+const USER_PROFILE_KEY = "userProfile";
+
+function loadUserProfile() {
+  try {
+    return JSON.parse(localStorage.getItem(USER_PROFILE_KEY)) || {};
+  } catch {
+    return {};
+  }
+}
+
+let userProfile = loadUserProfile();
+
+function saveUserProfile() {
+  try {
+    localStorage.setItem(USER_PROFILE_KEY, JSON.stringify(userProfile));
+  } catch {
+    // Ignore storage errors
+  }
+}
+
+function updateBadges() {
+  if (!Array.isArray(userProfile.badges)) {
+    userProfile.badges = [];
+  }
+  const thresholds = [3, 7, 30];
+  thresholds.forEach((t) => {
+    const id = `${t}-day-streak`;
+    if (userProfile.streak >= t && !userProfile.badges.includes(id)) {
+      userProfile.badges.push(id);
+    }
+  });
+}
+
+function updateDailyStreak() {
+  const today = new Date().toDateString();
+  if (userProfile.lastVisit !== today) {
+    const yesterday = new Date(Date.now() - 86400000).toDateString();
+    if (userProfile.lastVisit === yesterday) {
+      userProfile.streak = (userProfile.streak || 0) + 1;
+    } else {
+      userProfile.streak = 1;
+    }
+    userProfile.lastVisit = today;
+    updateBadges();
+    saveUserProfile();
+  }
+}
+
+updateDailyStreak();
+
 let currentLetterFilter = "All";
 let termsData = { terms: [] };
 


### PR DESCRIPTION
## Summary
- track daily visit streaks and award badges using localStorage
- add React component to render earned badges

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b52386227c8328992d35ed15fad3dc