### PR TITLE
Add navigation progress bar tied to router events

### DIFF
--- a/assets/js/progress.js
+++ b/assets/js/progress.js
@@ -1,0 +1,49 @@
+(function () {
+  const bar = document.createElement('div');
+  bar.id = 'progress-bar';
+  document.body.prepend(bar);
+
+  let pending = 0;
+  let revealTimeout;
+  let isVisible = false;
+
+  function resetBar() {
+    bar.classList.remove('active', 'finish');
+    bar.style.width = '0%';
+    bar.style.opacity = '0';
+    isVisible = false;
+  }
+
+  function start() {
+    pending++;
+    if (pending === 1) {
+      revealTimeout = setTimeout(() => {
+        bar.classList.add('active');
+        bar.style.opacity = '1';
+        isVisible = true;
+      }, 100);
+    }
+  }
+
+  function done() {
+    if (pending === 0) return;
+    pending--;
+    if (pending === 0) {
+      clearTimeout(revealTimeout);
+      if (isVisible) {
+        bar.classList.add('finish');
+        const duration = parseFloat(getComputedStyle(bar).transitionDuration) * 1000;
+        setTimeout(resetBar, duration);
+      } else {
+        resetBar();
+      }
+    }
+  }
+
+  window.navigationProgress = { start, done };
+
+  window.addEventListener('hashchange', () => {
+    start();
+    setTimeout(done, 0);
+  });
+})();

--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
   <footer aria-label="Project contribution">
     <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
   </footer>
+  <script src="assets/js/progress.js"></script>
   <script src="script.js"></script>
   <script src="assets/js/app.js"></script>
   <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "script.js",
   "scripts": {
     "build": "node scripts/build.js",
-    "test": "html-validate index.html search.html diagnostics.html && node diagnostics.test.js",
+    "test": "html-validate index.html search.html diagnostics.html && node diagnostics.test.js && node progressbar.test.js",
     "watch": "chokidar \"**/*.html\" -c \"npm run build\""
   },
   "keywords": [],

--- a/progressbar.test.js
+++ b/progressbar.test.js
@@ -1,0 +1,49 @@
+const fs = require('fs');
+const { JSDOM } = require('jsdom');
+
+(async () => {
+  const html = '<!DOCTYPE html><html><body></body></html>';
+  const dom = new JSDOM(html, { runScripts: 'dangerously' });
+  const progressScript = fs.readFileSync('assets/js/progress.js', 'utf8');
+  dom.window.eval(progressScript);
+  const bar = dom.window.document.getElementById('progress-bar');
+  const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+
+  // quick navigation should remain hidden
+  dom.window.navigationProgress.start();
+  dom.window.navigationProgress.done();
+  await wait(150);
+  if (dom.window.getComputedStyle(bar).opacity !== '0') {
+    console.error('Progress bar should stay hidden for quick navigation');
+    process.exit(1);
+  }
+
+  // long navigation should reveal and hide
+  dom.window.navigationProgress.start();
+  await wait(150);
+  if (dom.window.getComputedStyle(bar).opacity !== '1') {
+    console.error('Progress bar should be visible for long navigation');
+    process.exit(1);
+  }
+  dom.window.navigationProgress.done();
+  await wait(350);
+  if (dom.window.getComputedStyle(bar).opacity !== '0') {
+    console.error('Progress bar should hide after completion');
+    process.exit(1);
+  }
+
+  // rapid navigation sequences
+  dom.window.navigationProgress.start();
+  await wait(120);
+  dom.window.navigationProgress.start();
+  dom.window.navigationProgress.done();
+  await wait(50);
+  dom.window.navigationProgress.done();
+  await wait(350);
+  if (dom.window.getComputedStyle(bar).opacity !== '0') {
+    console.error('Progress bar should hide after rapid navigation');
+    process.exit(1);
+  }
+
+  console.log('Progress bar tests passed');
+})();

--- a/search.html
+++ b/search.html
@@ -15,6 +15,7 @@
   <script>
     window.__BASE_URL__ = window.__BASE_URL__ || '';
   </script>
+  <script src="assets/js/progress.js"></script>
   <script src="assets/js/search.js"></script>
   <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
   <script src="assets/js/metrics.js"></script>

--- a/styles.css
+++ b/styles.css
@@ -4,6 +4,33 @@
   box-sizing: border-box;
 }
 
+:root {
+  --motion-duration-fast: 100ms;
+  --motion-duration-medium: 300ms;
+}
+
+#progress-bar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 0%;
+  height: 3px;
+  background-color: #007bff;
+  transition: width var(--motion-duration-medium) ease, opacity var(--motion-duration-fast) ease;
+  opacity: 0;
+  z-index: 1000;
+}
+
+#progress-bar.active {
+  opacity: 1;
+  width: 80%;
+}
+
+#progress-bar.finish {
+  width: 100%;
+  opacity: 0;
+}
+
 body {
   font-family: Arial, sans-serif;
   line-height: 1.6;


### PR DESCRIPTION
## Summary
- Show top progress bar when hash router triggers navigation
- Style progress indicator using motion tokens
- Add tests covering quick and rapid navigation scenarios

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b54727f71c8328a88b581adb5c7cc8