### PR TITLE
Add adjacent term navigation

### DIFF
--- a/script.js
+++ b/script.js
@@ -5,12 +5,34 @@ const randomButton = document.getElementById("random-term");
 const alphaNav = document.getElementById("alpha-nav");
 const darkModeToggle = document.getElementById("dark-mode-toggle");
 const showFavoritesToggle = document.getElementById("show-favorites");
-const favorites = new Set(JSON.parse(localStorage.getItem("favorites") || "[]"));
+const favorites = new Set(
+  JSON.parse(localStorage.getItem("favorites") || "[]"),
+);
 const siteUrl = "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/";
 const canonicalLink = document.getElementById("canonical-link");
 
 let currentLetterFilter = "All";
 let termsData = { terms: [] };
+
+function slugify(str) {
+  return str
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function fetchAdjacentSlugs(slug) {
+  const params = new URLSearchParams({ slug });
+  const searchValue = searchInput.value.trim();
+  if (searchValue) params.set("q", searchValue);
+  if (currentLetterFilter !== "All") params.set("letter", currentLetterFilter);
+  if (showFavoritesToggle && showFavoritesToggle.checked) {
+    params.set("favorites", Array.from(favorites).join(","));
+  }
+  return fetch(`/api/adjacent?${params.toString()}`)
+    .then((res) => (res.ok ? res.json() : Promise.reject(res.status)))
+    .catch(() => ({}));
+}
 
 if (localStorage.getItem("darkMode") === "true") {
   document.body.classList.add("dark-mode");
@@ -19,7 +41,10 @@ if (localStorage.getItem("darkMode") === "true") {
 if (darkModeToggle) {
   darkModeToggle.addEventListener("click", () => {
     document.body.classList.toggle("dark-mode");
-    localStorage.setItem("darkMode", document.body.classList.contains("dark-mode"));
+    localStorage.setItem(
+      "darkMode",
+      document.body.classList.contains("dark-mode"),
+    );
   });
 }
 
@@ -43,9 +68,11 @@ function loadTerms() {
       populateTermsList();
 
       if (window.location.hash) {
-        const termFromHash = decodeURIComponent(window.location.hash.substring(1));
+        const termFromHash = decodeURIComponent(
+          window.location.hash.substring(1),
+        );
         const matchedTerm = termsData.terms.find(
-          (t) => t.term.toLowerCase() === termFromHash.toLowerCase()
+          (t) => t.term.toLowerCase() === termFromHash.toLowerCase(),
         );
         if (matchedTerm) {
           displayDefinition(matchedTerm);
@@ -56,7 +83,7 @@ function loadTerms() {
       console.error("Detailed error fetching data:", error);
       definitionContainer.style.display = "block";
       definitionContainer.innerHTML =
-        '<p>Unable to load dictionary data. Please check your connection and try again.</p>' +
+        "<p>Unable to load dictionary data. Please check your connection and try again.</p>" +
         '<button id="retry-fetch">Retry</button>';
       const retryBtn = document.getElementById("retry-fetch");
       if (retryBtn) {
@@ -97,12 +124,16 @@ function toggleFavorite(term) {
 }
 
 function highlightActiveButton(button) {
-  alphaNav.querySelectorAll("button").forEach((btn) => btn.classList.remove("active"));
+  alphaNav
+    .querySelectorAll("button")
+    .forEach((btn) => btn.classList.remove("active"));
   button.classList.add("active");
 }
 
 function buildAlphaNav() {
-  const letters = Array.from(new Set(termsData.terms.map((t) => t.term.charAt(0).toUpperCase()))).sort();
+  const letters = Array.from(
+    new Set(termsData.terms.map((t) => t.term.charAt(0).toUpperCase())),
+  ).sort();
 
   const allButton = document.createElement("button");
   allButton.textContent = "All";
@@ -134,9 +165,13 @@ function populateTermsList() {
     .sort((a, b) => a.term.localeCompare(b.term))
     .forEach((item) => {
       const matchesSearch = item.term.toLowerCase().includes(searchValue);
-      const matchesFavorites = !showFavoritesToggle || !showFavoritesToggle.checked || favorites.has(item.term);
+      const matchesFavorites =
+        !showFavoritesToggle ||
+        !showFavoritesToggle.checked ||
+        favorites.has(item.term);
       const matchesLetter =
-        currentLetterFilter === "All" || item.term.charAt(0).toUpperCase() === currentLetterFilter;
+        currentLetterFilter === "All" ||
+        item.term.charAt(0).toUpperCase() === currentLetterFilter;
       if (matchesSearch && matchesFavorites && matchesLetter) {
         const termDiv = document.createElement("div");
         termDiv.classList.add("dictionary-item");
@@ -181,33 +216,88 @@ function populateTermsList() {
 }
 
 function displayDefinition(term) {
+  const slug = slugify(term.term);
   definitionContainer.style.display = "block";
-  definitionContainer.innerHTML = `<h3>${term.term}</h3><p>${term.definition}</p>`;
+  definitionContainer.innerHTML = `
+    <div class="definition-header">
+      <h3>${term.term}</h3>
+      <div class="adjacent-nav">
+        <button id="prev-term" type="button" aria-label="Previous term">Previous</button>
+        <button id="next-term" type="button" aria-label="Next term">Next</button>
+      </div>
+    </div>
+    <p>${term.definition}</p>`;
   window.location.hash = encodeURIComponent(term.term);
   if (canonicalLink) {
     canonicalLink.setAttribute(
       "href",
-      `${siteUrl}#${encodeURIComponent(term.term)}`
+      `${siteUrl}#${encodeURIComponent(term.term)}`,
     );
   }
+
+  const prevBtn = document.getElementById("prev-term");
+  const nextBtn = document.getElementById("next-term");
+
+  fetchAdjacentSlugs(slug).then(({ previous, next }) => {
+    if (previous) {
+      prevBtn.dataset.slug = previous;
+    } else {
+      prevBtn.disabled = true;
+    }
+    if (next) {
+      nextBtn.dataset.slug = next;
+    } else {
+      nextBtn.disabled = true;
+    }
+  });
+
+  prevBtn.addEventListener("click", (e) => {
+    e.stopPropagation();
+    const target = prevBtn.dataset.slug;
+    if (target) {
+      const matched = termsData.terms.find((t) => slugify(t.term) === target);
+      if (matched) {
+        displayDefinition(matched);
+      }
+    }
+  });
+
+  nextBtn.addEventListener("click", (e) => {
+    e.stopPropagation();
+    const target = nextBtn.dataset.slug;
+    if (target) {
+      const matched = termsData.terms.find((t) => slugify(t.term) === target);
+      if (matched) {
+        displayDefinition(matched);
+      }
+    }
+  });
 }
 
 function clearDefinition() {
   definitionContainer.style.display = "none";
   definitionContainer.innerHTML = "";
-  history.replaceState(null, "", window.location.pathname + window.location.search);
+  history.replaceState(
+    null,
+    "",
+    window.location.pathname + window.location.search,
+  );
   if (canonicalLink) {
     canonicalLink.setAttribute("href", siteUrl);
   }
 }
 
 function showRandomTerm() {
-  const randomTerm = termsData.terms[Math.floor(Math.random() * termsData.terms.length)];
+  const randomTerm =
+    termsData.terms[Math.floor(Math.random() * termsData.terms.length)];
   displayDefinition(randomTerm);
 
   const today = new Date().toDateString();
   try {
-    localStorage.setItem("lastRandomTerm", JSON.stringify({ date: today, term: randomTerm }));
+    localStorage.setItem(
+      "lastRandomTerm",
+      JSON.stringify({ date: today, term: randomTerm }),
+    );
   } catch (e) {
     // Ignore storage errors
   }
@@ -249,8 +339,7 @@ window.addEventListener("scroll", () => {
   scrollBtn.style.display = window.scrollY > 200 ? "block" : "none";
 });
 scrollBtn.addEventListener("click", () =>
-  window.scrollTo({ top: 0, behavior: "smooth" })
+  window.scrollTo({ top: 0, behavior: "smooth" }),
 );
 
 definitionContainer.addEventListener("click", clearDefinition);
-

--- a/styles.css
+++ b/styles.css
@@ -25,7 +25,7 @@ body {
 
 h1 {
   text-align: center;
-  font-family: 'Cinzel', serif;
+  font-family: "Cinzel", serif;
   font-weight: 700;
   font-size: 48px;
   margin-bottom: 20px;
@@ -101,6 +101,37 @@ body.dark-mode mark {
   margin-bottom: 20px;
 }
 
+.definition-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.adjacent-nav {
+  display: flex;
+  gap: 10px;
+}
+
+.adjacent-nav button {
+  padding: 5px 10px;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  background-color: #007bff;
+  color: #fff;
+  cursor: pointer;
+  min-width: 44px;
+  min-height: 44px;
+}
+
+.adjacent-nav button:hover:not(:disabled) {
+  background-color: #0056b3;
+}
+
+.adjacent-nav button:disabled {
+  background-color: #ccc;
+  cursor: default;
+}
+
 #search {
   width: 100%;
   padding: 10px;
@@ -110,7 +141,6 @@ body.dark-mode mark {
   box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
   min-height: 44px;
 }
-
 
 /* Controls styling */
 #random-term {
@@ -206,7 +236,9 @@ label {
   border-radius: 4px;
   padding: 10px;
   cursor: pointer;
-  transition: background-color 0.2s, color 0.2s;
+  transition:
+    background-color 0.2s,
+    color 0.2s;
   min-width: 44px;
   min-height: 44px;
 }
@@ -290,6 +322,20 @@ body.dark-mode .dictionary-item p {
 body.dark-mode #definition-container {
   background-color: #1e1e1e;
   box-shadow: 0 0 5px rgba(255, 255, 255, 0.1);
+}
+
+body.dark-mode .adjacent-nav button {
+  background-color: #333;
+  color: #fff;
+  border-color: #555;
+}
+
+body.dark-mode .adjacent-nav button:hover:not(:disabled) {
+  background-color: #555;
+}
+
+body.dark-mode .adjacent-nav button:disabled {
+  background-color: #555;
 }
 
 body.dark-mode .favorite-star {


### PR DESCRIPTION
## Summary
- fetch previous/next slugs from API to navigate between terms
- add navigation buttons beside entry header while preserving filters
- style navigation controls and dark mode appearance

## Testing
- `npx prettier -w script.js styles.css`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5238a31848328a7466e6f95870666