### PR TITLE
feat: add affix navigation chips

### DIFF
--- a/script.js
+++ b/script.js
@@ -180,9 +180,93 @@ function populateTermsList() {
     });
 }
 
+function findAffixMatches(term) {
+  const lower = term.term.toLowerCase();
+  const prefixes = [];
+  const suffixes = [];
+
+  termsData.terms.forEach((t) => {
+    const other = t.term.toLowerCase();
+    if (other === lower) {
+      return;
+    }
+    if (lower.startsWith(other)) {
+      prefixes.push(t);
+    }
+    if (lower.endsWith(other)) {
+      suffixes.push(t);
+    }
+  });
+
+  return { prefixes, suffixes };
+}
+
 function displayDefinition(term) {
   definitionContainer.style.display = "block";
   definitionContainer.innerHTML = `<h3>${term.term}</h3><p>${term.definition}</p>`;
+
+  const { prefixes, suffixes } = findAffixMatches(term);
+
+  if (prefixes.length || suffixes.length) {
+    const affixContainer = document.createElement("div");
+    affixContainer.classList.add("affix-container");
+
+    if (prefixes.length) {
+      const prefixDiv = document.createElement("div");
+      const prefixLabel = document.createElement("strong");
+      prefixLabel.textContent = "Prefixes: ";
+      prefixDiv.appendChild(prefixLabel);
+      prefixes.forEach((p) => {
+        const link = document.createElement("a");
+        link.href = `#${encodeURIComponent(p.term)}`;
+        link.textContent = p.term;
+        link.addEventListener("click", (e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          displayDefinition(p);
+        });
+        prefixDiv.appendChild(link);
+      });
+      affixContainer.appendChild(prefixDiv);
+    }
+
+    if (suffixes.length) {
+      const suffixDiv = document.createElement("div");
+      const suffixLabel = document.createElement("strong");
+      suffixLabel.textContent = "Suffixes: ";
+      suffixDiv.appendChild(suffixLabel);
+      suffixes.forEach((s) => {
+        const link = document.createElement("a");
+        link.href = `#${encodeURIComponent(s.term)}`;
+        link.textContent = s.term;
+        link.addEventListener("click", (e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          displayDefinition(s);
+        });
+        suffixDiv.appendChild(link);
+      });
+      affixContainer.appendChild(suffixDiv);
+    }
+
+    definitionContainer.appendChild(affixContainer);
+
+    const chipContainer = document.createElement("div");
+    chipContainer.classList.add("nav-chips");
+    [...prefixes, ...suffixes].forEach((t) => {
+      const chip = document.createElement("button");
+      chip.classList.add("nav-chip");
+      chip.textContent = t.term;
+      chip.addEventListener("click", (e) => {
+        e.stopPropagation();
+        displayDefinition(t);
+      });
+      chipContainer.appendChild(chip);
+    });
+    if (chipContainer.childElementCount > 0) {
+      definitionContainer.appendChild(chipContainer);
+    }
+  }
   window.location.hash = encodeURIComponent(term.term);
   if (canonicalLink) {
     canonicalLink.setAttribute(

--- a/styles.css
+++ b/styles.css
@@ -222,6 +222,35 @@ label {
   color: #fff;
 }
 
+/* Affix list and navigation chips */
+.affix-container {
+  margin-top: 10px;
+  font-size: 0.9em;
+}
+
+.affix-container a {
+  margin-right: 8px;
+}
+
+.nav-chips {
+  margin-top: 10px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
+.nav-chip {
+  background-color: #eee;
+  border: 1px solid #ccc;
+  border-radius: 16px;
+  padding: 5px 10px;
+  cursor: pointer;
+}
+
+.nav-chip:hover {
+  background-color: #ddd;
+}
+
 /* Scroll to Top button styles */
 #scrollToTopBtn {
   display: none;
@@ -324,6 +353,16 @@ body.dark-mode #alpha-nav button:focus {
 body.dark-mode #alpha-nav button.active {
   background-color: #007bff;
   border-color: #007bff;
+}
+
+body.dark-mode .nav-chip {
+  background-color: #333;
+  border-color: #555;
+  color: #fff;
+}
+
+body.dark-mode .nav-chip:hover {
+  background-color: #555;
 }
 
 @media (max-width: 480px) {


### PR DESCRIPTION
## Summary
- list term prefixes and suffixes with links to corresponding entries
- add navigation chips below definitions for one-click access

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5390dcd048328a3089c639c948c10