### PR TITLE
feat: add word of day component

### DIFF
--- a/components/WordOfDay.tsx
+++ b/components/WordOfDay.tsx
@@ -1,0 +1,63 @@
+import React, { useEffect, useState } from "react";
+
+interface Entry {
+  id: string;
+  word: string;
+  definition: string;
+}
+
+/**
+ * WordOfDay displays a daily dictionary entry and provides
+ * navigation to previous/next days along with an option to
+ * save entries for later reference.
+ */
+const WordOfDay: React.FC = () => {
+  const [entry, setEntry] = useState<Entry | null>(null);
+  const [offset, setOffset] = useState(0);
+
+  const fetchEntry = async (dayOffset: number) => {
+    try {
+      const res = await fetch(`/api/word-of-day?offset=${dayOffset}`);
+      if (!res.ok) throw new Error("Failed to fetch word of day");
+      const data = await res.json();
+      setEntry(data);
+    } catch (err) {
+      console.error(err);
+      setEntry(null);
+    }
+  };
+
+  useEffect(() => {
+    fetchEntry(offset);
+  }, [offset]);
+
+  const handlePrev = () => setOffset((o) => o - 1);
+  const handleNext = () => setOffset((o) => o + 1);
+
+  const handleSave = () => {
+    if (!entry) return;
+    const saved: Entry[] = JSON.parse(
+      localStorage.getItem("savedWords") || "[]",
+    );
+    if (!saved.find((e) => e.id === entry.id)) {
+      saved.push(entry);
+      localStorage.setItem("savedWords", JSON.stringify(saved));
+    }
+  };
+
+  if (!entry) return <p>Loading...</p>;
+
+  return (
+    <div className="word-of-day">
+      <h2>{entry.word}</h2>
+      <p>{entry.definition}</p>
+      <div className="word-of-day__actions">
+        <button onClick={handlePrev}>Previous</button>
+        <button onClick={handleNext}>Next</button>
+        <button onClick={handleSave}>Save to list</button>
+      </div>
+    </div>
+  );
+};
+
+export default WordOfDay;


### PR DESCRIPTION
## Summary
- add WordOfDay component to display daily entry
- include navigation for previous/next days and save-to-list support

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5391566188328bb311dd5bd487b52