### PR TITLE
Add accessible see-also chips with animated paths

### DIFF
--- a/script.js
+++ b/script.js
@@ -5,7 +5,9 @@ const randomButton = document.getElementById("random-term");
 const alphaNav = document.getElementById("alpha-nav");
 const darkModeToggle = document.getElementById("dark-mode-toggle");
 const showFavoritesToggle = document.getElementById("show-favorites");
-const favorites = new Set(JSON.parse(localStorage.getItem("favorites") || "[]"));
+const favorites = new Set(
+  JSON.parse(localStorage.getItem("favorites") || "[]"),
+);
 const siteUrl = "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/";
 const canonicalLink = document.getElementById("canonical-link");
 
@@ -19,7 +21,10 @@ if (localStorage.getItem("darkMode") === "true") {
 if (darkModeToggle) {
   darkModeToggle.addEventListener("click", () => {
     document.body.classList.toggle("dark-mode");
-    localStorage.setItem("darkMode", document.body.classList.contains("dark-mode"));
+    localStorage.setItem(
+      "darkMode",
+      document.body.classList.contains("dark-mode"),
+    );
   });
 }
 
@@ -43,9 +48,11 @@ function loadTerms() {
       populateTermsList();
 
       if (window.location.hash) {
-        const termFromHash = decodeURIComponent(window.location.hash.substring(1));
+        const termFromHash = decodeURIComponent(
+          window.location.hash.substring(1),
+        );
         const matchedTerm = termsData.terms.find(
-          (t) => t.term.toLowerCase() === termFromHash.toLowerCase()
+          (t) => t.term.toLowerCase() === termFromHash.toLowerCase(),
         );
         if (matchedTerm) {
           displayDefinition(matchedTerm);
@@ -56,7 +63,7 @@ function loadTerms() {
       console.error("Detailed error fetching data:", error);
       definitionContainer.style.display = "block";
       definitionContainer.innerHTML =
-        '<p>Unable to load dictionary data. Please check your connection and try again.</p>' +
+        "<p>Unable to load dictionary data. Please check your connection and try again.</p>" +
         '<button id="retry-fetch">Retry</button>';
       const retryBtn = document.getElementById("retry-fetch");
       if (retryBtn) {
@@ -97,12 +104,16 @@ function toggleFavorite(term) {
 }
 
 function highlightActiveButton(button) {
-  alphaNav.querySelectorAll("button").forEach((btn) => btn.classList.remove("active"));
+  alphaNav
+    .querySelectorAll("button")
+    .forEach((btn) => btn.classList.remove("active"));
   button.classList.add("active");
 }
 
 function buildAlphaNav() {
-  const letters = Array.from(new Set(termsData.terms.map((t) => t.term.charAt(0).toUpperCase()))).sort();
+  const letters = Array.from(
+    new Set(termsData.terms.map((t) => t.term.charAt(0).toUpperCase())),
+  ).sort();
 
   const allButton = document.createElement("button");
   allButton.textContent = "All";
@@ -134,9 +145,13 @@ function populateTermsList() {
     .sort((a, b) => a.term.localeCompare(b.term))
     .forEach((item) => {
       const matchesSearch = item.term.toLowerCase().includes(searchValue);
-      const matchesFavorites = !showFavoritesToggle || !showFavoritesToggle.checked || favorites.has(item.term);
+      const matchesFavorites =
+        !showFavoritesToggle ||
+        !showFavoritesToggle.checked ||
+        favorites.has(item.term);
       const matchesLetter =
-        currentLetterFilter === "All" || item.term.charAt(0).toUpperCase() === currentLetterFilter;
+        currentLetterFilter === "All" ||
+        item.term.charAt(0).toUpperCase() === currentLetterFilter;
       if (matchesSearch && matchesFavorites && matchesLetter) {
         const termDiv = document.createElement("div");
         termDiv.classList.add("dictionary-item");
@@ -182,32 +197,122 @@ function populateTermsList() {
 
 function displayDefinition(term) {
   definitionContainer.style.display = "block";
-  definitionContainer.innerHTML = `<h3>${term.term}</h3><p>${term.definition}</p>`;
+  let html = `<h3>${term.term}</h3><p>${term.definition}</p>`;
+
+  if (term.sources && term.sources.length) {
+    const sourceLinks = term.sources
+      .map(
+        (s) =>
+          `<a href="${s.url}" target="_blank" rel="noopener noreferrer">${s.name}</a>`,
+      )
+      .join(", ");
+    html += `<p class="sources"><strong>Sources:</strong> ${sourceLinks}</p>`;
+  }
+
+  if (term.seeAlso && term.seeAlso.length) {
+    const chips = term.seeAlso
+      .map(
+        (sa) =>
+          `<button class="see-also-chip" data-term="${sa}">${sa}</button>`,
+      )
+      .join("");
+    html += `<div class="see-also"><strong>See also:</strong> ${chips}</div>`;
+  }
+
+  definitionContainer.innerHTML = html;
   window.location.hash = encodeURIComponent(term.term);
   if (canonicalLink) {
     canonicalLink.setAttribute(
       "href",
-      `${siteUrl}#${encodeURIComponent(term.term)}`
+      `${siteUrl}#${encodeURIComponent(term.term)}`,
     );
+  }
+
+  if (term.seeAlso && term.seeAlso.length) {
+    const chipsEls = definitionContainer.querySelectorAll(".see-also-chip");
+    chipsEls.forEach((chip) => {
+      requestAnimationFrame(() => chip.classList.add("motion-in"));
+      chip.addEventListener("click", (e) => {
+        e.stopPropagation();
+        const target = termsData.terms.find(
+          (t) => t.term.toLowerCase() === chip.dataset.term.toLowerCase(),
+        );
+        if (!target) return;
+
+        if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+          displayDefinition(target);
+          return;
+        }
+
+        const chipRect = chip.getBoundingClientRect();
+        const defRect = definitionContainer.getBoundingClientRect();
+
+        const svg = document.createElementNS(
+          "http://www.w3.org/2000/svg",
+          "svg",
+        );
+        svg.setAttribute("class", "see-also-path");
+        svg.setAttribute("aria-hidden", "true");
+        svg.style.position = "fixed";
+        svg.style.left = "0";
+        svg.style.top = "0";
+        svg.style.width = "100%";
+        svg.style.height = "100%";
+        svg.style.pointerEvents = "none";
+
+        const path = document.createElementNS(
+          "http://www.w3.org/2000/svg",
+          "path",
+        );
+        const startX = chipRect.left + chipRect.width / 2;
+        const startY = chipRect.top + chipRect.height / 2;
+        const endX = defRect.left + defRect.width / 2;
+        const endY = defRect.top + defRect.height / 2;
+        path.setAttribute("d", `M ${startX} ${startY} L ${endX} ${endY}`);
+        const length = path.getTotalLength();
+        path.style.strokeDasharray = length;
+        path.style.strokeDashoffset = length;
+        path.classList.add("see-also-path-line");
+        svg.appendChild(path);
+        document.body.appendChild(svg);
+
+        path.addEventListener(
+          "animationend",
+          () => {
+            svg.remove();
+            displayDefinition(target);
+          },
+          { once: true },
+        );
+      });
+    });
   }
 }
 
 function clearDefinition() {
   definitionContainer.style.display = "none";
   definitionContainer.innerHTML = "";
-  history.replaceState(null, "", window.location.pathname + window.location.search);
+  history.replaceState(
+    null,
+    "",
+    window.location.pathname + window.location.search,
+  );
   if (canonicalLink) {
     canonicalLink.setAttribute("href", siteUrl);
   }
 }
 
 function showRandomTerm() {
-  const randomTerm = termsData.terms[Math.floor(Math.random() * termsData.terms.length)];
+  const randomTerm =
+    termsData.terms[Math.floor(Math.random() * termsData.terms.length)];
   displayDefinition(randomTerm);
 
   const today = new Date().toDateString();
   try {
-    localStorage.setItem("lastRandomTerm", JSON.stringify({ date: today, term: randomTerm }));
+    localStorage.setItem(
+      "lastRandomTerm",
+      JSON.stringify({ date: today, term: randomTerm }),
+    );
   } catch (e) {
     // Ignore storage errors
   }
@@ -249,8 +354,7 @@ window.addEventListener("scroll", () => {
   scrollBtn.style.display = window.scrollY > 200 ? "block" : "none";
 });
 scrollBtn.addEventListener("click", () =>
-  window.scrollTo({ top: 0, behavior: "smooth" })
+  window.scrollTo({ top: 0, behavior: "smooth" }),
 );
 
 definitionContainer.addEventListener("click", clearDefinition);
-

--- a/styles.css
+++ b/styles.css
@@ -25,7 +25,7 @@ body {
 
 h1 {
   text-align: center;
-  font-family: 'Cinzel', serif;
+  font-family: "Cinzel", serif;
   font-weight: 700;
   font-size: 48px;
   margin-bottom: 20px;
@@ -110,7 +110,6 @@ body.dark-mode mark {
   box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
   min-height: 44px;
 }
-
 
 /* Controls styling */
 #random-term {
@@ -206,7 +205,9 @@ label {
   border-radius: 4px;
   padding: 10px;
   cursor: pointer;
-  transition: background-color 0.2s, color 0.2s;
+  transition:
+    background-color 0.2s,
+    color 0.2s;
   min-width: 44px;
   min-height: 44px;
 }
@@ -345,5 +346,62 @@ body.dark-mode #alpha-nav button.active {
 
   #alpha-nav button {
     font-size: 14px;
+  }
+}
+
+.see-also {
+  margin-top: 10px;
+}
+
+.see-also-chip {
+  display: inline-block;
+  margin: 4px 4px 0 0;
+  padding: 4px 8px;
+  background-color: #e0e0e0;
+  border-radius: 16px;
+  border: none;
+  cursor: pointer;
+  opacity: 0;
+  transform: translateY(-4px);
+}
+
+.see-also-chip:focus {
+  outline: 2px solid #007bff;
+}
+
+.see-also-chip.motion-in {
+  animation: chip-in 0.3s forwards;
+}
+
+@keyframes chip-in {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.see-also-path-line {
+  stroke: #007bff;
+  stroke-width: 2;
+  fill: none;
+  animation: draw-path 0.5s forwards;
+}
+
+@keyframes draw-path {
+  to {
+    stroke-dashoffset: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .see-also-chip {
+    transition: none;
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+
+  .see-also-path-line {
+    animation: none;
   }
 }

--- a/terms.json
+++ b/terms.json
@@ -2,11 +2,29 @@
   "terms": [
     {
       "term": "Phishing",
-      "definition": "An attempt to trick individuals into revealing sensitive information through fraudulent emails, websites, or messages."
+      "definition": "An attempt to trick individuals into revealing sensitive information through fraudulent emails, websites, or messages.",
+      "seeAlso": ["Phishing Email"],
+      "sources": [
+        {
+          "name": "NIST",
+          "url": "https://csrc.nist.gov/publications/detail/sp/800-114/rev-1/final"
+        },
+        {
+          "name": "OWASP",
+          "url": "https://owasp.org/www-community/attacks/Phishing"
+        }
+      ]
     },
     {
       "term": "Phishing Email",
-      "definition": "An email sent by attackers that appears legitimate but aims to trick recipients into revealing sensitive information or performing actions."
+      "definition": "An email sent by attackers that appears legitimate but aims to trick recipients into revealing sensitive information or performing actions.",
+      "seeAlso": ["Phishing"],
+      "sources": [
+        {
+          "name": "OWASP",
+          "url": "https://owasp.org/www-community/attacks/Phishing"
+        }
+      ]
     },
     {
       "term": "Social Engineering Toolkit (SET)",


### PR DESCRIPTION
## Summary
- display "See also" chips with motion-in animation and reduced-motion fallback
- animate an SVG path to related term when a chip is clicked
- render term sources with accessible links (e.g., NIST, OWASP)

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5473474ec83288a17a7e97b33edd9