### PR TITLE
Respect reduced motion preferences

### DIFF
--- a/MOTION_AUDIT.md
+++ b/MOTION_AUDIT.md
@@ -1,0 +1,16 @@
+# Motion Audit Report
+
+## Overview
+
+An audit was conducted to ensure non-essential animations respect the user's `prefers-reduced-motion` setting.
+
+## Findings and Updates
+
+- No `components/` or `app/` directories were present in the project.
+- **assets/css/style.css**: skip-link transition is disabled when reduced motion is requested.
+- **styles.css**: transitions and hover scaling are disabled for list items, dictionary cards, favorite stars, and alphabet navigation buttons when reduced motion is requested.
+- **script.js**: smooth scrolling is disabled in favor of instant scrolling for users who prefer reduced motion.
+
+## Compliance
+
+All identified non-essential animations now honor the `prefers-reduced-motion: reduce` media query.

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -91,3 +91,9 @@ p {
   margin-top: 0;
   margin-bottom: 1rem;
 }
+
+@media (prefers-reduced-motion: reduce) {
+  .skip-link {
+    transition: none;
+  }
+}

--- a/script.js
+++ b/script.js
@@ -245,11 +245,12 @@ searchInput.addEventListener("input", () => {
 });
 
 const scrollBtn = document.getElementById("scrollToTopBtn");
+const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 window.addEventListener("scroll", () => {
   scrollBtn.style.display = window.scrollY > 200 ? "block" : "none";
 });
 scrollBtn.addEventListener("click", () =>
-  window.scrollTo({ top: 0, behavior: "smooth" })
+  window.scrollTo({ top: 0, behavior: prefersReducedMotion ? "auto" : "smooth" })
 );
 
 definitionContainer.addEventListener("click", clearDefinition);

--- a/styles.css
+++ b/styles.css
@@ -347,3 +347,25 @@ body.dark-mode #alpha-nav button.active {
     font-size: 14px;
   }
 }
+
+@media (prefers-reduced-motion: reduce) {
+  li {
+    transition: none;
+  }
+
+  .dictionary-item {
+    transition: none;
+  }
+
+  .dictionary-item:hover {
+    transform: none;
+  }
+
+  .favorite-star {
+    transition: none;
+  }
+
+  #alpha-nav button {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary
- disable skip-link transition when user requests reduced motion
- remove transitions and hover scaling for dictionary items, list entries, favorite star, and alphabet navigation buttons when `prefers-reduced-motion` is set
- toggle smooth scrolling based on reduced-motion preference and add motion audit report

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b58dc330088328aa2735a05901d868