### PR TITLE
feat: add anagram search panel

### DIFF
--- a/assets/js/anagrams.js
+++ b/assets/js/anagrams.js
@@ -1,0 +1,35 @@
+(function () {
+  const form = document.getElementById('anagram-form');
+  const wordInput = document.getElementById('anagram-word');
+  const lengthInput = document.getElementById('anagram-length');
+  const results = document.getElementById('anagram-results');
+
+  if (!form) return;
+
+  form.addEventListener('submit', (e) => {
+    e.preventDefault();
+    const word = wordInput.value.trim();
+    const len = lengthInput.value.trim();
+    if (!word) return;
+    const baseUrl = window.__BASE_URL__ || '';
+    const params = new URLSearchParams({ word });
+    if (len) params.append('length', len);
+
+    fetch(`${baseUrl}/api/anagrams?${params.toString()}`)
+      .then((r) => (r.ok ? r.json() : Promise.reject(r.statusText)))
+      .then((data) => {
+        results.innerHTML = '';
+        (data.anagrams || []).forEach((term) => {
+          const a = document.createElement('a');
+          a.textContent = term;
+          a.href = `${baseUrl}/#${encodeURIComponent(term)}`;
+          a.className = 'chip';
+          results.appendChild(a);
+        });
+      })
+      .catch((err) => {
+        console.error('Failed to fetch anagrams', err);
+        results.textContent = 'Error fetching anagrams';
+      });
+  });
+})();

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "node scripts/build.js",
     "test": "html-validate index.html search.html diagnostics.html && node diagnostics.test.js",
-    "watch": "chokidar \"**/*.html\" -c \"npm run build\""
+    "watch": "chokidar \"**/*.html\" -c \"npm run build\"",
+    "start": "node server.js"
   },
   "keywords": [],
   "author": "",

--- a/search.html
+++ b/search.html
@@ -11,11 +11,22 @@
     <h1>Search</h1>
     <input id="search-box" type="text" placeholder="Search terms...">
     <div id="results"></div>
+
+    <section id="anagrams-panel">
+      <h2>Find Anagrams</h2>
+      <form id="anagram-form">
+        <input id="anagram-word" type="text" placeholder="Word" required>
+        <input id="anagram-length" type="number" min="1" placeholder="Length">
+        <button type="submit">Generate</button>
+      </form>
+      <div id="anagram-results" aria-live="polite"></div>
+    </section>
   </main>
   <script>
     window.__BASE_URL__ = window.__BASE_URL__ || '';
   </script>
   <script src="assets/js/search.js"></script>
+  <script src="assets/js/anagrams.js"></script>
   <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
   <script src="assets/js/metrics.js"></script>
 </body>

--- a/server.js
+++ b/server.js
@@ -1,0 +1,60 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const termsPath = path.join(__dirname, 'terms.json');
+let terms = [];
+try {
+  const data = JSON.parse(fs.readFileSync(termsPath, 'utf8'));
+  terms = Array.isArray(data) ? data : data.terms || [];
+} catch (err) {
+  console.error('Failed to load terms.json', err);
+}
+
+function sanitize(str) {
+  return (str || '').toLowerCase().replace(/[^a-z]/g, '');
+}
+
+function letterCount(str) {
+  return sanitize(str).split('').reduce((acc, ch) => {
+    acc[ch] = (acc[ch] || 0) + 1;
+    return acc;
+  }, {});
+}
+
+const server = http.createServer((req, res) => {
+  const url = new URL(req.url, `http://${req.headers.host}`);
+  if (url.pathname === '/api/anagrams') {
+    const word = url.searchParams.get('word') || '';
+    if (!word) {
+      res.writeHead(400, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Missing word parameter' }));
+      return;
+    }
+    const lenParam = url.searchParams.get('length');
+    const requestedLength = lenParam ? parseInt(lenParam, 10) : null;
+    const baseCount = letterCount(word);
+
+    const results = terms
+      .map((t) => t.term || t.name || '')
+      .filter((term) => {
+        const clean = sanitize(term);
+        if (requestedLength && clean.length !== requestedLength) return false;
+        if (clean === sanitize(word)) return false;
+        const count = letterCount(clean);
+        return Object.keys(count).every((ch) => count[ch] <= (baseCount[ch] || 0));
+      });
+
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ anagrams: results }));
+    return;
+  }
+
+  res.writeHead(404, { 'Content-Type': 'text/plain' });
+  res.end('Not found');
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/styles.css
+++ b/styles.css
@@ -287,6 +287,32 @@ body.dark-mode .dictionary-item p {
   color: #ccc;
 }
 
+.chip {
+  display: inline-block;
+  padding: 0.25rem 0.5rem;
+  margin: 0.25rem;
+  background-color: #e0e0e0;
+  border-radius: 16px;
+  font-size: 0.875rem;
+  color: #333;
+  text-decoration: none;
+}
+
+.chip:hover,
+.chip:focus {
+  background-color: #d5d5d5;
+}
+
+body.dark-mode .chip {
+  background-color: #333;
+  color: #fff;
+}
+
+body.dark-mode .chip:hover,
+body.dark-mode .chip:focus {
+  background-color: #444;
+}
+
 body.dark-mode #definition-container {
   background-color: #1e1e1e;
   box-shadow: 0 0 5px rgba(255, 255, 255, 0.1);


### PR DESCRIPTION
## Summary
- add server endpoint to generate dictionary-based anagrams with optional length filter
- create search page panel that fetches anagrams and shows them as linkable chips
- style chip links and expose a start script for running the endpoint

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5390f194c8328a292e277d24268f4