### PR TITLE
Add RTL language detection with mirrored layouts

### DIFF
--- a/assets/js/rtl.js
+++ b/assets/js/rtl.js
@@ -1,0 +1,16 @@
+(function () {
+  const rtlLangs = [
+    'ar', 'he', 'fa', 'ur', 'ps', 'sd', 'ug', 'dv', 'yi'
+  ];
+  const htmlEl = document.documentElement;
+  const lang = (htmlEl.getAttribute('lang') || navigator.language || '').toLowerCase();
+  if (rtlLangs.some(l => lang.startsWith(l))) {
+    htmlEl.setAttribute('dir', 'rtl');
+  }
+  document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('input, textarea').forEach((el) => {
+      el.setAttribute('dir', 'auto');
+      el.style.unicodeBidi = 'plaintext';
+    });
+  });
+})();

--- a/diagnostics.html
+++ b/diagnostics.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" dir="ltr">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -16,6 +16,7 @@
       <tbody id="metrics-body"></tbody>
     </table>
   </main>
+  <script src="assets/js/rtl.js" defer></script>
   <script src="assets/js/diagnostics.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" dir="ltr">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -32,6 +32,7 @@
   <footer aria-label="Project contribution">
     <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
   </footer>
+  <script src="assets/js/rtl.js" defer></script>
   <script src="script.js"></script>
   <script src="assets/js/app.js"></script>
   <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>

--- a/layout.html
+++ b/layout.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" dir="ltr">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -33,6 +33,7 @@
   </main>
   <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
 
+  <script src="assets/js/rtl.js" defer></script>
   <script src="script.js"></script>
   <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
   <script src="assets/js/metrics.js"></script>

--- a/search.html
+++ b/search.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" dir="ltr">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -15,6 +15,7 @@
   <script>
     window.__BASE_URL__ = window.__BASE_URL__ || '';
   </script>
+  <script src="assets/js/rtl.js" defer></script>
   <script src="assets/js/search.js"></script>
   <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
   <script src="assets/js/metrics.js"></script>

--- a/styles.css
+++ b/styles.css
@@ -13,6 +13,12 @@ body {
   overflow-x: hidden;
 }
 
+input,
+textarea {
+  direction: auto;
+  unicode-bidi: plaintext;
+}
+
 .container {
   max-width: 800px;
   width: 100%;
@@ -156,6 +162,26 @@ label {
   width: 44px;
   height: 44px;
   margin-right: 5px;
+}
+
+[dir="rtl"] label {
+  margin-right: 10px;
+  margin-left: 0;
+}
+
+[dir="rtl"] #show-favorites {
+  margin-left: 5px;
+  margin-right: 0;
+}
+
+[dir="rtl"] .favorite-star {
+  margin-right: 5px;
+  margin-left: 0;
+}
+
+[dir="rtl"] #scrollToTopBtn {
+  left: 20px;
+  right: auto;
 }
 
 /* Favorite star styles */

--- a/templates/about.html
+++ b/templates/about.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" dir="ltr">
 <head>
   <meta charset="UTF-8" />
   <title>About</title>
@@ -17,4 +17,5 @@
     <li><a href="https://owasp.org/Top10/">OWASP Top 10</a></li>
   </ul>
 </body>
+<script src="../assets/js/rtl.js" defer></script>
 </html>

--- a/templates/contribute.html
+++ b/templates/contribute.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" dir="ltr">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -17,6 +17,7 @@
       <li>Commit and push your changes.</li>
       <li>Open a pull request.</li>
     </ol>
-  </main>
+</main>
+<script src="../assets/js/rtl.js" defer></script>
 </body>
 </html>

--- a/templates/guidelines.html
+++ b/templates/guidelines.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" dir="ltr">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -12,5 +12,6 @@
     <p>Each entry in this dictionary should offer an original explanation of a term rather than copying text from other sources.</p>
     <p>Write definitions in your own words and back them with reputable sources. Include citations or links to the materials that informed your description.</p>
   </main>
+<script src="../assets/js/rtl.js" defer></script>
 </body>
 </html>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ lang }}">
+<html lang="{{ lang }}" dir="ltr">
 <head>
   <meta charset="utf-8" />
   <title>{{ title }}</title>
@@ -46,6 +46,7 @@
       <li><a href="{{ contact_url }}">{{ contact_label }}</a></li>
     </ul>
   </footer>
+  <script src="{{ base_url }}/assets/js/rtl.js" defer></script>
   <script src="{{ base_url }}/assets/js/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- detect RTL browser languages and flip page direction
- mirror layout styles and support caret/selection in inputs
- wire RTL handling across pages and templates

## Testing
- `npm test`
- `npx stylelint styles.css` *(fails: npm error canceled)*

------
https://chatgpt.com/codex/tasks/task_e_68b53928e7c08328af58d6946b4207d9