### PR TITLE
Add word forms table with copy buttons

### DIFF
--- a/data/terms.yaml
+++ b/data/terms.yaml
@@ -73,3 +73,15 @@
     - CWE
   sources:
     - https://owasp.org/www-project-top-ten/
+- name: Attack
+  slug: attack
+  definition: >-
+    An attempt to exploit a system's vulnerability.
+  category: General
+  tenses:
+    "Present": attack
+    "Past": attacked
+    "Present Participle": attacking
+    "Past Participle": attacked
+  plurals:
+    "Plural": attacks

--- a/script.js
+++ b/script.js
@@ -5,7 +5,9 @@ const randomButton = document.getElementById("random-term");
 const alphaNav = document.getElementById("alpha-nav");
 const darkModeToggle = document.getElementById("dark-mode-toggle");
 const showFavoritesToggle = document.getElementById("show-favorites");
-const favorites = new Set(JSON.parse(localStorage.getItem("favorites") || "[]"));
+const favorites = new Set(
+  JSON.parse(localStorage.getItem("favorites") || "[]"),
+);
 const siteUrl = "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/";
 const canonicalLink = document.getElementById("canonical-link");
 
@@ -19,7 +21,10 @@ if (localStorage.getItem("darkMode") === "true") {
 if (darkModeToggle) {
   darkModeToggle.addEventListener("click", () => {
     document.body.classList.toggle("dark-mode");
-    localStorage.setItem("darkMode", document.body.classList.contains("dark-mode"));
+    localStorage.setItem(
+      "darkMode",
+      document.body.classList.contains("dark-mode"),
+    );
   });
 }
 
@@ -43,9 +48,11 @@ function loadTerms() {
       populateTermsList();
 
       if (window.location.hash) {
-        const termFromHash = decodeURIComponent(window.location.hash.substring(1));
+        const termFromHash = decodeURIComponent(
+          window.location.hash.substring(1),
+        );
         const matchedTerm = termsData.terms.find(
-          (t) => t.term.toLowerCase() === termFromHash.toLowerCase()
+          (t) => t.term.toLowerCase() === termFromHash.toLowerCase(),
         );
         if (matchedTerm) {
           displayDefinition(matchedTerm);
@@ -56,7 +63,7 @@ function loadTerms() {
       console.error("Detailed error fetching data:", error);
       definitionContainer.style.display = "block";
       definitionContainer.innerHTML =
-        '<p>Unable to load dictionary data. Please check your connection and try again.</p>' +
+        "<p>Unable to load dictionary data. Please check your connection and try again.</p>" +
         '<button id="retry-fetch">Retry</button>';
       const retryBtn = document.getElementById("retry-fetch");
       if (retryBtn) {
@@ -97,12 +104,16 @@ function toggleFavorite(term) {
 }
 
 function highlightActiveButton(button) {
-  alphaNav.querySelectorAll("button").forEach((btn) => btn.classList.remove("active"));
+  alphaNav
+    .querySelectorAll("button")
+    .forEach((btn) => btn.classList.remove("active"));
   button.classList.add("active");
 }
 
 function buildAlphaNav() {
-  const letters = Array.from(new Set(termsData.terms.map((t) => t.term.charAt(0).toUpperCase()))).sort();
+  const letters = Array.from(
+    new Set(termsData.terms.map((t) => t.term.charAt(0).toUpperCase())),
+  ).sort();
 
   const allButton = document.createElement("button");
   allButton.textContent = "All";
@@ -134,9 +145,13 @@ function populateTermsList() {
     .sort((a, b) => a.term.localeCompare(b.term))
     .forEach((item) => {
       const matchesSearch = item.term.toLowerCase().includes(searchValue);
-      const matchesFavorites = !showFavoritesToggle || !showFavoritesToggle.checked || favorites.has(item.term);
+      const matchesFavorites =
+        !showFavoritesToggle ||
+        !showFavoritesToggle.checked ||
+        favorites.has(item.term);
       const matchesLetter =
-        currentLetterFilter === "All" || item.term.charAt(0).toUpperCase() === currentLetterFilter;
+        currentLetterFilter === "All" ||
+        item.term.charAt(0).toUpperCase() === currentLetterFilter;
       if (matchesSearch && matchesFavorites && matchesLetter) {
         const termDiv = document.createElement("div");
         termDiv.classList.add("dictionary-item");
@@ -180,14 +195,75 @@ function populateTermsList() {
     });
 }
 
+function createFormsTable(forms, title) {
+  const table = document.createElement("table");
+  table.classList.add("forms-table");
+
+  const thead = document.createElement("thead");
+  const headerRow1 = document.createElement("tr");
+  const headerCell = document.createElement("th");
+  headerCell.setAttribute("colspan", Object.keys(forms).length);
+  headerCell.textContent = title;
+  headerRow1.appendChild(headerCell);
+  thead.appendChild(headerRow1);
+
+  const headerRow2 = document.createElement("tr");
+  Object.keys(forms).forEach((label) => {
+    const th = document.createElement("th");
+    th.textContent = label;
+    headerRow2.appendChild(th);
+  });
+  thead.appendChild(headerRow2);
+
+  const tbody = document.createElement("tbody");
+  const bodyRow = document.createElement("tr");
+  Object.values(forms).forEach((value) => {
+    const td = document.createElement("td");
+    const span = document.createElement("span");
+    span.textContent = value;
+    td.appendChild(span);
+    const btn = document.createElement("button");
+    btn.classList.add("copy-btn");
+    btn.textContent = "Copy";
+    btn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      navigator.clipboard.writeText(value);
+      btn.textContent = "Copied";
+      setTimeout(() => (btn.textContent = "Copy"), 1000);
+    });
+    td.appendChild(btn);
+    bodyRow.appendChild(td);
+  });
+  tbody.appendChild(bodyRow);
+  table.appendChild(thead);
+  table.appendChild(tbody);
+
+  return table;
+}
+
 function displayDefinition(term) {
   definitionContainer.style.display = "block";
   definitionContainer.innerHTML = `<h3>${term.term}</h3><p>${term.definition}</p>`;
+  if (term.tenses || term.plurals || term.comparatives) {
+    const formsWrapper = document.createElement("div");
+    if (term.tenses) {
+      formsWrapper.appendChild(createFormsTable(term.tenses, "Tenses"));
+    }
+    if (term.plurals) {
+      formsWrapper.appendChild(createFormsTable(term.plurals, "Plurals"));
+    }
+    if (term.comparatives) {
+      formsWrapper.appendChild(
+        createFormsTable(term.comparatives, "Comparatives"),
+      );
+    }
+    definitionContainer.appendChild(formsWrapper);
+  }
   window.location.hash = encodeURIComponent(term.term);
   if (canonicalLink) {
     canonicalLink.setAttribute(
       "href",
-      `${siteUrl}#${encodeURIComponent(term.term)}`
+      `${siteUrl}#${encodeURIComponent(term.term)}`,
     );
   }
 }
@@ -195,19 +271,27 @@ function displayDefinition(term) {
 function clearDefinition() {
   definitionContainer.style.display = "none";
   definitionContainer.innerHTML = "";
-  history.replaceState(null, "", window.location.pathname + window.location.search);
+  history.replaceState(
+    null,
+    "",
+    window.location.pathname + window.location.search,
+  );
   if (canonicalLink) {
     canonicalLink.setAttribute("href", siteUrl);
   }
 }
 
 function showRandomTerm() {
-  const randomTerm = termsData.terms[Math.floor(Math.random() * termsData.terms.length)];
+  const randomTerm =
+    termsData.terms[Math.floor(Math.random() * termsData.terms.length)];
   displayDefinition(randomTerm);
 
   const today = new Date().toDateString();
   try {
-    localStorage.setItem("lastRandomTerm", JSON.stringify({ date: today, term: randomTerm }));
+    localStorage.setItem(
+      "lastRandomTerm",
+      JSON.stringify({ date: today, term: randomTerm }),
+    );
   } catch (e) {
     // Ignore storage errors
   }
@@ -249,8 +333,7 @@ window.addEventListener("scroll", () => {
   scrollBtn.style.display = window.scrollY > 200 ? "block" : "none";
 });
 scrollBtn.addEventListener("click", () =>
-  window.scrollTo({ top: 0, behavior: "smooth" })
+  window.scrollTo({ top: 0, behavior: "smooth" }),
 );
 
 definitionContainer.addEventListener("click", clearDefinition);
-

--- a/styles.css
+++ b/styles.css
@@ -25,7 +25,7 @@ body {
 
 h1 {
   text-align: center;
-  font-family: 'Cinzel', serif;
+  font-family: "Cinzel", serif;
   font-weight: 700;
   font-size: 48px;
   margin-bottom: 20px;
@@ -101,6 +101,30 @@ body.dark-mode mark {
   margin-bottom: 20px;
 }
 
+#definition-container .forms-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 10px;
+}
+
+#definition-container .forms-table th,
+#definition-container .forms-table td {
+  border: 1px solid #ccc;
+  padding: 8px;
+  text-align: center;
+}
+
+#definition-container .forms-table th {
+  background-color: #e9e9e9;
+}
+
+.copy-btn {
+  margin-left: 6px;
+  padding: 2px 6px;
+  font-size: 12px;
+  cursor: pointer;
+}
+
 #search {
   width: 100%;
   padding: 10px;
@@ -110,7 +134,6 @@ body.dark-mode mark {
   box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
   min-height: 44px;
 }
-
 
 /* Controls styling */
 #random-term {
@@ -206,7 +229,9 @@ label {
   border-radius: 4px;
   padding: 10px;
   cursor: pointer;
-  transition: background-color 0.2s, color 0.2s;
+  transition:
+    background-color 0.2s,
+    color 0.2s;
   min-width: 44px;
   min-height: 44px;
 }

--- a/terms.json
+++ b/terms.json
@@ -131,6 +131,19 @@
     {
       "term": "Phishing Email",
       "definition": "An email sent by attackers that appears legitimate but aims to trick recipients into revealing sensitive information or performing actions."
+    },
+    {
+      "term": "Attack",
+      "definition": "An attempt to exploit a system's vulnerability.",
+      "tenses": {
+        "Present": "attack",
+        "Past": "attacked",
+        "Present Participle": "attacking",
+        "Past Participle": "attacked"
+      },
+      "plurals": {
+        "Plural": "attacks"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary
- build a dynamic table component for tenses, plurals, and comparatives with per-cell copy buttons
- style the word forms table and copy controls
- add sample term data including tenses and plurals

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5390c63908328b6c7d8313224dbab