### PR TITLE
feat: add alphabet index component

### DIFF
--- a/components/AlphaIndex.tsx
+++ b/components/AlphaIndex.tsx
@@ -1,0 +1,26 @@
+import Link from 'next/link';
+
+const letters = Array.from({ length: 26 }, (_, i) => String.fromCharCode(65 + i));
+
+export default function AlphaIndex() {
+  return (
+    <nav
+      style={{
+        position: 'sticky',
+        top: 0,
+        background: 'white',
+        zIndex: 1000,
+        padding: '0.5rem',
+        display: 'flex',
+        gap: '0.5rem',
+        flexWrap: 'wrap'
+      }}
+    >
+      {letters.map(letter => (
+        <Link key={letter} href={`/letter/${letter}`}>
+          {letter}
+        </Link>
+      ))}
+    </nav>
+  );
+}


### PR DESCRIPTION
## Summary
- add sticky alphabet index component linking to letter pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b523882ba08328a251116f65e51ad4