### PR TITLE
Add deck support on headword pages

### DIFF
--- a/script.js
+++ b/script.js
@@ -182,13 +182,61 @@ function populateTermsList() {
 
 function displayDefinition(term) {
   definitionContainer.style.display = "block";
-  definitionContainer.innerHTML = `<h3>${term.term}</h3><p>${term.definition}</p>`;
+  definitionContainer.innerHTML = `<h3>${term.term}</h3><p>${term.definition}</p><button id="add-to-deck" type="button">Add to deck</button>`;
+  const addBtn = document.getElementById("add-to-deck");
+  if (addBtn) {
+    addBtn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      showDeckPreview(term);
+    });
+  }
   window.location.hash = encodeURIComponent(term.term);
   if (canonicalLink) {
     canonicalLink.setAttribute(
       "href",
       `${siteUrl}#${encodeURIComponent(term.term)}`
     );
+  }
+}
+
+function showDeckPreview(term) {
+  const overlay = document.createElement("div");
+  overlay.id = "deck-preview";
+  overlay.innerHTML = `<div class="deck-preview-content"><h4>Front</h4><p>${term.term}</p><h4>Back</h4><p>${term.definition}</p><button id="save-card" type="button">Save</button><button id="cancel-card" type="button">Cancel</button></div>`;
+  document.body.appendChild(overlay);
+
+  const content = overlay.querySelector(".deck-preview-content");
+  if (content) {
+    content.addEventListener("click", (e) => e.stopPropagation());
+  }
+
+  overlay.addEventListener("click", () => overlay.remove());
+  const cancelBtn = document.getElementById("cancel-card");
+  if (cancelBtn) {
+    cancelBtn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      overlay.remove();
+    });
+  }
+
+  const saveBtn = document.getElementById("save-card");
+  if (saveBtn) {
+    saveBtn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      fetch("/api/decks", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ front: term.term, back: term.definition }),
+      })
+        .then(() => {
+          overlay.remove();
+          alert("Saved to deck");
+        })
+        .catch(() => {
+          overlay.remove();
+          alert("Failed to save card");
+        });
+    });
   }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -101,6 +101,20 @@ body.dark-mode mark {
   margin-bottom: 20px;
 }
 
+#definition-container button {
+  margin-top: 10px;
+  padding: 10px;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  background-color: #007bff;
+  color: #fff;
+  cursor: pointer;
+}
+
+#definition-container button:hover {
+  background-color: #0056b3;
+}
+
 #search {
   width: 100%;
   padding: 10px;
@@ -242,6 +256,34 @@ label {
   background-color: #0056b3;
 }
 
+#deck-preview {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+#deck-preview .deck-preview-content {
+  background: #fff;
+  padding: 20px;
+  border-radius: 5px;
+  max-width: 90%;
+}
+
+#deck-preview h4 {
+  margin: 0 0 10px;
+}
+
+#deck-preview button {
+  margin-right: 10px;
+}
+
 /* Dark Mode styles */
 body.dark-mode {
   background-color: #121212;
@@ -292,6 +334,16 @@ body.dark-mode #definition-container {
   box-shadow: 0 0 5px rgba(255, 255, 255, 0.1);
 }
 
+body.dark-mode #definition-container button {
+  background-color: #333;
+  color: #fff;
+  border-color: #555;
+}
+
+body.dark-mode #definition-container button:hover {
+  background-color: #555;
+}
+
 body.dark-mode .favorite-star {
   color: #888;
 }
@@ -324,6 +376,11 @@ body.dark-mode #alpha-nav button:focus {
 body.dark-mode #alpha-nav button.active {
   background-color: #007bff;
   border-color: #007bff;
+}
+
+body.dark-mode #deck-preview .deck-preview-content {
+  background: #1e1e1e;
+  color: #fff;
 }
 
 @media (max-width: 480px) {


### PR DESCRIPTION
## Summary
- Add "Add to deck" button to headword definitions
- Preview flashcard front/back and save to `/api/decks`
- Style deck preview and button with dark-mode support

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b53915d48883288356c1ff2c22e1e7