### PR TITLE
Add daily activity tracking with profile streak and badges

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,41 +1,49 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Cyber Security Dictionary</title>
-  <link rel="stylesheet" href="styles.css">
-  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet">
-  <link rel="canonical" id="canonical-link" href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/">
-</head>
-<body>
-  <main class="container">
-    <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav" aria-label="Site links"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
-    <div id="definition-container" style="display: none;"></div>
-    <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
-    <input type="text" id="search" placeholder="Search...">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cyber Security Dictionary</title>
+    <link rel="stylesheet" href="styles.css">
+    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet">
+    <link rel="canonical" id="canonical-link" href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/">
+  </head>
+  <body>
+    <main class="container">
+      <h1>Cyber Security Dictionary</h1>
+      <nav class="site-nav" aria-label="Site links">
+        <a href="templates/guidelines.html">Definition Guidelines</a> |
+        <a href="profile.html">Profile</a>
+      </nav>
+      <div id="definition-container" style="display: none"></div>
+      <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
+      <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" type="button" aria-label="Show random term">Random Term</button>
+      <button id="random-term" type="button" aria-label="Show random term">
+        Random Term
+      </button>
 
-    <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">Toggle Dark Mode</button>
-    <input type="checkbox" id="show-favorites" aria-label="Show favorites">
-    <label for="show-favorites">Show Favorites</label>
+      <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">
+        Toggle Dark Mode
+      </button>
+      <input type="checkbox" id="show-favorites" aria-label="Show favorites">
+      <label for="show-favorites">Show Favorites</label>
 
-    <ul id="terms-list"></ul>
-  </main>
-  <footer class="container" aria-label="Contribute">
-    <p><a href="templates/contribute.html">Contribute</a></p>
-  </footer>
-  <button id="scrollToTopBtn" type="button" aria-label="Scroll to top">↑</button>
+      <ul id="terms-list"></ul>
+    </main>
+    <footer class="container" aria-label="Contribute">
+      <p><a href="templates/contribute.html">Contribute</a></p>
+    </footer>
+    <button id="scrollToTopBtn" type="button" aria-label="Scroll to top">
+      ↑
+    </button>
 
-  <footer aria-label="Project contribution">
-    <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
-  </footer>
-  <script src="script.js"></script>
-  <script src="assets/js/app.js"></script>
-  <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
-  <script src="assets/js/metrics.js"></script>
-</body>
+    <footer aria-label="Project contribution">
+      <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
+    </footer>
+    <script src="script.js"></script>
+    <script src="assets/js/app.js"></script>
+    <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
+    <script src="assets/js/metrics.js"></script>
+  </body>
 </html>
-

--- a/profile.html
+++ b/profile.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>User Profile</title>
+    <link rel="stylesheet" href="styles.css">
+  </head>
+  <body>
+    <main class="container">
+      <h1>User Profile</h1>
+      <p>Current streak: <span id="streak-count">0</span> days</p>
+      <h2>Badges</h2>
+      <ul id="badges"></ul>
+    </main>
+    <footer class="container">
+      <a href="index.html">Back to Dictionary</a>
+    </footer>
+    <script src="profile.js"></script>
+  </body>
+</html>

--- a/profile.js
+++ b/profile.js
@@ -1,0 +1,22 @@
+function renderProfile() {
+  let activity;
+  try {
+    activity = JSON.parse(localStorage.getItem("activity")) || {};
+  } catch (e) {
+    activity = {};
+  }
+
+  document.getElementById("streak-count").textContent = activity.streak || 0;
+  const badgesEl = document.getElementById("badges");
+  if (activity.badges && activity.badges.length) {
+    activity.badges.forEach((b) => {
+      const li = document.createElement("li");
+      li.textContent = b;
+      badgesEl.appendChild(li);
+    });
+  } else {
+    badgesEl.textContent = "No badges earned yet.";
+  }
+}
+
+window.addEventListener("DOMContentLoaded", renderProfile);

--- a/script.js
+++ b/script.js
@@ -5,7 +5,9 @@ const randomButton = document.getElementById("random-term");
 const alphaNav = document.getElementById("alpha-nav");
 const darkModeToggle = document.getElementById("dark-mode-toggle");
 const showFavoritesToggle = document.getElementById("show-favorites");
-const favorites = new Set(JSON.parse(localStorage.getItem("favorites") || "[]"));
+const favorites = new Set(
+  JSON.parse(localStorage.getItem("favorites") || "[]"),
+);
 const siteUrl = "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/";
 const canonicalLink = document.getElementById("canonical-link");
 
@@ -19,11 +21,15 @@ if (localStorage.getItem("darkMode") === "true") {
 if (darkModeToggle) {
   darkModeToggle.addEventListener("click", () => {
     document.body.classList.toggle("dark-mode");
-    localStorage.setItem("darkMode", document.body.classList.contains("dark-mode"));
+    localStorage.setItem(
+      "darkMode",
+      document.body.classList.contains("dark-mode"),
+    );
   });
 }
 
 window.addEventListener("DOMContentLoaded", () => {
+  updateDailyActivity();
   loadTerms();
 });
 
@@ -43,9 +49,11 @@ function loadTerms() {
       populateTermsList();
 
       if (window.location.hash) {
-        const termFromHash = decodeURIComponent(window.location.hash.substring(1));
+        const termFromHash = decodeURIComponent(
+          window.location.hash.substring(1),
+        );
         const matchedTerm = termsData.terms.find(
-          (t) => t.term.toLowerCase() === termFromHash.toLowerCase()
+          (t) => t.term.toLowerCase() === termFromHash.toLowerCase(),
         );
         if (matchedTerm) {
           displayDefinition(matchedTerm);
@@ -56,7 +64,7 @@ function loadTerms() {
       console.error("Detailed error fetching data:", error);
       definitionContainer.style.display = "block";
       definitionContainer.innerHTML =
-        '<p>Unable to load dictionary data. Please check your connection and try again.</p>' +
+        "<p>Unable to load dictionary data. Please check your connection and try again.</p>" +
         '<button id="retry-fetch">Retry</button>';
       const retryBtn = document.getElementById("retry-fetch");
       if (retryBtn) {
@@ -83,6 +91,47 @@ function removeDuplicateTermsAndDefinitions() {
   termsData.terms = uniqueTermsData;
 }
 
+function updateDailyActivity() {
+  const today = new Date().toDateString();
+  let activity;
+  try {
+    activity = JSON.parse(localStorage.getItem("activity")) || {};
+  } catch (e) {
+    activity = {};
+  }
+
+  const yesterday = new Date();
+  yesterday.setDate(yesterday.getDate() - 1);
+  const yesterdayStr = yesterday.toDateString();
+
+  let streak = 1;
+  if (activity.lastDate === today) {
+    streak = activity.streak || 1;
+  } else if (activity.lastDate === yesterdayStr) {
+    streak = (activity.streak || 1) + 1;
+  }
+
+  const badges = activity.badges || [];
+  const thresholds = [
+    { days: 3, name: "3-day Streak" },
+    { days: 7, name: "7-day Streak" },
+    { days: 30, name: "30-day Streak" },
+  ];
+  thresholds.forEach((b) => {
+    if (streak >= b.days && !badges.includes(b.name)) {
+      badges.push(b.name);
+    }
+  });
+
+  const updated = { lastDate: today, streak, badges };
+  try {
+    localStorage.setItem("activity", JSON.stringify(updated));
+  } catch (e) {
+    // Ignore storage errors
+  }
+  return updated;
+}
+
 function toggleFavorite(term) {
   if (favorites.has(term)) {
     favorites.delete(term);
@@ -97,12 +146,16 @@ function toggleFavorite(term) {
 }
 
 function highlightActiveButton(button) {
-  alphaNav.querySelectorAll("button").forEach((btn) => btn.classList.remove("active"));
+  alphaNav
+    .querySelectorAll("button")
+    .forEach((btn) => btn.classList.remove("active"));
   button.classList.add("active");
 }
 
 function buildAlphaNav() {
-  const letters = Array.from(new Set(termsData.terms.map((t) => t.term.charAt(0).toUpperCase()))).sort();
+  const letters = Array.from(
+    new Set(termsData.terms.map((t) => t.term.charAt(0).toUpperCase())),
+  ).sort();
 
   const allButton = document.createElement("button");
   allButton.textContent = "All";
@@ -134,9 +187,13 @@ function populateTermsList() {
     .sort((a, b) => a.term.localeCompare(b.term))
     .forEach((item) => {
       const matchesSearch = item.term.toLowerCase().includes(searchValue);
-      const matchesFavorites = !showFavoritesToggle || !showFavoritesToggle.checked || favorites.has(item.term);
+      const matchesFavorites =
+        !showFavoritesToggle ||
+        !showFavoritesToggle.checked ||
+        favorites.has(item.term);
       const matchesLetter =
-        currentLetterFilter === "All" || item.term.charAt(0).toUpperCase() === currentLetterFilter;
+        currentLetterFilter === "All" ||
+        item.term.charAt(0).toUpperCase() === currentLetterFilter;
       if (matchesSearch && matchesFavorites && matchesLetter) {
         const termDiv = document.createElement("div");
         termDiv.classList.add("dictionary-item");
@@ -187,7 +244,7 @@ function displayDefinition(term) {
   if (canonicalLink) {
     canonicalLink.setAttribute(
       "href",
-      `${siteUrl}#${encodeURIComponent(term.term)}`
+      `${siteUrl}#${encodeURIComponent(term.term)}`,
     );
   }
 }
@@ -195,19 +252,27 @@ function displayDefinition(term) {
 function clearDefinition() {
   definitionContainer.style.display = "none";
   definitionContainer.innerHTML = "";
-  history.replaceState(null, "", window.location.pathname + window.location.search);
+  history.replaceState(
+    null,
+    "",
+    window.location.pathname + window.location.search,
+  );
   if (canonicalLink) {
     canonicalLink.setAttribute("href", siteUrl);
   }
 }
 
 function showRandomTerm() {
-  const randomTerm = termsData.terms[Math.floor(Math.random() * termsData.terms.length)];
+  const randomTerm =
+    termsData.terms[Math.floor(Math.random() * termsData.terms.length)];
   displayDefinition(randomTerm);
 
   const today = new Date().toDateString();
   try {
-    localStorage.setItem("lastRandomTerm", JSON.stringify({ date: today, term: randomTerm }));
+    localStorage.setItem(
+      "lastRandomTerm",
+      JSON.stringify({ date: today, term: randomTerm }),
+    );
   } catch (e) {
     // Ignore storage errors
   }
@@ -249,8 +314,7 @@ window.addEventListener("scroll", () => {
   scrollBtn.style.display = window.scrollY > 200 ? "block" : "none";
 });
 scrollBtn.addEventListener("click", () =>
-  window.scrollTo({ top: 0, behavior: "smooth" })
+  window.scrollTo({ top: 0, behavior: "smooth" }),
 );
 
 definitionContainer.addEventListener("click", clearDefinition);
-


### PR DESCRIPTION
## Summary
- track user visits and award streak badges via localStorage
- add profile page displaying current streak and earned badges
- link profile into main navigation

## Testing
- `npm test`
- `npx html-validate profile.html`

------
https://chatgpt.com/codex/tasks/task_e_68b5391a4cb08328942d475d163f1692