### PR TITLE
Add compare route for side-by-side term viewing

### DIFF
--- a/assets/js/compare.js
+++ b/assets/js/compare.js
@@ -1,0 +1,54 @@
+(function(){
+  function slugify(term){
+    return term
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '');
+  }
+
+  function renderEntry(container, term){
+    if(term){
+      container.innerHTML = `<h2>${term.term}</h2><p>${term.definition}</p>`;
+    } else {
+      container.textContent = 'Entry not found';
+    }
+  }
+
+  function setupSyncScroll(a, b){
+    let isSyncing = false;
+    a.addEventListener('scroll', () => {
+      if(isSyncing) return;
+      const ratio = a.scrollTop / (a.scrollHeight - a.clientHeight || 1);
+      isSyncing = true;
+      b.scrollTop = ratio * (b.scrollHeight - b.clientHeight);
+      isSyncing = false;
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const params = new URLSearchParams(window.location.search);
+    const leftSlug = params.get('a') || params.get('left');
+    const rightSlug = params.get('b') || params.get('right');
+
+    const leftContainer = document.getElementById('entry-left');
+    const rightContainer = document.getElementById('entry-right');
+
+    fetch('terms.json')
+      .then(r => r.ok ? r.json() : Promise.reject(r.statusText))
+      .then(data => {
+        const terms = data.terms || data;
+        const leftTerm = terms.find(t => slugify(t.term) === leftSlug);
+        const rightTerm = terms.find(t => slugify(t.term) === rightSlug);
+        renderEntry(leftContainer, leftTerm);
+        renderEntry(rightContainer, rightTerm);
+      })
+      .catch(err => {
+        console.error('Failed to load terms.json', err);
+        renderEntry(leftContainer, null);
+        renderEntry(rightContainer, null);
+      });
+
+    setupSyncScroll(leftContainer, rightContainer);
+    setupSyncScroll(rightContainer, leftContainer);
+  });
+})();

--- a/compare.html
+++ b/compare.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Compare Terms</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <main class="container">
+    <h1>Compare Terms</h1>
+    <div id="compare-container">
+      <div id="entry-left" class="compare-column" tabindex="0"></div>
+      <div id="entry-right" class="compare-column" tabindex="0"></div>
+    </div>
+  </main>
+  <script src="assets/js/compare.js"></script>
+  <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
+  <script src="assets/js/metrics.js"></script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "script.js",
   "scripts": {
     "build": "node scripts/build.js",
-    "test": "html-validate index.html search.html diagnostics.html && node diagnostics.test.js",
+    "test": "html-validate index.html search.html diagnostics.html compare.html && node diagnostics.test.js",
     "watch": "chokidar \"**/*.html\" -c \"npm run build\""
   },
   "keywords": [],

--- a/styles.css
+++ b/styles.css
@@ -242,6 +242,21 @@ label {
   background-color: #0056b3;
 }
 
+/* Compare page */
+#compare-container {
+  display: flex;
+  gap: 20px;
+}
+
+.compare-column {
+  flex: 1;
+  max-height: 70vh;
+  overflow-y: auto;
+  padding: 10px;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+}
+
 /* Dark Mode styles */
 body.dark-mode {
   background-color: #121212;
@@ -324,6 +339,11 @@ body.dark-mode #alpha-nav button:focus {
 body.dark-mode #alpha-nav button.active {
   background-color: #007bff;
   border-color: #007bff;
+}
+
+body.dark-mode .compare-column {
+  background-color: #1e1e1e;
+  border-color: #333;
 }
 
 @media (max-width: 480px) {


### PR DESCRIPTION
## Summary
- Add /compare page rendering two term entries side by side via query slugs
- Implement script to load entries and keep columns scrolls synchronized
- Style compare columns and wire into test suite

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b53921ddb88328a0c32cdf85d9335f