### PR TITLE
Add term reveal animations with motion preferences

### DIFF
--- a/script.js
+++ b/script.js
@@ -182,7 +182,27 @@ function populateTermsList() {
 
 function displayDefinition(term) {
   definitionContainer.style.display = "block";
-  definitionContainer.innerHTML = `<h3>${term.term}</h3><p>${term.definition}</p>`;
+
+  const pronunciationHTML = term.pronunciation
+    ? `<div class="pronunciation" style="animation-delay: 0.15s">${term.pronunciation}</div>`
+    : "";
+
+  const badgesHTML = Array.isArray(term.badges)
+    ? `<div class="badges">${term.badges
+        .map(
+          (b, i) =>
+            `<span class="badge" style="animation-delay: ${0.3 + i * 0.15}s">${b}</span>`
+        )
+        .join("")}</div>`
+    : "";
+
+  definitionContainer.innerHTML = `
+    <h1 class="term-title">${term.term}</h1>
+    ${pronunciationHTML}
+    ${badgesHTML}
+    <p>${term.definition}</p>
+  `;
+
   window.location.hash = encodeURIComponent(term.term);
   if (canonicalLink) {
     canonicalLink.setAttribute(

--- a/styles.css
+++ b/styles.css
@@ -347,3 +347,37 @@ body.dark-mode #alpha-nav button.active {
     font-size: 14px;
   }
 }
+
+/* Term reveal animation */
+.term-title,
+.pronunciation,
+.badges .badge {
+  opacity: 0;
+  transform: translateY(8px);
+  animation: term-fade-slide 0.3s forwards;
+}
+
+.pronunciation {
+  animation-delay: 0.15s;
+}
+
+.badges .badge {
+  animation-delay: 0.3s;
+}
+
+@keyframes term-fade-slide {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .term-title,
+  .pronunciation,
+  .badges .badge {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Summary
- Fade and slide term heading into view
- Stagger pronunciation and badges after heading animation
- Respect reduced-motion preference by disabling animations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b54732b41083289fafe9d283c20dbc