### PR TITLE
Track and display recent slugs

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,11 @@
 
     <ul id="terms-list"></ul>
   </main>
+  <aside id="recent-slugs" class="sidebar">
+    <h2>Recent Slugs</h2>
+    <ul id="recent-slug-list"></ul>
+    <button id="clear-recent" type="button" aria-label="Clear recent slugs">Clear</button>
+  </aside>
   <footer class="container" aria-label="Contribute">
     <p><a href="templates/contribute.html">Contribute</a></p>
   </footer>

--- a/layout.html
+++ b/layout.html
@@ -31,6 +31,11 @@
 
     <ul id="terms-list"></ul>
   </main>
+  <aside id="recent-slugs" class="sidebar">
+    <h2>Recent Slugs</h2>
+    <ul id="recent-slug-list"></ul>
+    <button id="clear-recent" type="button" aria-label="Clear recent slugs">Clear</button>
+  </aside>
   <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
 
   <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -5,9 +5,19 @@ const randomButton = document.getElementById("random-term");
 const alphaNav = document.getElementById("alpha-nav");
 const darkModeToggle = document.getElementById("dark-mode-toggle");
 const showFavoritesToggle = document.getElementById("show-favorites");
-const favorites = new Set(JSON.parse(localStorage.getItem("favorites") || "[]"));
+const favorites = new Set(
+  JSON.parse(localStorage.getItem("favorites") || "[]"),
+);
 const siteUrl = "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/";
 const canonicalLink = document.getElementById("canonical-link");
+
+const RECENT_KEY = "recentSlugs";
+let recentSlugs = [];
+try {
+  recentSlugs = JSON.parse(localStorage.getItem(RECENT_KEY) || "[]");
+} catch (e) {
+  recentSlugs = [];
+}
 
 let currentLetterFilter = "All";
 let termsData = { terms: [] };
@@ -19,7 +29,10 @@ if (localStorage.getItem("darkMode") === "true") {
 if (darkModeToggle) {
   darkModeToggle.addEventListener("click", () => {
     document.body.classList.toggle("dark-mode");
-    localStorage.setItem("darkMode", document.body.classList.contains("dark-mode"));
+    localStorage.setItem(
+      "darkMode",
+      document.body.classList.contains("dark-mode"),
+    );
   });
 }
 
@@ -43,9 +56,11 @@ function loadTerms() {
       populateTermsList();
 
       if (window.location.hash) {
-        const termFromHash = decodeURIComponent(window.location.hash.substring(1));
+        const termFromHash = decodeURIComponent(
+          window.location.hash.substring(1),
+        );
         const matchedTerm = termsData.terms.find(
-          (t) => t.term.toLowerCase() === termFromHash.toLowerCase()
+          (t) => t.term.toLowerCase() === termFromHash.toLowerCase(),
         );
         if (matchedTerm) {
           displayDefinition(matchedTerm);
@@ -56,7 +71,7 @@ function loadTerms() {
       console.error("Detailed error fetching data:", error);
       definitionContainer.style.display = "block";
       definitionContainer.innerHTML =
-        '<p>Unable to load dictionary data. Please check your connection and try again.</p>' +
+        "<p>Unable to load dictionary data. Please check your connection and try again.</p>" +
         '<button id="retry-fetch">Retry</button>';
       const retryBtn = document.getElementById("retry-fetch");
       if (retryBtn) {
@@ -97,12 +112,16 @@ function toggleFavorite(term) {
 }
 
 function highlightActiveButton(button) {
-  alphaNav.querySelectorAll("button").forEach((btn) => btn.classList.remove("active"));
+  alphaNav
+    .querySelectorAll("button")
+    .forEach((btn) => btn.classList.remove("active"));
   button.classList.add("active");
 }
 
 function buildAlphaNav() {
-  const letters = Array.from(new Set(termsData.terms.map((t) => t.term.charAt(0).toUpperCase()))).sort();
+  const letters = Array.from(
+    new Set(termsData.terms.map((t) => t.term.charAt(0).toUpperCase())),
+  ).sort();
 
   const allButton = document.createElement("button");
   allButton.textContent = "All";
@@ -134,9 +153,13 @@ function populateTermsList() {
     .sort((a, b) => a.term.localeCompare(b.term))
     .forEach((item) => {
       const matchesSearch = item.term.toLowerCase().includes(searchValue);
-      const matchesFavorites = !showFavoritesToggle || !showFavoritesToggle.checked || favorites.has(item.term);
+      const matchesFavorites =
+        !showFavoritesToggle ||
+        !showFavoritesToggle.checked ||
+        favorites.has(item.term);
       const matchesLetter =
-        currentLetterFilter === "All" || item.term.charAt(0).toUpperCase() === currentLetterFilter;
+        currentLetterFilter === "All" ||
+        item.term.charAt(0).toUpperCase() === currentLetterFilter;
       if (matchesSearch && matchesFavorites && matchesLetter) {
         const termDiv = document.createElement("div");
         termDiv.classList.add("dictionary-item");
@@ -187,27 +210,76 @@ function displayDefinition(term) {
   if (canonicalLink) {
     canonicalLink.setAttribute(
       "href",
-      `${siteUrl}#${encodeURIComponent(term.term)}`
+      `${siteUrl}#${encodeURIComponent(term.term)}`,
     );
   }
+  saveRecentSlug(term);
 }
 
 function clearDefinition() {
   definitionContainer.style.display = "none";
   definitionContainer.innerHTML = "";
-  history.replaceState(null, "", window.location.pathname + window.location.search);
+  history.replaceState(
+    null,
+    "",
+    window.location.pathname + window.location.search,
+  );
   if (canonicalLink) {
     canonicalLink.setAttribute("href", siteUrl);
   }
 }
 
+function slugify(str) {
+  return str
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function saveRecentSlug(term) {
+  const slug = slugify(term.term);
+  recentSlugs = recentSlugs.filter((s) => s !== slug);
+  recentSlugs.unshift(slug);
+  if (recentSlugs.length > 10) {
+    recentSlugs = recentSlugs.slice(0, 10);
+  }
+  try {
+    localStorage.setItem(RECENT_KEY, JSON.stringify(recentSlugs));
+  } catch (e) {
+    // Ignore storage errors
+  }
+  renderRecentSlugs();
+}
+
+function renderRecentSlugs() {
+  const list = document.getElementById("recent-slug-list");
+  const container = document.getElementById("recent-slugs");
+  if (!list || !container) {
+    return;
+  }
+  list.innerHTML = "";
+  recentSlugs.forEach((slug) => {
+    const li = document.createElement("li");
+    const link = document.createElement("a");
+    link.href = `terms/${slug}.html`;
+    link.textContent = slug;
+    li.appendChild(link);
+    list.appendChild(li);
+  });
+  container.style.display = recentSlugs.length ? "block" : "none";
+}
+
 function showRandomTerm() {
-  const randomTerm = termsData.terms[Math.floor(Math.random() * termsData.terms.length)];
+  const randomTerm =
+    termsData.terms[Math.floor(Math.random() * termsData.terms.length)];
   displayDefinition(randomTerm);
 
   const today = new Date().toDateString();
   try {
-    localStorage.setItem("lastRandomTerm", JSON.stringify({ date: today, term: randomTerm }));
+    localStorage.setItem(
+      "lastRandomTerm",
+      JSON.stringify({ date: today, term: randomTerm }),
+    );
   } catch (e) {
     // Ignore storage errors
   }
@@ -249,8 +321,22 @@ window.addEventListener("scroll", () => {
   scrollBtn.style.display = window.scrollY > 200 ? "block" : "none";
 });
 scrollBtn.addEventListener("click", () =>
-  window.scrollTo({ top: 0, behavior: "smooth" })
+  window.scrollTo({ top: 0, behavior: "smooth" }),
 );
 
 definitionContainer.addEventListener("click", clearDefinition);
 
+const clearRecentBtn = document.getElementById("clear-recent");
+if (clearRecentBtn) {
+  clearRecentBtn.addEventListener("click", () => {
+    recentSlugs = [];
+    try {
+      localStorage.removeItem(RECENT_KEY);
+    } catch (e) {
+      // Ignore storage errors
+    }
+    renderRecentSlugs();
+  });
+}
+
+renderRecentSlugs();

--- a/styles.css
+++ b/styles.css
@@ -25,7 +25,7 @@ body {
 
 h1 {
   text-align: center;
-  font-family: 'Cinzel', serif;
+  font-family: "Cinzel", serif;
   font-weight: 700;
   font-size: 48px;
   margin-bottom: 20px;
@@ -110,7 +110,6 @@ body.dark-mode mark {
   box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
   min-height: 44px;
 }
-
 
 /* Controls styling */
 #random-term {
@@ -206,7 +205,9 @@ label {
   border-radius: 4px;
   padding: 10px;
   cursor: pointer;
-  transition: background-color 0.2s, color 0.2s;
+  transition:
+    background-color 0.2s,
+    color 0.2s;
   min-width: 44px;
   min-height: 44px;
 }
@@ -239,6 +240,48 @@ label {
 }
 
 #scrollToTopBtn:hover {
+  background-color: #0056b3;
+}
+
+/* Recent slugs sidebar */
+#recent-slugs {
+  position: fixed;
+  right: 0;
+  top: 0;
+  width: 200px;
+  height: 100%;
+  overflow-y: auto;
+  background-color: #fff;
+  border-left: 1px solid #ccc;
+  padding: 10px;
+}
+
+#recent-slugs h2 {
+  margin-top: 0;
+  font-size: 20px;
+}
+
+#recent-slug-list li {
+  cursor: pointer;
+  padding: 5px 0;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+#recent-slug-list li:last-child {
+  border-bottom: none;
+}
+
+#clear-recent {
+  margin-top: 10px;
+  padding: 5px 10px;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  background-color: #007bff;
+  color: #fff;
+  cursor: pointer;
+}
+
+#clear-recent:hover {
   background-color: #0056b3;
 }
 
@@ -290,6 +333,22 @@ body.dark-mode .dictionary-item p {
 body.dark-mode #definition-container {
   background-color: #1e1e1e;
   box-shadow: 0 0 5px rgba(255, 255, 255, 0.1);
+}
+
+body.dark-mode #recent-slugs {
+  background-color: #1e1e1e;
+  border-color: #333;
+  color: #fff;
+}
+
+body.dark-mode #clear-recent {
+  background-color: #333;
+  border-color: #555;
+  color: #fff;
+}
+
+body.dark-mode #clear-recent:hover {
+  background-color: #555;
 }
 
 body.dark-mode .favorite-star {


### PR DESCRIPTION
## Summary
- Track recently viewed term slugs in `localStorage`
- Display recent slugs in a sidebar with a clear button
- Style sidebar for light and dark modes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5238c2d18832882ffca75dec3a9bb