### PR TITLE
feat: add word breadcrumb component

### DIFF
--- a/app/word/[slug]/page.tsx
+++ b/app/word/[slug]/page.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+interface PageProps {
+  params: {
+    slug: string;
+  };
+}
+
+export default function WordPage({ params }: PageProps) {
+  const word = decodeURIComponent(params.slug);
+  return (
+    <nav>
+      Home &gt; English &gt; {word}
+    </nav>
+  );
+}


### PR DESCRIPTION
## Summary
- add page for word slug with breadcrumb Home > English > [Word]

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b52388bbf083289daad80c483e3770