### PR TITLE
Add animated compliance badges for NIST and OWASP

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,10 @@
 <body>
   <main class="container">
     <h1>Cyber Security Dictionary</h1>
+    <div class="compliance-badges">
+      <a class="badge compliance-badge" href="https://nvd.nist.gov/" target="_blank" rel="noopener">NIST</a>
+      <a class="badge compliance-badge" href="https://owasp.org/Top10/" target="_blank" rel="noopener">OWASP</a>
+    </div>
     <nav class="site-nav" aria-label="Site links"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
     <div id="definition-container" style="display: none;"></div>
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>

--- a/styles.css
+++ b/styles.css
@@ -191,6 +191,44 @@ label {
   color: #fff;
 }
 
+/* External compliance badges */
+.compliance-badges {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.compliance-badge {
+  animation: badge-entry 0.3s ease-out both;
+  transform-origin: center;
+}
+
+@keyframes badge-entry {
+  from {
+    transform: scale(0.5);
+    opacity: 0;
+  }
+  to {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .compliance-badge {
+    animation: badge-entry-reduced 0.3s ease-out both;
+  }
+
+  @keyframes badge-entry-reduced {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+}
+
 /* Alphabet navigation styles */
 #alpha-nav {
   display: flex;


### PR DESCRIPTION
## Summary
- Add NIST and OWASP badges to the homepage with links to their resources
- Animate badges with scale+opacity and fall back to opacity-only for reduced motion

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b547376f6c83288dfbbfa349eeef97