### PR TITLE
Add accordion for homograph senses with URL persistence

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -25,7 +25,7 @@ body {
 
 h1 {
   text-align: center;
-  font-family: 'Cinzel', serif;
+  font-family: "Cinzel", serif;
   font-weight: 700;
   font-size: 48px;
   margin-bottom: 20px;
@@ -111,7 +111,6 @@ body.dark-mode mark {
   min-height: 44px;
 }
 
-
 /* Controls styling */
 #random-term {
   margin-top: 10px;
@@ -156,6 +155,18 @@ label {
   width: 44px;
   height: 44px;
   margin-right: 5px;
+}
+
+.accordion details {
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  margin-bottom: 10px;
+  padding: 10px;
+}
+
+.accordion summary {
+  cursor: pointer;
+  font-weight: bold;
 }
 
 /* Favorite star styles */
@@ -206,7 +217,9 @@ label {
   border-radius: 4px;
   padding: 10px;
   cursor: pointer;
-  transition: background-color 0.2s, color 0.2s;
+  transition:
+    background-color 0.2s,
+    color 0.2s;
   min-width: 44px;
   min-height: 44px;
 }


### PR DESCRIPTION
## Summary
- Group duplicate terms into homographs with multiple definitions
- Introduce accordion component for sub-senses and persist open state in URL hash
- Style accordion details for improved readability

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b539061ad48328b77d85a7ce9007ff