### PR TITLE
Generate topic pages from CMS data

### DIFF
--- a/data/topics.yaml
+++ b/data/topics.yaml
@@ -1,0 +1,13 @@
+- slug: vulnerability-tracking
+  name: Vulnerability Tracking
+  description: Resources and identifiers for tracking vulnerabilities.
+  words:
+    - cve
+    - cvss
+    - nvd
+- slug: security-frameworks
+  name: Security Frameworks
+  description: Frameworks and standards for security operations.
+  words:
+    - mitre-attack
+    - owasp-top-10

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "script.js",
   "scripts": {
     "build": "node scripts/build.js",
+    "build:topics": "node scripts/build-topics.js",
     "test": "html-validate index.html search.html diagnostics.html && node diagnostics.test.js",
     "watch": "chokidar \"**/*.html\" -c \"npm run build\""
   },

--- a/scripts/build-topics.js
+++ b/scripts/build-topics.js
@@ -1,0 +1,67 @@
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+// Paths to data files
+const dataDir = path.join(__dirname, '..', 'data');
+const topicsPath = path.join(dataDir, 'topics.yaml');
+const termsPath = path.join(dataDir, 'terms.yaml');
+
+// Load YAML data from CMS files
+const topics = yaml.load(fs.readFileSync(topicsPath, 'utf8'));
+const terms = yaml.load(fs.readFileSync(termsPath, 'utf8'));
+
+// Map term slugs to their display names
+const termMap = {};
+for (const term of terms) {
+  termMap[term.slug] = term.name;
+}
+
+// Output directory for generated topic pages
+const outDir = path.join(__dirname, '..', 'topics');
+fs.mkdirSync(outDir, { recursive: true });
+
+// Generate individual topic pages
+for (const topic of topics) {
+  const wordList = topic.words.map(slug => `<li>${termMap[slug] || slug}</li>`).join('\n    ');
+  const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>${topic.name} - Cybersecurity Topics</title>
+  <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+  <main class="container">
+    <h1>${topic.name}</h1>
+    <p>${topic.description}</p>
+    <ul>
+    ${wordList}
+    </ul>
+  </main>
+</body>
+</html>`;
+  fs.writeFileSync(path.join(outDir, `${topic.slug}.html`), html);
+}
+
+// Generate an index page listing all topics
+const links = topics
+  .map(t => `<li><a href="${t.slug}.html">${t.name}</a></li>`)
+  .join('\n    ');
+const indexHtml = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Topics - Cybersecurity Dictionary</title>
+  <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+  <main class="container">
+    <h1>Topics</h1>
+    <ul>
+    ${links}
+    </ul>
+  </main>
+</body>
+</html>`;
+fs.writeFileSync(path.join(outDir, 'index.html'), indexHtml);

--- a/topics/index.html
+++ b/topics/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Topics - Cybersecurity Dictionary</title>
+  <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+  <main class="container">
+    <h1>Topics</h1>
+    <ul>
+    <li><a href="vulnerability-tracking.html">Vulnerability Tracking</a></li>
+    <li><a href="security-frameworks.html">Security Frameworks</a></li>
+    </ul>
+  </main>
+</body>
+</html>

--- a/topics/security-frameworks.html
+++ b/topics/security-frameworks.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Security Frameworks - Cybersecurity Topics</title>
+  <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+  <main class="container">
+    <h1>Security Frameworks</h1>
+    <p>Frameworks and standards for security operations.</p>
+    <ul>
+    <li>MITRE ATT&CK</li>
+    <li>OWASP Top 10</li>
+    </ul>
+  </main>
+</body>
+</html>

--- a/topics/vulnerability-tracking.html
+++ b/topics/vulnerability-tracking.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Vulnerability Tracking - Cybersecurity Topics</title>
+  <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+  <main class="container">
+    <h1>Vulnerability Tracking</h1>
+    <p>Resources and identifiers for tracking vulnerabilities.</p>
+    <ul>
+    <li>CVE</li>
+    <li>CVSS</li>
+    <li>NVD</li>
+    </ul>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- build static topic pages from CMS-sourced YAML data
- add topics data file and generation script
- include topics index and individual topic HTML files

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5238e50088328a64a9fb8510dbb1d