### PR TITLE
Add difficulty filter slider and query param support

### DIFF
--- a/assets/js/AdvancedFilters.tsx
+++ b/assets/js/AdvancedFilters.tsx
@@ -1,0 +1,47 @@
+import React, { useEffect, useState, ChangeEvent } from 'react';
+
+declare global {
+  interface Window {
+    __handleSearch?: () => void;
+  }
+}
+
+const AdvancedFilters: React.FC = () => {
+  const params = new URLSearchParams(window.location.search);
+  const initial = parseInt(params.get('difficulty') || '0', 10);
+  const [difficulty, setDifficulty] = useState(initial);
+
+  useEffect(() => {
+    const searchParams = new URLSearchParams(window.location.search);
+    if (difficulty > 0) {
+      searchParams.set('difficulty', difficulty.toString());
+    } else {
+      searchParams.delete('difficulty');
+    }
+    const newUrl = `${window.location.pathname}?${searchParams.toString()}`;
+    window.history.replaceState({}, '', newUrl);
+    if (typeof window.__handleSearch === 'function') {
+      window.__handleSearch();
+    }
+  }, [difficulty]);
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setDifficulty(parseInt(e.target.value, 10));
+  };
+
+  return (
+    <div className="advanced-filters">
+      <label htmlFor="difficulty">Difficulty: {difficulty}</label>
+      <input
+        id="difficulty"
+        type="range"
+        min="0"
+        max="5"
+        value={difficulty}
+        onChange={handleChange}
+      />
+    </div>
+  );
+};
+
+export default AdvancedFilters;

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -24,7 +24,18 @@
     if(!query){
       return;
     }
-    const matches = terms
+    const params = new URLSearchParams(window.location.search);
+    const diff = parseInt(params.get('difficulty') || '0', 10);
+
+    let filtered = terms;
+    if (diff > 0) {
+      filtered = terms.filter(t => {
+        const td = typeof t.difficulty === 'number' ? t.difficulty : 0;
+        return td <= diff;
+      });
+    }
+
+    const matches = filtered
       .map(term => ({ term, score: score(term, query) }))
       .filter(item => item.score > 0)
       .sort((a,b) => b.score - a.score);
@@ -33,6 +44,8 @@
       resultsContainer.appendChild(renderCard(term));
     });
   }
+
+  window.__handleSearch = handleSearch;
 
   function score(term, query){
     let s = 0;


### PR DESCRIPTION
## Summary
- add React advanced filters component with difficulty slider tied to query string
- use difficulty query param to filter search results and expose global handler

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b523903df08328b9d9c4363da66a14