### PR TITLE
feat: add web vitals analytics

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,8 +34,7 @@
   </footer>
   <script src="script.js"></script>
   <script src="assets/js/app.js"></script>
-  <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
-  <script src="assets/js/metrics.js"></script>
+  <script type="module" src="assets/js/metrics.js"></script>
 </body>
 </html>
 

--- a/layout.html
+++ b/layout.html
@@ -34,7 +34,6 @@
   <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
 
   <script src="script.js"></script>
-  <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
-  <script src="assets/js/metrics.js"></script>
+  <script type="module" src="assets/js/metrics.js"></script>
 </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "cybersecuirtydictionary",
       "version": "1.0.0",
       "license": "ISC",
+      "dependencies": {
+        "web-vitals": "^3.5.2"
+      },
       "devDependencies": {
         "chokidar-cli": "^3.0.0",
         "html-validate": "^10.0.0",
@@ -2110,6 +2113,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/web-vitals": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-3.5.2.tgz",
+      "integrity": "sha512-c0rhqNcHXRkY/ogGDJQxZ9Im9D19hDihbzSQJrsioex+KnFgmMzBiy57Z1EjkhX/+OjyBpclDCzz2ITtjokFmg==",
+      "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,10 @@
     "html-validate": "^10.0.0",
     "http-server": "^14.1.1",
     "js-yaml": "^4.1.0",
-    "prettier": "^3.6.2",
-    "jsdom": "^26.1.0"
+    "jsdom": "^26.1.0",
+    "prettier": "^3.6.2"
+  },
+  "dependencies": {
+    "web-vitals": "^3.5.2"
   }
 }

--- a/search.html
+++ b/search.html
@@ -16,7 +16,6 @@
     window.__BASE_URL__ = window.__BASE_URL__ || '';
   </script>
   <script src="assets/js/search.js"></script>
-  <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
-  <script src="assets/js/metrics.js"></script>
+  <script type="module" src="assets/js/metrics.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- install `web-vitals` package
- report CLS, LCP, and INP metrics with attribution to `/analytics`
- load analytics module on pages with ES module script

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b58dbec22083288e88b01343eee690