### PR TITLE
Add reduced-motion E2E tests with CLS check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,13 @@ jobs:
         uses: lycheeverse/lychee-action@v2
         with:
           args: --no-cache terms.json
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npx playwright install --with-deps
+      - run: npm test

--- a/e2e/reduced-motion.spec.js
+++ b/e2e/reduced-motion.spec.js
@@ -1,0 +1,37 @@
+const { test, expect } = require('@playwright/test');
+
+test('reduced-motion toggle disables transforms', async ({ page }) => {
+  await page.goto('/');
+  await page.waitForSelector('.dictionary-item');
+  const firstItem = page.locator('.dictionary-item').first();
+
+  // Hover to trigger transform before enabling reduced motion
+  await firstItem.hover();
+  const baseline = await firstItem.evaluate((el) => getComputedStyle(el).transform);
+  expect(baseline).not.toBe('none');
+  await page.mouse.move(0, 0);
+
+  await page.click('#reduce-motion-toggle');
+  await firstItem.hover();
+  const reduced = await firstItem.evaluate((el) => getComputedStyle(el).transform);
+  expect(reduced).toBe('none');
+});
+
+test('no CLS spikes during route change', async ({ page }) => {
+  await page.addInitScript(() => {
+    window.__cls = 0;
+    new PerformanceObserver((list) => {
+      for (const entry of list.getEntries()) {
+        if (!entry.hadRecentInput) {
+          window.__cls += entry.value;
+        }
+      }
+    }).observe({ type: 'layout-shift', buffered: true });
+  });
+
+  await page.goto('/search.html');
+  await page.waitForLoadState('load');
+  await page.waitForTimeout(500);
+  const cls = await page.evaluate(() => window.__cls);
+  expect(cls).toBeLessThan(0.1);
+});

--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
     <button id="random-term" type="button" aria-label="Show random term">Random Term</button>
 
     <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+    <button id="reduce-motion-toggle" type="button" aria-label="Toggle reduced motion">Toggle Reduced Motion</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
+        "@playwright/test": "^1.55.0",
         "chokidar-cli": "^3.0.0",
         "html-validate": "^10.0.0",
         "http-server": "^14.1.1",
@@ -205,6 +206,22 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
+      "integrity": "sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@sidvind/better-ajv-errors": {
@@ -1587,6 +1604,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/portfinder": {

--- a/package.json
+++ b/package.json
@@ -5,18 +5,19 @@
   "main": "script.js",
   "scripts": {
     "build": "node scripts/build.js",
-    "test": "html-validate index.html search.html diagnostics.html && node diagnostics.test.js",
+    "test": "html-validate index.html search.html diagnostics.html && node diagnostics.test.js && playwright test",
     "watch": "chokidar \"**/*.html\" -c \"npm run build\""
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "@playwright/test": "^1.55.0",
     "chokidar-cli": "^3.0.0",
     "html-validate": "^10.0.0",
     "http-server": "^14.1.1",
     "js-yaml": "^4.1.0",
-    "prettier": "^3.6.2",
-    "jsdom": "^26.1.0"
+    "jsdom": "^26.1.0",
+    "prettier": "^3.6.2"
   }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,13 @@
+const { defineConfig } = require('@playwright/test');
+
+module.exports = defineConfig({
+  testDir: './e2e',
+  use: {
+    baseURL: 'http://localhost:3000',
+  },
+  webServer: {
+    command: 'npx http-server -p 3000',
+    port: 3000,
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/script.js
+++ b/script.js
@@ -4,6 +4,7 @@ const searchInput = document.getElementById("search");
 const randomButton = document.getElementById("random-term");
 const alphaNav = document.getElementById("alpha-nav");
 const darkModeToggle = document.getElementById("dark-mode-toggle");
+const reduceMotionToggle = document.getElementById("reduce-motion-toggle");
 const showFavoritesToggle = document.getElementById("show-favorites");
 const favorites = new Set(JSON.parse(localStorage.getItem("favorites") || "[]"));
 const siteUrl = "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/";
@@ -16,10 +17,24 @@ if (localStorage.getItem("darkMode") === "true") {
   document.body.classList.add("dark-mode");
 }
 
+if (localStorage.getItem("reduceMotion") === "true") {
+  document.body.classList.add("reduce-motion");
+}
+
 if (darkModeToggle) {
   darkModeToggle.addEventListener("click", () => {
     document.body.classList.toggle("dark-mode");
     localStorage.setItem("darkMode", document.body.classList.contains("dark-mode"));
+  });
+}
+
+if (reduceMotionToggle) {
+  reduceMotionToggle.addEventListener("click", () => {
+    document.body.classList.toggle("reduce-motion");
+    localStorage.setItem(
+      "reduceMotion",
+      document.body.classList.contains("reduce-motion")
+    );
   });
 }
 

--- a/styles.css
+++ b/styles.css
@@ -93,6 +93,15 @@ body.dark-mode mark {
   transform: scale(1.02);
 }
 
+body.reduce-motion * {
+  animation: none !important;
+  transition: none !important;
+}
+
+body.reduce-motion .dictionary-item:hover {
+  transform: none;
+}
+
 #definition-container {
   padding: 20px;
   background-color: #f2f2f2;


### PR DESCRIPTION
## Summary
- add reduced motion toggle and persist state
- disable animations and transforms when reduced motion enabled
- add Playwright E2E tests checking motion toggle and CLS on navigation
- run E2E tests in CI

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b547540ae08328b22026d6a765c5d3