### PR TITLE
Fade in focus outlines

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -6,6 +6,7 @@
   --color-card-bg: #ffffff;
   --color-badge-bg: #e9ecef;
   --color-badge-text: #212529;
+  --focus-ring: #0d6efd;
 }
 
 [data-theme="dark"] {
@@ -16,13 +17,21 @@
   --color-card-bg: #1e1e1e;
   --color-badge-bg: #343a40;
   --color-badge-text: #f8f9fa;
+  --focus-ring: #79b8ff;
 }
 
 body {
   margin: 0;
   background: var(--color-bg);
   color: var(--color-text);
-  font-family: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  font-family:
+    system-ui,
+    -apple-system,
+    "Segoe UI",
+    Roboto,
+    Helvetica,
+    Arial,
+    sans-serif;
   line-height: 1.6;
 }
 
@@ -38,9 +47,37 @@ a {
 }
 
 a:hover,
-a:focus {
+a:focus-visible {
   color: var(--color-link-hover);
   text-decoration: underline;
+}
+
+a,
+button,
+input,
+select,
+textarea {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+  transition: outline-color 0.2s ease;
+}
+
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+  outline-color: var(--focus-ring);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  a,
+  button,
+  input,
+  select,
+  textarea {
+    transition: none;
+  }
 }
 
 /* Grid and cards */
@@ -53,7 +90,7 @@ a:focus {
 .card {
   background: var(--color-card-bg);
   border-radius: 0.5rem;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   padding: 1rem;
 }
 
@@ -83,7 +120,12 @@ a:focus {
 }
 
 /* Typography */
-h1,h2,h3,h4,h5,h6 {
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
   line-height: 1.25;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -4,6 +4,10 @@
   box-sizing: border-box;
 }
 
+:root {
+  --focus-ring-color: #005fcc;
+}
+
 body {
   font-family: Arial, sans-serif;
   line-height: 1.6;
@@ -11,6 +15,34 @@ body {
   margin: 0;
   padding: 0;
   overflow-x: hidden;
+}
+
+a,
+button,
+input,
+textarea,
+select {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+  transition: outline-color 0.2s ease;
+}
+
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+textarea:focus-visible,
+select:focus-visible {
+  outline-color: var(--focus-ring-color);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  a,
+  button,
+  input,
+  textarea,
+  select {
+    transition: none;
+  }
 }
 
 .container {
@@ -25,7 +57,7 @@ body {
 
 h1 {
   text-align: center;
-  font-family: 'Cinzel', serif;
+  font-family: "Cinzel", serif;
   font-weight: 700;
   font-size: 48px;
   margin-bottom: 20px;
@@ -110,7 +142,6 @@ body.dark-mode mark {
   box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
   min-height: 44px;
 }
-
 
 /* Controls styling */
 #random-term {
@@ -206,7 +237,9 @@ label {
   border-radius: 4px;
   padding: 10px;
   cursor: pointer;
-  transition: background-color 0.2s, color 0.2s;
+  transition:
+    background-color 0.2s,
+    color 0.2s;
   min-width: 44px;
   min-height: 44px;
 }
@@ -246,6 +279,7 @@ label {
 body.dark-mode {
   background-color: #121212;
   color: #fff;
+  --focus-ring-color: #1e90ff;
 }
 
 body.dark-mode .container {


### PR DESCRIPTION
## Summary
- Fade focus outlines in via opacity instead of movement
- Respect reduced-motion and switch to immediate focus rings
- Apply consistent focus ring colors across light and dark themes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5473ae1d88328acc50786600a24b8