### PR TITLE
Add trending analytics page with charts

### DIFF
--- a/assets/js/trending.js
+++ b/assets/js/trending.js
@@ -1,0 +1,46 @@
+(function () {
+  const ANALYTICS_BASE =
+    window.__ANALYTICS_BASE__ || "https://analytics.example.com";
+
+  async function fetchCounts(range) {
+    const url = `${ANALYTICS_BASE}/trending?range=${range}`;
+    const res = await fetch(url);
+    if (!res.ok) {
+      throw new Error(`Failed to fetch ${range} data`);
+    }
+    return res.json();
+  }
+
+  function buildChart(canvas, items, label) {
+    if (!canvas) return;
+    const labels = items.map((i) => i.term || i.label || i.date || "");
+    const counts = items.map((i) => i.count || i.value || 0);
+    new Chart(canvas.getContext("2d"), {
+      type: "bar",
+      data: {
+        labels,
+        datasets: [
+          {
+            label,
+            data: counts,
+            backgroundColor: "rgba(54, 162, 235, 0.5)",
+          },
+        ],
+      },
+      options: { responsive: true, maintainAspectRatio: false },
+    });
+  }
+
+  document.addEventListener("DOMContentLoaded", async () => {
+    try {
+      const [weekly, monthly] = await Promise.all([
+        fetchCounts("week"),
+        fetchCounts("month"),
+      ]);
+      buildChart(document.getElementById("weeklyChart"), weekly, "Weekly");
+      buildChart(document.getElementById("monthlyChart"), monthly, "Monthly");
+    } catch (err) {
+      console.error("Error loading analytics data", err);
+    }
+  });
+})();

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 <body>
   <main class="container">
     <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav" aria-label="Site links"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
+    <nav class="site-nav" aria-label="Site links"><a href="templates/guidelines.html">Definition Guidelines</a><a href="trending.html">Trending</a></nav>
     <div id="definition-container" style="display: none;"></div>
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">

--- a/sw.js
+++ b/sw.js
@@ -1,36 +1,44 @@
-const CACHE_NAME = 'csd-cache-v1';
+const CACHE_NAME = "csd-cache-v1";
 const URLS_TO_CACHE = [
-  '/',
-  '/index.html',
-  '/styles.css',
-  '/script.js',
-  '/data.json'
+  "/",
+  "/index.html",
+  "/styles.css",
+  "/script.js",
+  "/data.json",
+  "/trending.html",
+  "/assets/js/trending.js",
 ];
 
-self.addEventListener('install', event => {
+self.addEventListener("install", (event) => {
   event.waitUntil(
-    caches.open(CACHE_NAME).then(cache => cache.addAll(URLS_TO_CACHE))
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(URLS_TO_CACHE)),
   );
 });
 
-self.addEventListener('activate', event => {
+self.addEventListener("activate", (event) => {
   event.waitUntil(
-    caches.keys().then(keys =>
-      Promise.all(
-        keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key))
-      )
-    )
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(
+          keys
+            .filter((key) => key !== CACHE_NAME)
+            .map((key) => caches.delete(key)),
+        ),
+      ),
   );
 });
 
-self.addEventListener('fetch', event => {
+self.addEventListener("fetch", (event) => {
   event.respondWith(
-    caches.match(event.request).then(response =>
-      response || fetch(event.request).catch(() => {
-        if (event.request.mode === 'navigate') {
-          return caches.match('/index.html');
-        }
-      })
-    )
+    caches.match(event.request).then(
+      (response) =>
+        response ||
+        fetch(event.request).catch(() => {
+          if (event.request.mode === "navigate") {
+            return caches.match("/index.html");
+          }
+        }),
+    ),
   );
 });

--- a/trending.html
+++ b/trending.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Trending Terms</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <main class="container">
+    <h1>Trending Terms</h1>
+    <section aria-label="Weekly trending terms">
+      <h2>Weekly</h2>
+      <canvas id="weeklyChart"></canvas>
+    </section>
+    <section aria-label="Monthly trending terms">
+      <h2>Monthly</h2>
+      <canvas id="monthlyChart"></canvas>
+    </section>
+  </main>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="assets/js/trending.js"></script>
+  <script src="assets/js/app.js"></script>
+  <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
+  <script src="assets/js/metrics.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add `/trending` page displaying weekly and monthly trends with Chart.js
- Fetch analytics data and render bar charts
- Link trending page from home navigation and cache via service worker

## Testing
- `npx html-validate trending.html`
- `npx html-validate index.html search.html diagnostics.html`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5238d396083288f98bfb3f86cd918