### PR TITLE
Add swipeable quotes carousel

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,12 @@
     <label for="show-favorites">Show Favorites</label>
 
     <ul id="terms-list"></ul>
+
+    <section id="quote-carousel" aria-label="Inspirational quotes">
+      <div class="carousel-track" id="quote-track"></div>
+      <button id="prev-quote" class="carousel-control" type="button" aria-label="Previous quote">&#10094;</button>
+      <button id="next-quote" class="carousel-control" type="button" aria-label="Next quote">&#10095;</button>
+    </section>
   </main>
   <footer class="container" aria-label="Contribute">
     <p><a href="templates/contribute.html">Contribute</a></p>

--- a/script.js
+++ b/script.js
@@ -25,6 +25,7 @@ if (darkModeToggle) {
 
 window.addEventListener("DOMContentLoaded", () => {
   loadTerms();
+  loadQuotes();
 });
 
 function loadTerms() {
@@ -253,4 +254,85 @@ scrollBtn.addEventListener("click", () =>
 );
 
 definitionContainer.addEventListener("click", clearDefinition);
+
+function loadQuotes() {
+  fetch("/api/quotes")
+    .then((response) => {
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+      return response.json();
+    })
+    .then((quotes) => {
+      if (Array.isArray(quotes)) {
+        initQuoteCarousel(quotes);
+      }
+    })
+    .catch((error) => console.error("Error fetching quotes:", error));
+}
+
+function initQuoteCarousel(quotes) {
+  const track = document.getElementById("quote-track");
+  const carousel = document.getElementById("quote-carousel");
+  const prevBtn = document.getElementById("prev-quote");
+  const nextBtn = document.getElementById("next-quote");
+  if (!track || !carousel || !prevBtn || !nextBtn) {
+    return;
+  }
+  quotes.forEach((q) => {
+    const slide = document.createElement("div");
+    slide.className = "quote-slide";
+    const block = document.createElement("blockquote");
+    block.textContent = q.text;
+    const author = document.createElement("p");
+    author.className = "quote-author";
+    author.textContent = `— ${q.author}`;
+    slide.appendChild(block);
+    slide.appendChild(author);
+    track.appendChild(slide);
+  });
+
+  let index = 0;
+
+  function update() {
+    track.style.transform = `translateX(-${index * 100}%)`;
+  }
+
+  function showPrev() {
+    index = (index - 1 + quotes.length) % quotes.length;
+    update();
+  }
+
+  function showNext() {
+    index = (index + 1) % quotes.length;
+    update();
+  }
+
+  prevBtn.addEventListener("click", showPrev);
+  nextBtn.addEventListener("click", showNext);
+
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "ArrowLeft") {
+      showPrev();
+    } else if (e.key === "ArrowRight") {
+      showNext();
+    }
+  });
+
+  let startX = 0;
+  carousel.addEventListener("touchstart", (e) => {
+    startX = e.touches[0].clientX;
+  });
+
+  carousel.addEventListener("touchend", (e) => {
+    const endX = e.changedTouches[0].clientX;
+    if (endX - startX > 50) {
+      showPrev();
+    } else if (startX - endX > 50) {
+      showNext();
+    }
+  });
+
+  update();
+}
 

--- a/styles.css
+++ b/styles.css
@@ -347,3 +347,50 @@ body.dark-mode #alpha-nav button.active {
     font-size: 14px;
   }
 }
+
+/* Quote carousel styles */
+#quote-carousel {
+  position: relative;
+  overflow: hidden;
+  margin-top: 20px;
+}
+
+#quote-track {
+  display: flex;
+  transition: transform 0.3s ease-in-out;
+}
+
+.quote-slide {
+  min-width: 100%;
+  box-sizing: border-box;
+  padding: 20px;
+  text-align: center;
+}
+
+.quote-slide blockquote {
+  font-style: italic;
+  margin: 0 0 10px;
+}
+
+.quote-author {
+  font-weight: bold;
+}
+
+.carousel-control {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  background-color: rgba(0, 0, 0, 0.5);
+  color: #fff;
+  border: none;
+  padding: 10px;
+  cursor: pointer;
+}
+
+#prev-quote {
+  left: 10px;
+}
+
+#next-quote {
+  right: 10px;
+}


### PR DESCRIPTION
## Summary
- Add quote carousel markup and styling
- Fetch curated quotes from `/api/quotes`
- Enable swipe and keyboard navigation with author attributions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5391135ac8328b03e81827310e3ba