### PR TITLE
Animate term cards on first view

### DIFF
--- a/components/TermCard.tsx
+++ b/components/TermCard.tsx
@@ -1,0 +1,39 @@
+import React, { useEffect, useRef, useState } from "react";
+import { motion, useAnimation, useInView } from "framer-motion";
+
+interface TermCardProps {
+  term: string;
+  definition: string;
+}
+
+const TermCard: React.FC<TermCardProps> = ({ term, definition }) => {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const controls = useAnimation();
+  const inView = useInView(ref);
+  const [hasAnimated, setHasAnimated] = useState(false);
+
+  useEffect(() => {
+    if (inView && !hasAnimated) {
+      controls.start("visible");
+      setHasAnimated(true);
+    }
+  }, [inView, hasAnimated, controls]);
+
+  return (
+    <motion.div
+      ref={ref}
+      initial="hidden"
+      animate={hasAnimated ? "visible" : controls}
+      variants={{
+        hidden: { opacity: 0, y: 20 },
+        visible: { opacity: 1, y: 0 },
+      }}
+      transition={{ duration: 0.4 }}
+    >
+      <h3>{term}</h3>
+      <p>{definition}</p>
+    </motion.div>
+  );
+};
+
+export default TermCard;


### PR DESCRIPTION
## Summary
- add TermCard component using Framer Motion's `useInView`
- track first viewport entry and store animation state to prevent reruns

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b58dc41a308328b7a119df97a5f18b