### PR TITLE
Add animated accordion with reduced-motion support

### DIFF
--- a/accordion.test.js
+++ b/accordion.test.js
@@ -1,0 +1,45 @@
+const { JSDOM } = require('jsdom');
+const { setupAccordion } = require('./assets/js/accordion.js');
+
+const html = `
+<div id="root">
+  <div class="accordion-item">
+    <button class="accordion-header" type="button">Definition</button>
+    <div class="accordion-panel">One</div>
+  </div>
+  <div class="accordion-item">
+    <button class="accordion-header" type="button">Examples</button>
+    <div class="accordion-panel">Two</div>
+  </div>
+  <div class="accordion-item">
+    <button class="accordion-header" type="button">Mitigations</button>
+    <div class="accordion-panel">Three</div>
+  </div>
+  <div class="accordion-item">
+    <button class="accordion-header" type="button">Standards</button>
+    <div class="accordion-panel">Four</div>
+  </div>
+</div>
+`;
+
+const dom = new JSDOM(html, { pretendToBeVisual: true });
+setupAccordion(dom.window.document.getElementById('root'));
+
+const headers = dom.window.document.querySelectorAll('.accordion-header');
+headers[0].focus();
+const down = new dom.window.KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true });
+headers[0].dispatchEvent(down);
+if (dom.window.document.activeElement !== headers[1]) {
+  console.error('ArrowDown did not move focus to next header');
+  process.exit(1);
+}
+
+headers[0].focus();
+const up = new dom.window.KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true });
+headers[0].dispatchEvent(up);
+if (dom.window.document.activeElement !== headers[3]) {
+  console.error('ArrowUp did not wrap focus to last header');
+  process.exit(1);
+}
+
+console.log('Accordion keyboard navigation test passed');

--- a/assets/js/accordion.js
+++ b/assets/js/accordion.js
@@ -1,0 +1,53 @@
+function setupAccordion(root) {
+  const headers = Array.from(root.querySelectorAll('.accordion-header'));
+  headers.forEach((header, i) => {
+    const panel = header.nextElementSibling;
+    header.setAttribute('aria-expanded', 'false');
+    header.addEventListener('click', () => {
+      const expanded = header.getAttribute('aria-expanded') === 'true';
+      header.setAttribute('aria-expanded', String(!expanded));
+      if (expanded) {
+        close(panel);
+      } else {
+        open(panel);
+      }
+    });
+    header.addEventListener('keydown', (e) => {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        headers[(i + 1) % headers.length].focus();
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        headers[(i - 1 + headers.length) % headers.length].focus();
+      }
+    });
+  });
+
+  function open(panel) {
+    panel.hidden = false;
+    const height = panel.scrollHeight;
+    panel.style.height = height + 'px';
+    panel.classList.add('open');
+    panel.addEventListener('transitionend', function handler() {
+      panel.style.height = 'auto';
+      panel.removeEventListener('transitionend', handler);
+    });
+  }
+
+  function close(panel) {
+    const height = panel.scrollHeight;
+    panel.style.height = height + 'px';
+    requestAnimationFrame(() => {
+      panel.style.height = '0px';
+      panel.classList.remove('open');
+    });
+    panel.addEventListener('transitionend', function handler() {
+      panel.hidden = true;
+      panel.removeEventListener('transitionend', handler);
+    });
+  }
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { setupAccordion };
+}

--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
   <footer aria-label="Project contribution">
     <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
   </footer>
+  <script src="assets/js/accordion.js"></script>
   <script src="script.js"></script>
   <script src="assets/js/app.js"></script>
   <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "script.js",
   "scripts": {
     "build": "node scripts/build.js",
-    "test": "html-validate index.html search.html diagnostics.html && node diagnostics.test.js",
+    "test": "html-validate index.html search.html diagnostics.html && node diagnostics.test.js && node accordion.test.js",
     "watch": "chokidar \"**/*.html\" -c \"npm run build\""
   },
   "keywords": [],

--- a/script.js
+++ b/script.js
@@ -180,9 +180,40 @@ function populateTermsList() {
     });
 }
 
+function createAccordionSection(title, content) {
+  return `
+    <div class="accordion-item">
+      <button class="accordion-header" type="button">${title}</button>
+      <div class="accordion-panel" hidden>
+        <p>${content}</p>
+      </div>
+    </div>
+  `;
+}
+
 function displayDefinition(term) {
   definitionContainer.style.display = "block";
-  definitionContainer.innerHTML = `<h3>${term.term}</h3><p>${term.definition}</p>`;
+  definitionContainer.innerHTML = `
+    <h3>${term.term}</h3>
+    <div class="accordion">
+      ${createAccordionSection("Definition", term.definition)}
+      ${createAccordionSection(
+        "Examples",
+        term.examples || "No examples provided."
+      )}
+      ${createAccordionSection(
+        "Mitigations",
+        term.mitigations || "No mitigations provided."
+      )}
+      ${createAccordionSection(
+        "Standards",
+        term.standards || "No standards provided."
+      )}
+    </div>`;
+  const acc = definitionContainer.querySelector('.accordion');
+  if (acc) {
+    setupAccordion(acc);
+  }
   window.location.hash = encodeURIComponent(term.term);
   if (canonicalLink) {
     canonicalLink.setAttribute(
@@ -252,5 +283,9 @@ scrollBtn.addEventListener("click", () =>
   window.scrollTo({ top: 0, behavior: "smooth" })
 );
 
-definitionContainer.addEventListener("click", clearDefinition);
+definitionContainer.addEventListener("click", (e) => {
+  if (e.target === definitionContainer) {
+    clearDefinition();
+  }
+});
 

--- a/styles.css
+++ b/styles.css
@@ -326,6 +326,41 @@ body.dark-mode #alpha-nav button.active {
   border-color: #007bff;
 }
 
+/* Accordion styles */
+.accordion-item + .accordion-item {
+  margin-top: 10px;
+}
+
+.accordion-header {
+  width: 100%;
+  text-align: left;
+  padding: 10px;
+  font-weight: bold;
+  background: #eee;
+  border: none;
+  cursor: pointer;
+}
+
+.accordion-panel {
+  overflow: hidden;
+  height: 0;
+  opacity: 0;
+  transform: translateY(-0.5rem);
+  transition: height 0.3s ease, opacity 0.3s ease, transform 0.3s ease;
+}
+
+.accordion-panel.open {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .accordion-panel {
+    transition: height 0.3s ease, opacity 0.3s ease;
+    transform: none;
+  }
+}
+
 @media (max-width: 480px) {
   h1 {
     font-size: 32px;


### PR DESCRIPTION
## Summary
- add reusable accordion component for definitions with height and opacity animations
- render Definition, Examples, Mitigations and Standards as animated accordion sections
- test keyboard navigation through accordion headers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b54733909c8328aa61320cbc065878