### PR TITLE
Add minimal pairs page with audio playback

### DIFF
--- a/assets/js/minimal-pairs.js
+++ b/assets/js/minimal-pairs.js
@@ -1,0 +1,29 @@
+const minimalPairs = [
+  { word1: "bit", ipa1: "/bɪt/", word2: "beat", ipa2: "/biːt/" },
+  { word1: "ship", ipa1: "/ʃɪp/", word2: "sheep", ipa2: "/ʃiːp/" },
+  { word1: "full", ipa1: "/fʊl/", word2: "fool", ipa2: "/fuːl/" },
+];
+
+document.addEventListener("DOMContentLoaded", () => {
+  const list = document.getElementById("pairs-list");
+
+  minimalPairs.forEach((pair) => {
+    const li = document.createElement("li");
+    li.innerHTML = `
+      <span>${pair.word1} <span class="ipa">${pair.ipa1}</span></span>
+      <button type="button" class="play" data-word="${pair.word1}" aria-label="Play ${pair.word1}">▶</button>
+      <span>${pair.word2} <span class="ipa">${pair.ipa2}</span></span>
+      <button type="button" class="play" data-word="${pair.word2}" aria-label="Play ${pair.word2}">▶</button>
+    `;
+    list.appendChild(li);
+  });
+
+  list.addEventListener("click", (e) => {
+    if (e.target.matches("button.play")) {
+      const word = e.target.getAttribute("data-word");
+      const utterance = new SpeechSynthesisUtterance(word);
+      speechSynthesis.cancel();
+      speechSynthesis.speak(utterance);
+    }
+  });
+});

--- a/minimal-pairs/index.html
+++ b/minimal-pairs/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Minimal Pairs</title>
+  <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+  <main class="container">
+    <h1>Minimal Pairs</h1>
+    <ul id="pairs-list"></ul>
+  </main>
+  <script src="../assets/js/minimal-pairs.js"></script>
+  <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
+  <script src="../assets/js/metrics.js"></script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "script.js",
   "scripts": {
     "build": "node scripts/build.js",
-    "test": "html-validate index.html search.html diagnostics.html && node diagnostics.test.js",
+    "test": "html-validate index.html search.html diagnostics.html minimal-pairs/index.html && node diagnostics.test.js",
     "watch": "chokidar \"**/*.html\" -c \"npm run build\""
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
- create `/minimal-pairs` page listing sample minimal pairs with IPA
- provide quick audio playback via speech synthesis
- include new page in html validation tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b52386c10083288ee378a727a252b6