### PR TITLE
feat: add theme selector with system preference

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,41 +1,50 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Cyber Security Dictionary</title>
-  <link rel="stylesheet" href="styles.css">
-  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet">
-  <link rel="canonical" id="canonical-link" href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/">
-</head>
-<body>
-  <main class="container">
-    <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav" aria-label="Site links"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
-    <div id="definition-container" style="display: none;"></div>
-    <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
-    <input type="text" id="search" placeholder="Search...">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cyber Security Dictionary</title>
+    <link rel="stylesheet" href="styles.css">
+    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet">
+    <link rel="canonical" id="canonical-link" href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/">
+  </head>
+  <body>
+    <main class="container">
+      <h1>Cyber Security Dictionary</h1>
+      <nav class="site-nav" aria-label="Site links">
+        <a href="templates/guidelines.html">Definition Guidelines</a>
+      </nav>
+      <div id="definition-container" style="display: none"></div>
+      <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
+      <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" type="button" aria-label="Show random term">Random Term</button>
+      <button id="random-term" type="button" aria-label="Show random term">Random Term</button>
 
-    <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">Toggle Dark Mode</button>
-    <input type="checkbox" id="show-favorites" aria-label="Show favorites">
-    <label for="show-favorites">Show Favorites</label>
+      <label for="theme-select">Theme</label>
+      <select id="theme-select">
+        <option value="system">System</option>
+        <option value="light">Light</option>
+        <option value="dark">Dark</option>
+        <option value="high-contrast">High Contrast</option>
+      </select>
+      <input type="checkbox" id="show-favorites">
+      <label for="show-favorites">Show Favorites</label>
 
-    <ul id="terms-list"></ul>
-  </main>
-  <footer class="container" aria-label="Contribute">
-    <p><a href="templates/contribute.html">Contribute</a></p>
-  </footer>
-  <button id="scrollToTopBtn" type="button" aria-label="Scroll to top">↑</button>
+      <ul id="terms-list"></ul>
+    </main>
+    <footer class="container" aria-label="Contribute">
+      <p><a href="templates/contribute.html">Contribute</a></p>
+    </footer>
+    <button id="scrollToTopBtn" type="button" aria-label="Scroll to top">
+      ↑
+    </button>
 
-  <footer aria-label="Project contribution">
-    <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
-  </footer>
-  <script src="script.js"></script>
-  <script src="assets/js/app.js"></script>
-  <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
-  <script src="assets/js/metrics.js"></script>
-</body>
+    <footer aria-label="Project contribution">
+      <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
+    </footer>
+    <script src="script.js"></script>
+    <script src="assets/js/app.js"></script>
+    <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
+    <script src="assets/js/metrics.js"></script>
+  </body>
 </html>
-

--- a/layout.html
+++ b/layout.html
@@ -1,40 +1,46 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Cyber Security Dictionary</title>
-  <link rel="stylesheet" href="styles.css">
-  <meta property="og:title" content="Cyber Security Dictionary">
-  <meta property="og:description" content="An interactive dictionary for cyber security terms.">
-  <meta property="og:type" content="website">
-  <meta property="og:url" content="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/">
-  <meta property="og:image" content="https://github.com/Alex-Unnippillil/CyberSecuirtyDictionary/assets/24538548/c5a54c56-babb-485d-b01c-4fdfb186325b">
-  <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Cyber Security Dictionary">
-  <meta name="twitter:description" content="An interactive dictionary for cyber security terms.">
-  <meta name="twitter:url" content="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/">
-  <meta name="twitter:image" content="https://github.com/Alex-Unnippillil/CyberSecuirtyDictionary/assets/24538548/c5a54c56-babb-485d-b01c-4fdfb186325b">
-</head>
-<body>
-  <main class="container">
-    <h1>Cyber Security Dictionary</h1>
-    <div id="definition-container" style="display: none;"></div>
-    <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
-    <input type="text" id="search" placeholder="Search...">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cyber Security Dictionary</title>
+    <link rel="stylesheet" href="styles.css">
+    <meta property="og:title" content="Cyber Security Dictionary">
+    <meta property="og:description" content="An interactive dictionary for cyber security terms.">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/">
+    <meta property="og:image" content="https://github.com/Alex-Unnippillil/CyberSecuirtyDictionary/assets/24538548/c5a54c56-babb-485d-b01c-4fdfb186325b">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Cyber Security Dictionary">
+    <meta name="twitter:description" content="An interactive dictionary for cyber security terms.">
+    <meta name="twitter:url" content="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/">
+    <meta name="twitter:image" content="https://github.com/Alex-Unnippillil/CyberSecuirtyDictionary/assets/24538548/c5a54c56-babb-485d-b01c-4fdfb186325b">
+  </head>
+  <body>
+    <main class="container">
+      <h1>Cyber Security Dictionary</h1>
+      <div id="definition-container" style="display: none"></div>
+      <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
+      <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+      <button id="random-term" aria-label="Show random term">Random Term</button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
-    <input type="checkbox" id="show-favorites" aria-label="Show favorites">
-    <label for="show-favorites">Show Favorites</label>
+      <label for="theme-select">Theme</label>
+      <select id="theme-select">
+        <option value="system">System</option>
+        <option value="light">Light</option>
+        <option value="dark">Dark</option>
+        <option value="high-contrast">High Contrast</option>
+      </select>
+      <input type="checkbox" id="show-favorites">
+      <label for="show-favorites">Show Favorites</label>
 
-    <ul id="terms-list"></ul>
-  </main>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+      <ul id="terms-list"></ul>
+    </main>
+    <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
 
-  <script src="script.js"></script>
-  <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
-  <script src="assets/js/metrics.js"></script>
-</body>
+    <script src="script.js"></script>
+    <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
+    <script src="assets/js/metrics.js"></script>
+  </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -3,25 +3,65 @@ const definitionContainer = document.getElementById("definition-container");
 const searchInput = document.getElementById("search");
 const randomButton = document.getElementById("random-term");
 const alphaNav = document.getElementById("alpha-nav");
-const darkModeToggle = document.getElementById("dark-mode-toggle");
+const themeSelect = document.getElementById("theme-select");
 const showFavoritesToggle = document.getElementById("show-favorites");
-const favorites = new Set(JSON.parse(localStorage.getItem("favorites") || "[]"));
+const favorites = new Set(
+  JSON.parse(localStorage.getItem("favorites") || "[]"),
+);
 const siteUrl = "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/";
 const canonicalLink = document.getElementById("canonical-link");
 
 let currentLetterFilter = "All";
 let termsData = { terms: [] };
 
-if (localStorage.getItem("darkMode") === "true") {
-  document.body.classList.add("dark-mode");
+const prefersDark = window.matchMedia("(prefers-color-scheme: dark)");
+
+function applyTheme(theme) {
+  const html = document.documentElement;
+  html.classList.remove("dark", "high-contrast");
+  if (theme === "dark") {
+    html.classList.add("dark");
+  } else if (theme === "high-contrast") {
+    html.classList.add("dark", "high-contrast");
+  }
 }
 
-if (darkModeToggle) {
-  darkModeToggle.addEventListener("click", () => {
-    document.body.classList.toggle("dark-mode");
-    localStorage.setItem("darkMode", document.body.classList.contains("dark-mode"));
+function initTheme() {
+  let stored = "system";
+  try {
+    stored = localStorage.getItem("theme") || "system";
+  } catch (e) {}
+  const effective =
+    stored === "system" ? (prefersDark.matches ? "dark" : "light") : stored;
+  applyTheme(effective);
+  if (themeSelect) {
+    themeSelect.value = stored;
+  }
+}
+
+initTheme();
+
+if (themeSelect) {
+  themeSelect.addEventListener("change", () => {
+    const value = themeSelect.value;
+    try {
+      localStorage.setItem("theme", value);
+    } catch (e) {}
+    const effective =
+      value === "system" ? (prefersDark.matches ? "dark" : "light") : value;
+    applyTheme(effective);
   });
 }
+
+prefersDark.addEventListener("change", () => {
+  let stored = "system";
+  try {
+    stored = localStorage.getItem("theme") || "system";
+  } catch (e) {}
+  if (stored === "system") {
+    applyTheme(prefersDark.matches ? "dark" : "light");
+  }
+});
 
 window.addEventListener("DOMContentLoaded", () => {
   loadTerms();
@@ -43,9 +83,11 @@ function loadTerms() {
       populateTermsList();
 
       if (window.location.hash) {
-        const termFromHash = decodeURIComponent(window.location.hash.substring(1));
+        const termFromHash = decodeURIComponent(
+          window.location.hash.substring(1),
+        );
         const matchedTerm = termsData.terms.find(
-          (t) => t.term.toLowerCase() === termFromHash.toLowerCase()
+          (t) => t.term.toLowerCase() === termFromHash.toLowerCase(),
         );
         if (matchedTerm) {
           displayDefinition(matchedTerm);
@@ -56,7 +98,7 @@ function loadTerms() {
       console.error("Detailed error fetching data:", error);
       definitionContainer.style.display = "block";
       definitionContainer.innerHTML =
-        '<p>Unable to load dictionary data. Please check your connection and try again.</p>' +
+        "<p>Unable to load dictionary data. Please check your connection and try again.</p>" +
         '<button id="retry-fetch">Retry</button>';
       const retryBtn = document.getElementById("retry-fetch");
       if (retryBtn) {
@@ -97,12 +139,16 @@ function toggleFavorite(term) {
 }
 
 function highlightActiveButton(button) {
-  alphaNav.querySelectorAll("button").forEach((btn) => btn.classList.remove("active"));
+  alphaNav
+    .querySelectorAll("button")
+    .forEach((btn) => btn.classList.remove("active"));
   button.classList.add("active");
 }
 
 function buildAlphaNav() {
-  const letters = Array.from(new Set(termsData.terms.map((t) => t.term.charAt(0).toUpperCase()))).sort();
+  const letters = Array.from(
+    new Set(termsData.terms.map((t) => t.term.charAt(0).toUpperCase())),
+  ).sort();
 
   const allButton = document.createElement("button");
   allButton.textContent = "All";
@@ -134,9 +180,13 @@ function populateTermsList() {
     .sort((a, b) => a.term.localeCompare(b.term))
     .forEach((item) => {
       const matchesSearch = item.term.toLowerCase().includes(searchValue);
-      const matchesFavorites = !showFavoritesToggle || !showFavoritesToggle.checked || favorites.has(item.term);
+      const matchesFavorites =
+        !showFavoritesToggle ||
+        !showFavoritesToggle.checked ||
+        favorites.has(item.term);
       const matchesLetter =
-        currentLetterFilter === "All" || item.term.charAt(0).toUpperCase() === currentLetterFilter;
+        currentLetterFilter === "All" ||
+        item.term.charAt(0).toUpperCase() === currentLetterFilter;
       if (matchesSearch && matchesFavorites && matchesLetter) {
         const termDiv = document.createElement("div");
         termDiv.classList.add("dictionary-item");
@@ -187,7 +237,7 @@ function displayDefinition(term) {
   if (canonicalLink) {
     canonicalLink.setAttribute(
       "href",
-      `${siteUrl}#${encodeURIComponent(term.term)}`
+      `${siteUrl}#${encodeURIComponent(term.term)}`,
     );
   }
 }
@@ -195,19 +245,27 @@ function displayDefinition(term) {
 function clearDefinition() {
   definitionContainer.style.display = "none";
   definitionContainer.innerHTML = "";
-  history.replaceState(null, "", window.location.pathname + window.location.search);
+  history.replaceState(
+    null,
+    "",
+    window.location.pathname + window.location.search,
+  );
   if (canonicalLink) {
     canonicalLink.setAttribute("href", siteUrl);
   }
 }
 
 function showRandomTerm() {
-  const randomTerm = termsData.terms[Math.floor(Math.random() * termsData.terms.length)];
+  const randomTerm =
+    termsData.terms[Math.floor(Math.random() * termsData.terms.length)];
   displayDefinition(randomTerm);
 
   const today = new Date().toDateString();
   try {
-    localStorage.setItem("lastRandomTerm", JSON.stringify({ date: today, term: randomTerm }));
+    localStorage.setItem(
+      "lastRandomTerm",
+      JSON.stringify({ date: today, term: randomTerm }),
+    );
   } catch (e) {
     // Ignore storage errors
   }
@@ -249,8 +307,7 @@ window.addEventListener("scroll", () => {
   scrollBtn.style.display = window.scrollY > 200 ? "block" : "none";
 });
 scrollBtn.addEventListener("click", () =>
-  window.scrollTo({ top: 0, behavior: "smooth" })
+  window.scrollTo({ top: 0, behavior: "smooth" }),
 );
 
 definitionContainer.addEventListener("click", clearDefinition);
-

--- a/styles.css
+++ b/styles.css
@@ -25,7 +25,7 @@ body {
 
 h1 {
   text-align: center;
-  font-family: 'Cinzel', serif;
+  font-family: "Cinzel", serif;
   font-weight: 700;
   font-size: 48px;
   margin-bottom: 20px;
@@ -61,7 +61,7 @@ mark {
   color: inherit;
 }
 
-body.dark-mode mark {
+html.dark mark {
   background-color: #ffeb3b;
   color: #000;
 }
@@ -111,7 +111,6 @@ body.dark-mode mark {
   min-height: 44px;
 }
 
-
 /* Controls styling */
 #random-term {
   margin-top: 10px;
@@ -129,20 +128,16 @@ body.dark-mode mark {
   background-color: #0056b3;
 }
 
-#dark-mode-toggle {
+#theme-select {
   margin-top: 10px;
   padding: 10px;
   border: 1px solid #ccc;
   border-radius: 5px;
-  background-color: #007bff;
-  color: #fff;
-  cursor: pointer;
-  min-width: 44px;
   min-height: 44px;
 }
 
-#dark-mode-toggle:hover {
-  background-color: #0056b3;
+#theme-select:hover {
+  border-color: #0056b3;
 }
 
 label {
@@ -206,7 +201,9 @@ label {
   border-radius: 4px;
   padding: 10px;
   cursor: pointer;
-  transition: background-color 0.2s, color 0.2s;
+  transition:
+    background-color 0.2s,
+    color 0.2s;
   min-width: 44px;
   min-height: 44px;
 }
@@ -243,87 +240,119 @@ label {
 }
 
 /* Dark Mode styles */
-body.dark-mode {
+html.dark body {
   background-color: #121212;
   color: #fff;
 }
 
-body.dark-mode .container {
+html.dark .container {
   background-color: #1e1e1e;
 }
 
-body.dark-mode #search {
+html.dark #search {
   background-color: #1e1e1e;
   color: #fff;
   border-color: #333;
 }
 
-body.dark-mode #dark-mode-toggle {
+html.dark #theme-select {
   background-color: #333;
   color: #fff;
   border-color: #555;
 }
 
-body.dark-mode li {
+html.dark li {
   background-color: #1e1e1e;
   border-bottom: 1px solid #333;
 }
 
-body.dark-mode li:hover {
+html.dark li:hover {
   background-color: #333;
 }
 
-body.dark-mode .dictionary-item {
+html.dark .dictionary-item {
   background-color: #1e1e1e;
   border-color: #333;
 }
 
-body.dark-mode .dictionary-item h3 {
+html.dark .dictionary-item h3 {
   color: #fff;
   border-bottom-color: #333;
 }
 
-body.dark-mode .dictionary-item p {
+html.dark .dictionary-item p {
   color: #ccc;
 }
 
-body.dark-mode #definition-container {
+html.dark #definition-container {
   background-color: #1e1e1e;
   box-shadow: 0 0 5px rgba(255, 255, 255, 0.1);
 }
 
-body.dark-mode .favorite-star {
+html.dark .favorite-star {
   color: #888;
 }
 
-body.dark-mode .favorite-star:hover,
-body.dark-mode .favorite-star:focus {
+html.dark .favorite-star:hover,
+html.dark .favorite-star:focus {
   color: #bbb;
 }
 
-body.dark-mode .favorited {
+html.dark .favorited {
   color: #ffd700;
 }
 
-body.dark-mode .badge {
+html.dark .badge {
   background-color: #1e90ff;
   color: #000;
 }
 
-body.dark-mode #alpha-nav button {
+html.dark #alpha-nav button {
   background-color: #333;
   border-color: #555;
   color: #fff;
 }
 
-body.dark-mode #alpha-nav button:hover,
-body.dark-mode #alpha-nav button:focus {
+html.dark #alpha-nav button:hover,
+html.dark #alpha-nav button:focus {
   background-color: #555;
 }
 
-body.dark-mode #alpha-nav button.active {
+html.dark #alpha-nav button.active {
   background-color: #007bff;
   border-color: #007bff;
+}
+
+/* High contrast overrides */
+html.high-contrast body {
+  background-color: #000;
+  color: #fff;
+}
+
+html.high-contrast a {
+  color: #0ff;
+}
+
+html.high-contrast mark {
+  background-color: #ff0;
+  color: #000;
+}
+
+html.high-contrast .container,
+html.high-contrast #search,
+html.high-contrast #theme-select,
+html.high-contrast li,
+html.high-contrast .dictionary-item,
+html.high-contrast #definition-container,
+html.high-contrast #alpha-nav button {
+  background-color: #000;
+  color: #fff;
+  border-color: #fff;
+}
+
+html.high-contrast #alpha-nav button:hover,
+html.high-contrast #alpha-nav button:focus {
+  background-color: #222;
 }
 
 @media (max-width: 480px) {


### PR DESCRIPTION
## Summary
- add theme selector to choose light, dark, high-contrast or system theme
- honor `prefers-color-scheme` and store choice in localStorage
- apply theme classes on `<html>` for dark and high-contrast styles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b539264cc08328bae1a599e5674d96