### PR TITLE
Add collocation patterns viewer

### DIFF
--- a/assets/js/collocations.js
+++ b/assets/js/collocations.js
@@ -1,0 +1,53 @@
+(function () {
+  function renderCollocations(collocations) {
+    const container = document.getElementById("collocation-chips");
+    if (!container) return;
+    collocations.forEach((item) => {
+      const chip = document.createElement("button");
+      chip.className = "collocation-chip";
+      chip.type = "button";
+      const label = document.createElement("span");
+      label.textContent = item.pattern || "";
+      const badge = document.createElement("span");
+      badge.className = "badge";
+      badge.textContent = item.count || 0;
+      chip.appendChild(label);
+      chip.appendChild(badge);
+      chip.addEventListener("click", () => showExamples(item));
+      container.appendChild(chip);
+    });
+  }
+
+  function showExamples(item) {
+    const modal = document.getElementById("examples-modal");
+    const list = document.getElementById("examples-list");
+    if (!modal || !list) return;
+    list.innerHTML = "";
+    (item.examples || []).forEach((ex) => {
+      const li = document.createElement("li");
+      li.textContent = ex;
+      list.appendChild(li);
+    });
+    modal.style.display = "block";
+  }
+
+  document.addEventListener("DOMContentLoaded", () => {
+    const modal = document.getElementById("examples-modal");
+    const closeBtn = modal ? modal.querySelector(".close") : null;
+    if (closeBtn) {
+      closeBtn.addEventListener("click", () => {
+        modal.style.display = "none";
+      });
+    }
+    window.addEventListener("click", (e) => {
+      if (e.target === modal) {
+        modal.style.display = "none";
+      }
+    });
+
+    fetch("/api/collocations")
+      .then((r) => (r.ok ? r.json() : Promise.reject(r.statusText)))
+      .then((data) => renderCollocations(data))
+      .catch((err) => console.error("Failed to load collocations", err));
+  });
+})();

--- a/collocations.html
+++ b/collocations.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Collocation Patterns</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <main class="container">
+    <h1>Collocation Patterns</h1>
+    <div id="collocation-chips"></div>
+  </main>
+  <div id="examples-modal" class="modal" style="display: none;">
+    <div class="modal-content">
+      <button type="button" class="close" aria-label="Close modal">&times;</button>
+      <h2>Examples</h2>
+      <ul id="examples-list"></ul>
+    </div>
+  </div>
+  <script src="assets/js/collocations.js"></script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -326,6 +326,62 @@ body.dark-mode #alpha-nav button.active {
   border-color: #007bff;
 }
 
+/* Collocation chip styles */
+.collocation-chip {
+  display: inline-flex;
+  align-items: center;
+  margin: 4px;
+  padding: 4px 8px;
+  border: 1px solid #ccc;
+  border-radius: 16px;
+  background-color: #f0f0f0;
+  cursor: pointer;
+}
+.collocation-chip .badge {
+  margin-left: 6px;
+}
+
+/* Modal styles */
+.modal {
+  position: fixed;
+  z-index: 1000;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  background-color: rgba(0, 0, 0, 0.4);
+  display: none;
+}
+.modal-content {
+  background-color: #fff;
+  margin: 10% auto;
+  padding: 20px;
+  border: 1px solid #888;
+  border-radius: 4px;
+  max-width: 600px;
+}
+.modal-content ul {
+  list-style: disc;
+  padding-left: 20px;
+}
+.modal .close {
+  float: right;
+  font-size: 28px;
+  font-weight: bold;
+  cursor: pointer;
+}
+
+body.dark-mode .collocation-chip {
+  background-color: #333;
+  border-color: #555;
+  color: #fff;
+}
+body.dark-mode .modal-content {
+  background-color: #1e1e1e;
+  color: #fff;
+  border-color: #333;
+}
 @media (max-width: 480px) {
   h1 {
     font-size: 32px;


### PR DESCRIPTION
## Summary
- Add standalone collocations page that fetches `/api/collocations`
- Display collocations as chips with counts and show examples in a modal
- Include supporting styles for chips and modal

## Testing
- `npm test`
- `npx html-validate collocations.html`


------
https://chatgpt.com/codex/tasks/task_e_68b5390b57648328b20427fccd0731e5