### PR TITLE
Add pronunciation practice with near-sounding pairs

### DIFF
--- a/assets/js/pairs.js
+++ b/assets/js/pairs.js
@@ -1,0 +1,63 @@
+window.addEventListener("DOMContentLoaded", () => {
+  fetch("pairs.json")
+    .then((response) => response.json())
+    .then((data) => {
+      const container = document.getElementById("pairs-container");
+      data.pairs.forEach((pair) => {
+        const pairDiv = document.createElement("div");
+        pairDiv.className = "pair";
+
+        const toggleBtn = document.createElement("button");
+        toggleBtn.textContent = "Hide Pair";
+
+        const wordsDiv = document.createElement("div");
+        wordsDiv.className = "words";
+
+        [
+          { word: pair.word1, ipa: pair.ipa1 },
+          { word: pair.word2, ipa: pair.ipa2 },
+        ].forEach((w) => {
+          const wordDiv = document.createElement("div");
+          wordDiv.className = "word";
+
+          const termSpan = document.createElement("span");
+          termSpan.className = "term";
+          termSpan.textContent = w.word;
+
+          const ipaSpan = document.createElement("span");
+          ipaSpan.className = "ipa";
+          ipaSpan.textContent = ` ${w.ipa}`;
+
+          const playBtn = document.createElement("button");
+          playBtn.textContent = "🔊";
+          playBtn.setAttribute(
+            "aria-label",
+            `Play pronunciation for ${w.word}`,
+          );
+          playBtn.addEventListener("click", () => {
+            const utterance = new SpeechSynthesisUtterance(w.word);
+            speechSynthesis.speak(utterance);
+          });
+
+          wordDiv.appendChild(termSpan);
+          wordDiv.appendChild(ipaSpan);
+          wordDiv.appendChild(playBtn);
+          wordsDiv.appendChild(wordDiv);
+        });
+
+        toggleBtn.addEventListener("click", () => {
+          wordsDiv.classList.toggle("hidden");
+          toggleBtn.textContent = wordsDiv.classList.contains("hidden")
+            ? "Show Pair"
+            : "Hide Pair";
+        });
+
+        pairDiv.appendChild(toggleBtn);
+        pairDiv.appendChild(wordsDiv);
+        container.appendChild(pairDiv);
+      });
+    })
+    .catch((err) => {
+      console.error("Error loading pairs:", err);
+    });
+});

--- a/index.html
+++ b/index.html
@@ -1,41 +1,56 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Cyber Security Dictionary</title>
-  <link rel="stylesheet" href="styles.css">
-  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet">
-  <link rel="canonical" id="canonical-link" href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/">
-</head>
-<body>
-  <main class="container">
-    <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav" aria-label="Site links"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
-    <div id="definition-container" style="display: none;"></div>
-    <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
-    <input type="text" id="search" placeholder="Search...">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cyber Security Dictionary</title>
+    <link rel="stylesheet" href="styles.css">
+    <link
+      href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap"
+      rel="stylesheet"
+    >
+    <link
+      rel="canonical"
+      id="canonical-link"
+      href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/"
+    >
+  </head>
+  <body>
+    <main class="container">
+      <h1>Cyber Security Dictionary</h1>
+      <nav class="site-nav" aria-label="Site links">
+        <a href="templates/guidelines.html">Definition Guidelines</a>
+        <a href="pairs.html">Pronunciation Practice</a>
+      </nav>
+      <div id="definition-container" style="display: none"></div>
+      <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
+      <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" type="button" aria-label="Show random term">Random Term</button>
+      <button id="random-term" type="button" aria-label="Show random term">
+        Random Term
+      </button>
 
-    <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">Toggle Dark Mode</button>
-    <input type="checkbox" id="show-favorites" aria-label="Show favorites">
-    <label for="show-favorites">Show Favorites</label>
+      <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">
+        Toggle Dark Mode
+      </button>
+      <input type="checkbox" id="show-favorites" aria-label="Show favorites">
+      <label for="show-favorites">Show Favorites</label>
 
-    <ul id="terms-list"></ul>
-  </main>
-  <footer class="container" aria-label="Contribute">
-    <p><a href="templates/contribute.html">Contribute</a></p>
-  </footer>
-  <button id="scrollToTopBtn" type="button" aria-label="Scroll to top">↑</button>
+      <ul id="terms-list"></ul>
+    </main>
+    <footer class="container" aria-label="Contribute">
+      <p><a href="templates/contribute.html">Contribute</a></p>
+    </footer>
+    <button id="scrollToTopBtn" type="button" aria-label="Scroll to top">
+      ↑
+    </button>
 
-  <footer aria-label="Project contribution">
-    <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
-  </footer>
-  <script src="script.js"></script>
-  <script src="assets/js/app.js"></script>
-  <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
-  <script src="assets/js/metrics.js"></script>
-</body>
+    <footer aria-label="Project contribution">
+      <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
+    </footer>
+    <script src="script.js"></script>
+    <script src="assets/js/app.js"></script>
+    <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
+    <script src="assets/js/metrics.js"></script>
+  </body>
 </html>
-

--- a/pairs.html
+++ b/pairs.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Pronunciation Practice</title>
+    <link rel="stylesheet" href="styles.css">
+  </head>
+  <body>
+    <main class="container">
+      <h1>Near-Sounding Pairs</h1>
+      <div id="pairs-container"></div>
+    </main>
+    <script>
+      window.__BASE_URL__ = window.__BASE_URL__ || "";
+    </script>
+    <script src="assets/js/pairs.js"></script>
+    <script src="assets/js/app.js"></script>
+    <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
+    <script src="assets/js/metrics.js"></script>
+  </body>
+</html>

--- a/pairs.json
+++ b/pairs.json
@@ -1,0 +1,22 @@
+{
+  "pairs": [
+    {
+      "word1": "Phishing",
+      "ipa1": "/ˈfɪʃɪŋ/",
+      "word2": "Fission",
+      "ipa2": "/ˈfɪʃən/"
+    },
+    {
+      "word1": "Cyber",
+      "ipa1": "/ˈsaɪbər/",
+      "word2": "Cipher",
+      "ipa2": "/ˈsaɪfər/"
+    },
+    {
+      "word1": "Hacker",
+      "ipa1": "/ˈhækər/",
+      "word2": "Hiker",
+      "ipa2": "/ˈhaɪkər/"
+    }
+  ]
+}

--- a/styles.css
+++ b/styles.css
@@ -25,7 +25,7 @@ body {
 
 h1 {
   text-align: center;
-  font-family: 'Cinzel', serif;
+  font-family: "Cinzel", serif;
   font-weight: 700;
   font-size: 48px;
   margin-bottom: 20px;
@@ -110,7 +110,6 @@ body.dark-mode mark {
   box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
   min-height: 44px;
 }
-
 
 /* Controls styling */
 #random-term {
@@ -206,7 +205,9 @@ label {
   border-radius: 4px;
   padding: 10px;
   cursor: pointer;
-  transition: background-color 0.2s, color 0.2s;
+  transition:
+    background-color 0.2s,
+    color 0.2s;
   min-width: 44px;
   min-height: 44px;
 }
@@ -324,6 +325,30 @@ body.dark-mode #alpha-nav button:focus {
 body.dark-mode #alpha-nav button.active {
   background-color: #007bff;
   border-color: #007bff;
+}
+
+.pair {
+  margin-bottom: 20px;
+}
+
+.words.hidden {
+  display: none;
+}
+
+.word {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 5px 0;
+}
+
+.word .ipa {
+  font-style: italic;
+  color: #555;
+}
+
+.word button {
+  margin-left: 10px;
 }
 
 @media (max-width: 480px) {


### PR DESCRIPTION
## Summary
- Add pronunciation practice page displaying near-sounding word pairs with IPA and audio playback
- Link pronunciation practice from the dictionary home page
- Style and data for toggleable minimal pairs

## Testing
- `npm test`
- `npx html-validate pairs.html`


------
https://chatgpt.com/codex/tasks/task_e_68b5391ae6ac832889097db3c70ee554