### PR TITLE
Add breadcrumb navigation to term pages

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,34 +1,45 @@
-const fs = require('fs');
-const path = require('path');
+const fs = require("fs");
+const path = require("path");
 
-const dataPath = path.join(__dirname, 'data.json');
-const data = JSON.parse(fs.readFileSync(dataPath, 'utf8'));
+const dataPath = path.join(__dirname, "data.json");
+const data = JSON.parse(fs.readFileSync(dataPath, "utf8"));
 
-const termsDir = path.join(__dirname, 'terms');
+const termsDir = path.join(__dirname, "terms");
 fs.mkdirSync(termsDir, { recursive: true });
 
-const baseUrl = 'https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms';
+const baseUrl =
+  "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/terms";
 
 const urls = [];
 
 function slugify(term) {
   return term
     .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
 }
 
 for (const term of data.terms) {
   const slug = slugify(term.term);
-  const metaRobots = term.draft ? '<meta name="robots" content="noindex">' : '';
+  const metaRobots = term.draft ? '<meta name="robots" content="noindex">' : "";
+  const breadcrumb = `
+<nav aria-label="Breadcrumb" class="breadcrumb">
+  <ol>
+    <li><a href="../index.html">Home</a></li>
+    <li><a href="../index.html">English</a></li>
+    <li aria-current="page">${term.term}</li>
+  </ol>
+</nav>`;
   const html = `<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
   <title>${term.term}</title>
   ${metaRobots}
+  <link rel="stylesheet" href="../styles.css">
 </head>
 <body>
+  ${breadcrumb}
   <h1>${term.term}</h1>
   <p>${term.definition}</p>
 </body>
@@ -41,8 +52,8 @@ for (const term of data.terms) {
 
 const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-${urls.map(u => `  <url><loc>${u}</loc></url>`).join('\n')}
+${urls.map((u) => `  <url><loc>${u}</loc></url>`).join("\n")}
 </urlset>
 `;
 
-fs.writeFileSync(path.join(__dirname, 'sitemap.xml'), sitemap);
+fs.writeFileSync(path.join(__dirname, "sitemap.xml"), sitemap);

--- a/styles.css
+++ b/styles.css
@@ -25,7 +25,7 @@ body {
 
 h1 {
   text-align: center;
-  font-family: 'Cinzel', serif;
+  font-family: "Cinzel", serif;
   font-weight: 700;
   font-size: 48px;
   margin-bottom: 20px;
@@ -37,6 +37,39 @@ ul {
   list-style: none;
   padding: 0;
   margin: 0;
+}
+
+.breadcrumb {
+  margin-bottom: 1rem;
+}
+
+.breadcrumb ol {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.breadcrumb li + li::before {
+  content: ">";
+  padding: 0 0.5rem;
+}
+
+.breadcrumb li {
+  padding: 0;
+  background: none;
+  border: none;
+  cursor: default;
+  min-height: 0;
+}
+
+.breadcrumb a {
+  text-decoration: none;
+  display: inline-block;
+  padding: 8px 12px;
+  min-height: 44px;
 }
 
 li {
@@ -110,7 +143,6 @@ body.dark-mode mark {
   box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
   min-height: 44px;
 }
-
 
 /* Controls styling */
 #random-term {
@@ -206,7 +238,9 @@ label {
   border-radius: 4px;
   padding: 10px;
   cursor: pointer;
-  transition: background-color 0.2s, color 0.2s;
+  transition:
+    background-color 0.2s,
+    color 0.2s;
   min-width: 44px;
   min-height: 44px;
 }


### PR DESCRIPTION
## Summary
- Add breadcrumb links at top of generated term pages for Home > English > term
- Style breadcrumbs with accessible tap targets via CSS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5391c8ad88328b3348fa01a99b9fa