### PR TITLE
feat: add translation accordions

### DIFF
--- a/script.js
+++ b/script.js
@@ -5,12 +5,21 @@ const randomButton = document.getElementById("random-term");
 const alphaNav = document.getElementById("alpha-nav");
 const darkModeToggle = document.getElementById("dark-mode-toggle");
 const showFavoritesToggle = document.getElementById("show-favorites");
-const favorites = new Set(JSON.parse(localStorage.getItem("favorites") || "[]"));
+const favorites = new Set(
+  JSON.parse(localStorage.getItem("favorites") || "[]"),
+);
 const siteUrl = "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/";
 const canonicalLink = document.getElementById("canonical-link");
 
 let currentLetterFilter = "All";
 let termsData = { terms: [] };
+
+const languageNames = {
+  es: "Spanish",
+  fr: "French",
+};
+
+const translationCache = {};
 
 if (localStorage.getItem("darkMode") === "true") {
   document.body.classList.add("dark-mode");
@@ -19,7 +28,10 @@ if (localStorage.getItem("darkMode") === "true") {
 if (darkModeToggle) {
   darkModeToggle.addEventListener("click", () => {
     document.body.classList.toggle("dark-mode");
-    localStorage.setItem("darkMode", document.body.classList.contains("dark-mode"));
+    localStorage.setItem(
+      "darkMode",
+      document.body.classList.contains("dark-mode"),
+    );
   });
 }
 
@@ -43,9 +55,11 @@ function loadTerms() {
       populateTermsList();
 
       if (window.location.hash) {
-        const termFromHash = decodeURIComponent(window.location.hash.substring(1));
+        const termFromHash = decodeURIComponent(
+          window.location.hash.substring(1),
+        );
         const matchedTerm = termsData.terms.find(
-          (t) => t.term.toLowerCase() === termFromHash.toLowerCase()
+          (t) => t.term.toLowerCase() === termFromHash.toLowerCase(),
         );
         if (matchedTerm) {
           displayDefinition(matchedTerm);
@@ -56,7 +70,7 @@ function loadTerms() {
       console.error("Detailed error fetching data:", error);
       definitionContainer.style.display = "block";
       definitionContainer.innerHTML =
-        '<p>Unable to load dictionary data. Please check your connection and try again.</p>' +
+        "<p>Unable to load dictionary data. Please check your connection and try again.</p>" +
         '<button id="retry-fetch">Retry</button>';
       const retryBtn = document.getElementById("retry-fetch");
       if (retryBtn) {
@@ -97,12 +111,16 @@ function toggleFavorite(term) {
 }
 
 function highlightActiveButton(button) {
-  alphaNav.querySelectorAll("button").forEach((btn) => btn.classList.remove("active"));
+  alphaNav
+    .querySelectorAll("button")
+    .forEach((btn) => btn.classList.remove("active"));
   button.classList.add("active");
 }
 
 function buildAlphaNav() {
-  const letters = Array.from(new Set(termsData.terms.map((t) => t.term.charAt(0).toUpperCase()))).sort();
+  const letters = Array.from(
+    new Set(termsData.terms.map((t) => t.term.charAt(0).toUpperCase())),
+  ).sort();
 
   const allButton = document.createElement("button");
   allButton.textContent = "All";
@@ -134,9 +152,13 @@ function populateTermsList() {
     .sort((a, b) => a.term.localeCompare(b.term))
     .forEach((item) => {
       const matchesSearch = item.term.toLowerCase().includes(searchValue);
-      const matchesFavorites = !showFavoritesToggle || !showFavoritesToggle.checked || favorites.has(item.term);
+      const matchesFavorites =
+        !showFavoritesToggle ||
+        !showFavoritesToggle.checked ||
+        favorites.has(item.term);
       const matchesLetter =
-        currentLetterFilter === "All" || item.term.charAt(0).toUpperCase() === currentLetterFilter;
+        currentLetterFilter === "All" ||
+        item.term.charAt(0).toUpperCase() === currentLetterFilter;
       if (matchesSearch && matchesFavorites && matchesLetter) {
         const termDiv = document.createElement("div");
         termDiv.classList.add("dictionary-item");
@@ -183,31 +205,104 @@ function populateTermsList() {
 function displayDefinition(term) {
   definitionContainer.style.display = "block";
   definitionContainer.innerHTML = `<h3>${term.term}</h3><p>${term.definition}</p>`;
+  buildTranslationPanels(term);
   window.location.hash = encodeURIComponent(term.term);
   if (canonicalLink) {
     canonicalLink.setAttribute(
       "href",
-      `${siteUrl}#${encodeURIComponent(term.term)}`
+      `${siteUrl}#${encodeURIComponent(term.term)}`,
     );
+  }
+}
+
+function buildTranslationPanels(term) {
+  const container = document.createElement("div");
+  container.id = "translations";
+
+  Object.entries(languageNames).forEach(([code, label]) => {
+    const details = document.createElement("details");
+    const summary = document.createElement("summary");
+    summary.textContent = label;
+    details.appendChild(summary);
+
+    details.addEventListener("toggle", () => {
+      if (details.open && !details.dataset.loaded) {
+        details.dataset.loaded = "true";
+        if (translationCache[code]) {
+          insertTranslation(details, translationCache[code], term.term);
+        } else {
+          fetch(`translations/${code}.json`)
+            .then((res) => res.json())
+            .then((data) => {
+              translationCache[code] = data;
+              insertTranslation(details, data, term.term);
+            })
+            .catch(() => {
+              const p = document.createElement("p");
+              p.textContent = "Error loading translations.";
+              details.appendChild(p);
+            });
+        }
+      }
+    });
+
+    container.appendChild(details);
+  });
+
+  definitionContainer.appendChild(container);
+}
+
+function insertTranslation(details, data, termName) {
+  const entry = data[termName];
+  if (entry) {
+    const t = document.createElement("p");
+    t.textContent = entry.translation;
+    details.appendChild(t);
+
+    if (entry.gloss) {
+      const g = document.createElement("p");
+      g.classList.add("gloss");
+      g.textContent = entry.gloss;
+      details.appendChild(g);
+    }
+
+    if (entry.usage) {
+      const u = document.createElement("p");
+      u.classList.add("usage");
+      u.textContent = entry.usage;
+      details.appendChild(u);
+    }
+  } else {
+    const p = document.createElement("p");
+    p.textContent = "No translation available.";
+    details.appendChild(p);
   }
 }
 
 function clearDefinition() {
   definitionContainer.style.display = "none";
   definitionContainer.innerHTML = "";
-  history.replaceState(null, "", window.location.pathname + window.location.search);
+  history.replaceState(
+    null,
+    "",
+    window.location.pathname + window.location.search,
+  );
   if (canonicalLink) {
     canonicalLink.setAttribute("href", siteUrl);
   }
 }
 
 function showRandomTerm() {
-  const randomTerm = termsData.terms[Math.floor(Math.random() * termsData.terms.length)];
+  const randomTerm =
+    termsData.terms[Math.floor(Math.random() * termsData.terms.length)];
   displayDefinition(randomTerm);
 
   const today = new Date().toDateString();
   try {
-    localStorage.setItem("lastRandomTerm", JSON.stringify({ date: today, term: randomTerm }));
+    localStorage.setItem(
+      "lastRandomTerm",
+      JSON.stringify({ date: today, term: randomTerm }),
+    );
   } catch (e) {
     // Ignore storage errors
   }
@@ -249,8 +344,7 @@ window.addEventListener("scroll", () => {
   scrollBtn.style.display = window.scrollY > 200 ? "block" : "none";
 });
 scrollBtn.addEventListener("click", () =>
-  window.scrollTo({ top: 0, behavior: "smooth" })
+  window.scrollTo({ top: 0, behavior: "smooth" }),
 );
 
 definitionContainer.addEventListener("click", clearDefinition);
-

--- a/styles.css
+++ b/styles.css
@@ -25,7 +25,7 @@ body {
 
 h1 {
   text-align: center;
-  font-family: 'Cinzel', serif;
+  font-family: "Cinzel", serif;
   font-weight: 700;
   font-size: 48px;
   margin-bottom: 20px;
@@ -101,6 +101,27 @@ body.dark-mode mark {
   margin-bottom: 20px;
 }
 
+#translations {
+  margin-top: 10px;
+}
+
+#translations details {
+  margin-bottom: 8px;
+}
+
+#translations summary {
+  cursor: pointer;
+  font-weight: bold;
+}
+
+#translations .gloss {
+  font-style: italic;
+}
+
+#translations .usage {
+  color: #555;
+}
+
 #search {
   width: 100%;
   padding: 10px;
@@ -110,7 +131,6 @@ body.dark-mode mark {
   box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
   min-height: 44px;
 }
-
 
 /* Controls styling */
 #random-term {
@@ -206,7 +226,9 @@ label {
   border-radius: 4px;
   padding: 10px;
   cursor: pointer;
-  transition: background-color 0.2s, color 0.2s;
+  transition:
+    background-color 0.2s,
+    color 0.2s;
   min-width: 44px;
   min-height: 44px;
 }
@@ -290,6 +312,10 @@ body.dark-mode .dictionary-item p {
 body.dark-mode #definition-container {
   background-color: #1e1e1e;
   box-shadow: 0 0 5px rgba(255, 255, 255, 0.1);
+}
+
+body.dark-mode #translations .usage {
+  color: #ccc;
 }
 
 body.dark-mode .favorite-star {

--- a/translations/es.json
+++ b/translations/es.json
@@ -1,0 +1,12 @@
+{
+  "Phishing": {
+    "translation": "Suplantación de identidad",
+    "gloss": "Engaño para obtener información personal",
+    "usage": "Se usa para describir correos electrónicos fraudulentos."
+  },
+  "Cyber Espionage": {
+    "translation": "Ciberespionaje",
+    "gloss": "Uso de técnicas digitales para espionaje",
+    "usage": "Término utilizado en contextos gubernamentales."
+  }
+}

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -1,0 +1,12 @@
+{
+  "Phishing": {
+    "translation": "Hameçonnage",
+    "gloss": "Technique visant à tromper pour obtenir des informations sensibles",
+    "usage": "Utilisé pour décrire des courriels frauduleux."
+  },
+  "Cyber Espionage": {
+    "translation": "Cyber-espionnage",
+    "gloss": "Utilisation de techniques numériques pour l'espionnage",
+    "usage": "Terme utilisé dans des contextes gouvernementaux."
+  }
+}


### PR DESCRIPTION
## Summary
- add per-language translation accordion panels with lazy loading
- style translation accordions and add dark mode support
- include sample Spanish and French translation data with glosses and usage notes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5390f7b1c8328a3e945af54a5b3ca