### PR TITLE
Add shimmering placeholders for loading state

### DIFF
--- a/script.js
+++ b/script.js
@@ -27,7 +27,17 @@ window.addEventListener("DOMContentLoaded", () => {
   loadTerms();
 });
 
+function showPlaceholders(count = 5) {
+  termsList.innerHTML = "";
+  for (let i = 0; i < count; i++) {
+    const ph = document.createElement("div");
+    ph.classList.add("dictionary-item", "placeholder");
+    termsList.appendChild(ph);
+  }
+}
+
 function loadTerms() {
+  showPlaceholders();
   fetch("terms.json")
     .then((response) => {
       if (!response.ok) {
@@ -65,6 +75,7 @@ function loadTerms() {
           loadTerms();
         });
       }
+      termsList.innerHTML = "";
     });
 }
 

--- a/styles.css
+++ b/styles.css
@@ -93,6 +93,32 @@ body.dark-mode mark {
   transform: scale(1.02);
 }
 
+.dictionary-item.placeholder {
+  background-color: #e0e0e0;
+  border-color: #e0e0e0;
+  pointer-events: none;
+  position: relative;
+  overflow: hidden;
+  height: 60px;
+}
+
+.dictionary-item.placeholder::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: -100%;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.6), transparent);
+  animation: shimmer 1.5s infinite;
+}
+
+@keyframes shimmer {
+  100% {
+    transform: translateX(100%);
+  }
+}
+
 #definition-container {
   padding: 20px;
   background-color: #f2f2f2;
@@ -276,6 +302,15 @@ body.dark-mode li:hover {
 body.dark-mode .dictionary-item {
   background-color: #1e1e1e;
   border-color: #333;
+}
+
+body.dark-mode .dictionary-item.placeholder {
+  background-color: #333;
+  border-color: #333;
+}
+
+body.dark-mode .dictionary-item.placeholder::after {
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.2), transparent);
 }
 
 body.dark-mode .dictionary-item h3 {


### PR DESCRIPTION
## Summary
- display animated placeholder panels in terms list during data fetch
- add shimmer animation with dark mode styling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5392af9bc8328a5b154b45e390270