### PR TITLE
feat: add vercel analytics tracking

### DIFF
--- a/diagnostics.html
+++ b/diagnostics.html
@@ -16,6 +16,11 @@
       <tbody id="metrics-body"></tbody>
     </table>
   </main>
+  <script>
+    window.va =
+      window.va || function () { (window.va.q = window.va.q || []).push(arguments); };
+  </script>
+  <script defer src="https://cdn.vercel-insights.com/v1/script.js"></script>
   <script src="assets/js/diagnostics.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -32,6 +32,11 @@
   <footer aria-label="Project contribution">
     <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
   </footer>
+  <script>
+    window.va =
+      window.va || function () { (window.va.q = window.va.q || []).push(arguments); };
+  </script>
+  <script defer src="https://cdn.vercel-insights.com/v1/script.js"></script>
   <script src="script.js"></script>
   <script src="assets/js/app.js"></script>
   <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>

--- a/layout.html
+++ b/layout.html
@@ -33,6 +33,11 @@
   </main>
   <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
 
+  <script>
+    window.va =
+      window.va || function () { (window.va.q = window.va.q || []).push(arguments); };
+  </script>
+  <script defer src="https://cdn.vercel-insights.com/v1/script.js"></script>
   <script src="script.js"></script>
   <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
   <script src="assets/js/metrics.js"></script>

--- a/script.js
+++ b/script.js
@@ -254,3 +254,15 @@ scrollBtn.addEventListener("click", () =>
 
 definitionContainer.addEventListener("click", clearDefinition);
 
+function trackPageview() {
+  if (window.va) {
+    window.va("pageview", {
+      path: window.location.pathname + window.location.hash,
+    });
+  }
+}
+window.addEventListener("hashchange", trackPageview);
+if (window.location.hash) {
+  trackPageview();
+}
+

--- a/search.html
+++ b/search.html
@@ -13,6 +13,11 @@
     <div id="results"></div>
   </main>
   <script>
+    window.va =
+      window.va || function () { (window.va.q = window.va.q || []).push(arguments); };
+  </script>
+  <script defer src="https://cdn.vercel-insights.com/v1/script.js"></script>
+  <script>
     window.__BASE_URL__ = window.__BASE_URL__ || '';
   </script>
   <script src="assets/js/search.js"></script>

--- a/templates/about.html
+++ b/templates/about.html
@@ -16,5 +16,10 @@
     <li><a href="https://attack.mitre.org/">MITRE ATT&amp;CK</a></li>
     <li><a href="https://owasp.org/Top10/">OWASP Top 10</a></li>
   </ul>
+  <script>
+    window.va =
+      window.va || function () { (window.va.q = window.va.q || []).push(arguments); };
+  </script>
+  <script defer src="https://cdn.vercel-insights.com/v1/script.js"></script>
 </body>
 </html>

--- a/templates/contribute.html
+++ b/templates/contribute.html
@@ -18,5 +18,10 @@
       <li>Open a pull request.</li>
     </ol>
   </main>
+  <script>
+    window.va =
+      window.va || function () { (window.va.q = window.va.q || []).push(arguments); };
+  </script>
+  <script defer src="https://cdn.vercel-insights.com/v1/script.js"></script>
 </body>
 </html>

--- a/templates/guidelines.html
+++ b/templates/guidelines.html
@@ -12,5 +12,10 @@
     <p>Each entry in this dictionary should offer an original explanation of a term rather than copying text from other sources.</p>
     <p>Write definitions in your own words and back them with reputable sources. Include citations or links to the materials that informed your description.</p>
   </main>
+  <script>
+    window.va =
+      window.va || function () { (window.va.q = window.va.q || []).push(arguments); };
+  </script>
+  <script defer src="https://cdn.vercel-insights.com/v1/script.js"></script>
 </body>
 </html>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -46,6 +46,11 @@
       <li><a href="{{ contact_url }}">{{ contact_label }}</a></li>
     </ul>
   </footer>
+  <script>
+    window.va =
+      window.va || function () { (window.va.q = window.va.q || []).push(arguments); };
+  </script>
+  <script defer src="https://cdn.vercel-insights.com/v1/script.js"></script>
   <script src="{{ base_url }}/assets/js/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- inject Vercel analytics snippet into pages
- log hash-based page transitions with Vercel `pageview` events

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b547537e708328b5562a7dd490e593