### PR TITLE
feat: add compare view for side-by-side headwords

### DIFF
--- a/assets/js/compare.js
+++ b/assets/js/compare.js
@@ -1,0 +1,79 @@
+(function () {
+  const leftEl = document.getElementById("headword-left");
+  const rightEl = document.getElementById("headword-right");
+
+  function parseSlugs() {
+    const segments = window.location.pathname.split("/").filter(Boolean);
+    let slugA = null;
+    let slugB = null;
+    const compareIndex = segments.indexOf("compare");
+    if (compareIndex !== -1) {
+      slugA = segments[compareIndex + 1] || null;
+      slugB = segments[compareIndex + 2] || null;
+    }
+    const params = new URLSearchParams(window.location.search);
+    if (!slugA) slugA = params.get("a");
+    if (!slugB) slugB = params.get("b");
+    return [slugA, slugB];
+  }
+
+  function createHeadwordLayout(term) {
+    const wrapper = document.createElement("div");
+    wrapper.className = "headword-layout";
+    if (!term) {
+      wrapper.innerHTML = "<p>Term not found.</p>";
+      return wrapper;
+    }
+    const h2 = document.createElement("h2");
+    h2.textContent = term.term;
+    const p = document.createElement("p");
+    p.textContent = term.definition;
+    wrapper.appendChild(h2);
+    wrapper.appendChild(p);
+    return wrapper;
+  }
+
+  function loadTerms(slugA, slugB) {
+    fetch("terms.json")
+      .then((res) => res.json())
+      .then((data) => {
+        const termA = data.terms.find(
+          (t) => t.term.toLowerCase() === decodeURIComponent(slugA || "").toLowerCase()
+        );
+        const termB = data.terms.find(
+          (t) => t.term.toLowerCase() === decodeURIComponent(slugB || "").toLowerCase()
+        );
+        leftEl.appendChild(createHeadwordLayout(termA));
+        rightEl.appendChild(createHeadwordLayout(termB));
+        setupSync();
+      })
+      .catch(() => {
+        leftEl.textContent = "Error loading terms.";
+        rightEl.textContent = "Error loading terms.";
+      });
+  }
+
+  function setupSync() {
+    let leftSyncing = false;
+    let rightSyncing = false;
+    leftEl.addEventListener("scroll", () => {
+      if (!leftSyncing) {
+        rightSyncing = true;
+        rightEl.scrollTop = leftEl.scrollTop;
+      }
+      leftSyncing = false;
+    });
+    rightEl.addEventListener("scroll", () => {
+      if (!rightSyncing) {
+        leftSyncing = true;
+        leftEl.scrollTop = rightEl.scrollTop;
+      }
+      rightSyncing = false;
+    });
+  }
+
+  document.addEventListener("DOMContentLoaded", () => {
+    const [a, b] = parseSlugs();
+    loadTerms(a, b);
+  });
+})();

--- a/compare.html
+++ b/compare.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Compare Terms - Cyber Security Dictionary</title>
+  <link rel="stylesheet" href="styles.css">
+  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet">
+</head>
+<body>
+  <main class="container">
+    <h1>Compare Terms</h1>
+    <div id="compare-wrapper" class="compare-wrapper">
+      <div id="headword-left" class="headword-column"></div>
+      <div id="headword-right" class="headword-column"></div>
+    </div>
+  </main>
+  <script src="assets/js/compare.js"></script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -347,3 +347,26 @@ body.dark-mode #alpha-nav button.active {
     font-size: 14px;
   }
 }
+
+/* Compare page styles */
+.compare-wrapper {
+  display: flex;
+  gap: 20px;
+}
+
+.headword-column {
+  flex: 1;
+  max-height: 70vh;
+  overflow-y: auto;
+  border: 1px solid #ccc;
+  padding: 10px;
+  border-radius: 5px;
+}
+
+.headword-layout h2 {
+  margin-top: 0;
+}
+
+body.dark-mode .headword-column {
+  border-color: #333;
+}

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,9 @@ const URLS_TO_CACHE = [
   '/index.html',
   '/styles.css',
   '/script.js',
-  '/data.json'
+  '/data.json',
+  '/compare.html',
+  '/assets/js/compare.js'
 ];
 
 self.addEventListener('install', event => {


### PR DESCRIPTION
## Summary
- add standalone compare.html page for viewing two terms at once
- implement synchronized scrolling logic in new script
- style dual headword columns and cache new assets in service worker

## Testing
- `npx html-validate compare.html`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5238cd5e483288ff41324342da86e