### PR TITLE
Add random entry fetch button with animated card

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,8 @@
 
     <button id="random-term" type="button" aria-label="Show random term">Random Term</button>
 
+    <button id="random-entry" type="button" aria-label="Fetch random entry">Random Entry</button>
+
     <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">Toggle Dark Mode</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>

--- a/layout.html
+++ b/layout.html
@@ -25,6 +25,8 @@
 
     <button id="random-term" aria-label="Show random term">Random Term</button>
 
+    <button id="random-entry" aria-label="Fetch random entry">Random Entry</button>
+
     <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>

--- a/script.js
+++ b/script.js
@@ -2,6 +2,7 @@ const termsList = document.getElementById("terms-list");
 const definitionContainer = document.getElementById("definition-container");
 const searchInput = document.getElementById("search");
 const randomButton = document.getElementById("random-term");
+const randomEntryButton = document.getElementById("random-entry");
 const alphaNav = document.getElementById("alpha-nav");
 const darkModeToggle = document.getElementById("dark-mode-toggle");
 const showFavoritesToggle = document.getElementById("show-favorites");
@@ -183,6 +184,9 @@ function populateTermsList() {
 function displayDefinition(term) {
   definitionContainer.style.display = "block";
   definitionContainer.innerHTML = `<h3>${term.term}</h3><p>${term.definition}</p>`;
+  definitionContainer.classList.remove("animate");
+  void definitionContainer.offsetWidth;
+  definitionContainer.classList.add("animate");
   window.location.hash = encodeURIComponent(term.term);
   if (canonicalLink) {
     canonicalLink.setAttribute(
@@ -214,6 +218,27 @@ function showRandomTerm() {
 }
 
 randomButton.addEventListener("click", showRandomTerm);
+
+function fetchRandomEntry() {
+  fetch("terms.json")
+    .then((response) => {
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+      return response.json();
+    })
+    .then((data) => {
+      const randomTerm = data.terms[Math.floor(Math.random() * data.terms.length)];
+      displayDefinition(randomTerm);
+    })
+    .catch((error) => {
+      console.error("Error fetching random entry:", error);
+    });
+}
+
+if (randomEntryButton) {
+  randomEntryButton.addEventListener("click", fetchRandomEntry);
+}
 if (showFavoritesToggle) {
   showFavoritesToggle.addEventListener("change", () => {
     clearDefinition();

--- a/styles.css
+++ b/styles.css
@@ -113,7 +113,8 @@ body.dark-mode mark {
 
 
 /* Controls styling */
-#random-term {
+#random-term,
+#random-entry {
   margin-top: 10px;
   padding: 10px;
   border: 1px solid #ccc;
@@ -125,8 +126,24 @@ body.dark-mode mark {
   min-height: 44px;
 }
 
-#random-term:hover {
+#random-term:hover,
+#random-entry:hover {
   background-color: #0056b3;
+}
+
+#definition-container.animate {
+  animation: fadeIn 0.3s ease-in-out;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
 }
 
 #dark-mode-toggle {


### PR DESCRIPTION
## Summary
- Add Random Entry button to fetch a random term from `terms.json`
- Animate definition card when displaying a term
- Style new button and animation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b53923a72083288bcb36988c6408a8