### PR TITLE
feat: add autocomplete search components

### DIFF
--- a/components/AutocompleteList.tsx
+++ b/components/AutocompleteList.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+interface AutocompleteListProps {
+  suggestions: string[];
+  highlightedIndex: number;
+  onSelect: (value: string) => void;
+}
+
+const AutocompleteList: React.FC<AutocompleteListProps> = ({
+  suggestions,
+  highlightedIndex,
+  onSelect,
+}) => {
+  return (
+    <ul className="autocomplete-list">
+      {suggestions.map((suggestion, index) => (
+        <li
+          key={`${suggestion}-${index}`}
+          className={index === highlightedIndex ? 'highlighted' : undefined}
+          onMouseDown={(e) => {
+            e.preventDefault();
+            onSelect(suggestion);
+          }}
+        >
+          {suggestion}
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default AutocompleteList;

--- a/components/SearchBox.tsx
+++ b/components/SearchBox.tsx
@@ -1,0 +1,78 @@
+import React, { useState, useRef, useEffect } from 'react';
+import AutocompleteList from './AutocompleteList';
+
+const SearchBox: React.FC = () => {
+  const [value, setValue] = useState('');
+  const [suggestions, setSuggestions] = useState<string[]>([]);
+  const [highlightedIndex, setHighlightedIndex] = useState(-1);
+  const [showSuggestions, setShowSuggestions] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (value.trim() === '') {
+      setSuggestions([]);
+      setShowSuggestions(false);
+      return;
+    }
+    fetch(`/api/suggest?q=${encodeURIComponent(value)}`)
+      .then((r) => (r.ok ? r.json() : Promise.reject(r.statusText)))
+      .then((data: string[]) => {
+        setSuggestions(data);
+        setHighlightedIndex(-1);
+        setShowSuggestions(true);
+      })
+      .catch(() => {
+        setSuggestions([]);
+        setShowSuggestions(false);
+      });
+  }, [value]);
+
+  const selectSuggestion = (suggestion: string) => {
+    setValue(suggestion);
+    setShowSuggestions(false);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (!showSuggestions) return;
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setHighlightedIndex((prev) => (prev + 1) % suggestions.length);
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setHighlightedIndex((prev) =>
+        prev <= 0 ? suggestions.length - 1 : prev - 1
+      );
+    } else if (e.key === 'Enter') {
+      if (highlightedIndex >= 0 && highlightedIndex < suggestions.length) {
+        e.preventDefault();
+        selectSuggestion(suggestions[highlightedIndex]);
+      }
+    }
+  };
+
+  const handleBlur = () => {
+    setTimeout(() => setShowSuggestions(false), 100);
+  };
+
+  return (
+    <div className="search-box" style={{ position: 'relative' }}>
+      <input
+        ref={inputRef}
+        type="text"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onKeyDown={handleKeyDown}
+        onBlur={handleBlur}
+      />
+      {showSuggestions && suggestions.length > 0 && (
+        <AutocompleteList
+          suggestions={suggestions}
+          highlightedIndex={highlightedIndex}
+          onSelect={selectSuggestion}
+        />
+      )}
+    </div>
+  );
+};
+
+export default SearchBox;


### PR DESCRIPTION
## Summary
- add AutocompleteList component to render suggestion dropdown
- extend SearchBox to fetch and select suggestions with keyboard navigation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b538fe3c588328ae06f5c4a8f107c2