### PR TITLE
Add pronunciation player component using Wavesurfer

### DIFF
--- a/components/PronunciationPlayer.tsx
+++ b/components/PronunciationPlayer.tsx
@@ -1,0 +1,76 @@
+import React, { useEffect, useRef, useState } from "react";
+
+export interface PronunciationPlayerProps {
+  /** URL of the pronunciation audio file */
+  src: string;
+}
+
+const PronunciationPlayer: React.FC<PronunciationPlayerProps> = ({ src }) => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const wavesurferRef = useRef<any>(null);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [rate, setRate] = useState(1);
+
+  // Create wavesurfer instance on mount
+  useEffect(() => {
+    let ws: any;
+    (async () => {
+      const WaveSurfer = (await import("wavesurfer.js")).default;
+      if (!containerRef.current) return;
+      ws = WaveSurfer.create({
+        container: containerRef.current,
+        height: 48,
+        waveColor: "#a0aec0",
+        progressColor: "#2d3748",
+        cursorColor: "#2d3748",
+        barWidth: 2,
+        responsive: true,
+      });
+      wavesurferRef.current = ws;
+      ws.on("finish", () => setIsPlaying(false));
+      ws.load(src);
+    })();
+    return () => {
+      ws?.destroy();
+      wavesurferRef.current = null;
+    };
+  }, [src]);
+
+  // Update playback rate when it changes
+  useEffect(() => {
+    wavesurferRef.current?.setPlaybackRate(rate);
+  }, [rate]);
+
+  const togglePlay = () => {
+    const ws = wavesurferRef.current;
+    if (!ws) return;
+    ws.playPause();
+    setIsPlaying(ws.isPlaying());
+  };
+
+  const handleRateChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setRate(parseFloat(e.target.value));
+  };
+
+  return (
+    <div className="pronunciation-player">
+      <div ref={containerRef} />
+      <div className="controls">
+        <button type="button" onClick={togglePlay}>
+          {isPlaying ? "Pause" : "Play"}
+        </button>
+        <label>
+          Rate:
+          <select value={rate} onChange={handleRateChange}>
+            <option value={0.75}>0.75x</option>
+            <option value={1}>1x</option>
+            <option value={1.25}>1.25x</option>
+            <option value={1.5}>1.5x</option>
+          </select>
+        </label>
+      </div>
+    </div>
+  );
+};
+
+export default PronunciationPlayer;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "cybersecuirtydictionary",
       "version": "1.0.0",
       "license": "ISC",
+      "dependencies": {
+        "wavesurfer.js": "^7.8.1"
+      },
       "devDependencies": {
         "chokidar-cli": "^3.0.0",
         "html-validate": "^10.0.0",
@@ -2110,6 +2113,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/wavesurfer.js": {
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/wavesurfer.js/-/wavesurfer.js-7.10.1.tgz",
+      "integrity": "sha512-tF1ptFCAi8SAqKbM1e7705zouLC3z4ulXCg15kSP5dQ7VDV30Q3x/xFRcuVIYTT5+jB/PdkhiBRCfsMshZG1Ug==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -18,5 +18,8 @@
     "js-yaml": "^4.1.0",
     "prettier": "^3.6.2",
     "jsdom": "^26.1.0"
+  },
+  "dependencies": {
+    "wavesurfer.js": "^7.8.1"
   }
 }


### PR DESCRIPTION
## Summary
- add React pronunciation player with play/pause and speed options
- render small waveform via dynamically loaded Wavesurfer.js
- declare wavesurfer.js dependency

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b53903c86c832882210b9a95f75ed6