### PR TITLE
Add study page with spaced repetition controls

### DIFF
--- a/assets/js/study.js
+++ b/assets/js/study.js
@@ -1,0 +1,71 @@
+const cardEl = document.getElementById('card');
+const termEl = document.getElementById('term');
+const defEl = document.getElementById('definition');
+const againBtn = document.getElementById('again');
+const hardBtn = document.getElementById('hard');
+const goodBtn = document.getElementById('good');
+const easyBtn = document.getElementById('easy');
+
+let terms = [];
+let index = 0;
+
+function shuffle(arr) {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}
+
+function loadTerms() {
+  fetch('terms.json')
+    .then((res) => res.json())
+    .then((data) => {
+      terms = shuffle(data.terms);
+      showCard();
+    })
+    .catch(() => {
+      termEl.textContent = 'Failed to load cards.';
+    });
+}
+
+function showCard() {
+  if (!terms.length) {
+    termEl.textContent = 'No cards available';
+    defEl.textContent = '';
+    return;
+  }
+  const card = terms[index % terms.length];
+  termEl.textContent = card.term;
+  defEl.textContent = card.definition;
+  defEl.style.display = 'none';
+}
+
+cardEl.addEventListener('click', () => {
+  defEl.style.display = defEl.style.display === 'none' ? 'block' : 'none';
+});
+
+function sendRating(rating) {
+  const card = terms[index % terms.length];
+  const apiBase = window.__API_BASE__ || '';
+  fetch(`${apiBase}/api/schedule`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ term: card.term, rating }),
+  }).catch(() => {
+    // Ignore network errors
+  });
+}
+
+function handleRating(rating) {
+  sendRating(rating);
+  index += 1;
+  showCard();
+}
+
+againBtn.addEventListener('click', () => handleRating('again'));
+hardBtn.addEventListener('click', () => handleRating('hard'));
+goodBtn.addEventListener('click', () => handleRating('good'));
+easyBtn.addEventListener('click', () => handleRating('easy'));
+
+loadTerms();

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "script.js",
   "scripts": {
     "build": "node scripts/build.js",
-    "test": "html-validate index.html search.html diagnostics.html && node diagnostics.test.js",
+    "test": "html-validate index.html search.html diagnostics.html study.html && node diagnostics.test.js",
     "watch": "chokidar \"**/*.html\" -c \"npm run build\""
   },
   "keywords": [],

--- a/study.html
+++ b/study.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Study</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <main class="container">
+    <h1>Study</h1>
+    <div id="card" class="study-card" aria-live="polite">
+      <h2 id="term">Loading...</h2>
+      <p id="definition" class="definition">Definition</p>
+    </div>
+    <div class="study-buttons">
+      <button id="again" type="button">Again</button>
+      <button id="hard" type="button">Hard</button>
+      <button id="good" type="button">Good</button>
+      <button id="easy" type="button">Easy</button>
+    </div>
+  </main>
+  <script>
+    window.__API_BASE__ = window.__API_BASE__ || '';
+  </script>
+  <script src="assets/js/study.js"></script>
+  <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
+  <script src="assets/js/metrics.js"></script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -347,3 +347,53 @@ body.dark-mode #alpha-nav button.active {
     font-size: 14px;
   }
 }
+/* Study page styles */
+.study-card {
+  background-color: #fff;
+  padding: 20px;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  min-height: 150px;
+  margin-bottom: 20px;
+  cursor: pointer;
+}
+
+.study-card .definition {
+  display: none;
+  margin-top: 10px;
+}
+
+.study-buttons {
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+}
+
+.study-buttons button {
+  padding: 10px;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  background-color: #007bff;
+  color: #fff;
+  cursor: pointer;
+  min-width: 44px;
+  min-height: 44px;
+}
+
+.study-buttons button:hover {
+  background-color: #0056b3;
+}
+
+body.dark-mode .study-card {
+  background-color: #1e1e1e;
+  border-color: #333;
+}
+
+body.dark-mode .study-buttons button {
+  background-color: #333;
+  border-color: #555;
+}
+
+body.dark-mode .study-buttons button:hover {
+  background-color: #555;
+}


### PR DESCRIPTION
## Summary
- add `/study` page with flashcard viewer and again/hard/good/easy buttons
- wire rating buttons to scheduling API endpoint
- style study UI and include new page in HTML validation tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b539170c8083288f06522ab3f9461a