### PR TITLE
feat: add register filter for definitions

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,12 @@
     <button id="random-term" type="button" aria-label="Show random term">Random Term</button>
 
     <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+    <label for="register-filter">Register:</label>
+    <select id="register-filter" aria-label="Filter by register">
+      <option value="all">All</option>
+      <option value="general">General</option>
+      <option value="technical">Technical</option>
+    </select>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 

--- a/terms.json
+++ b/terms.json
@@ -2,11 +2,21 @@
   "terms": [
     {
       "term": "Phishing",
-      "definition": "An attempt to trick individuals into revealing sensitive information through fraudulent emails, websites, or messages."
+      "senses": [
+        {
+          "definition": "An attempt to trick individuals into revealing sensitive information through fraudulent emails, websites, or messages.",
+          "register": "general"
+        },
+        {
+          "definition": "A social engineering technique where attackers craft seemingly legitimate communications to steal credentials or financial data.",
+          "register": "technical"
+        }
+      ]
     },
     {
       "term": "Phishing Email",
-      "definition": "An email sent by attackers that appears legitimate but aims to trick recipients into revealing sensitive information or performing actions."
+      "definition": "An email sent by attackers that appears legitimate but aims to trick recipients into revealing sensitive information or performing actions.",
+      "register": "technical"
     },
     {
       "term": "Social Engineering Toolkit (SET)",


### PR DESCRIPTION
## Summary
- add dropdown to filter definitions by register (all/general/technical)
- manage register-aware state and hide non-matching senses
- include example register metadata in terms

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b53913068c8328879db2d66e06d030