### PR TITLE
feat: centralize animation tokens for interactive controls

### DIFF
--- a/components/button.ts
+++ b/components/button.ts
@@ -1,0 +1,5 @@
+import { applyControlAnimation } from './interactive';
+
+export function enhanceButton(button: HTMLButtonElement) {
+  applyControlAnimation(button);
+}

--- a/components/input.ts
+++ b/components/input.ts
@@ -1,0 +1,5 @@
+import { applyControlAnimation } from './interactive';
+
+export function enhanceInput(input: HTMLInputElement) {
+  applyControlAnimation(input);
+}

--- a/components/interactive.ts
+++ b/components/interactive.ts
@@ -1,0 +1,32 @@
+import { durations, easing, distances } from '../styles/animations';
+
+function applyHover(el: HTMLElement) {
+  el.style.transform = `translateY(-${distances.hover})`;
+}
+
+function applyPress(el: HTMLElement) {
+  el.style.transform = `translateY(${distances.press})`;
+}
+
+function clearTransform(el: HTMLElement) {
+  el.style.transform = '';
+}
+
+function applyFocus(el: HTMLElement) {
+  el.style.boxShadow = `0 0 0 ${distances.focus} currentColor`;
+}
+
+function clearFocus(el: HTMLElement) {
+  el.style.boxShadow = '';
+}
+
+export function applyControlAnimation(el: HTMLElement) {
+  el.style.transition = `transform ${durations.press} ${easing.standard}, box-shadow ${durations.focus} ${easing.standard}`;
+
+  el.addEventListener('pointerenter', () => applyHover(el));
+  el.addEventListener('pointerleave', () => clearTransform(el));
+  el.addEventListener('pointerdown', () => applyPress(el));
+  el.addEventListener('pointerup', () => applyHover(el));
+  el.addEventListener('focus', () => applyFocus(el));
+  el.addEventListener('blur', () => clearFocus(el));
+}

--- a/components/link.ts
+++ b/components/link.ts
@@ -1,0 +1,5 @@
+import { applyControlAnimation } from './interactive';
+
+export function enhanceLink(link: HTMLAnchorElement) {
+  applyControlAnimation(link);
+}

--- a/styles/animations.ts
+++ b/styles/animations.ts
@@ -1,0 +1,15 @@
+export const durations = {
+  hover: '150ms',
+  press: '150ms',
+  focus: '150ms',
+} as const;
+
+export const easing = {
+  standard: 'cubic-bezier(0.4, 0, 0.2, 1)',
+} as const;
+
+export const distances = {
+  hover: '2px',
+  press: '1px',
+  focus: '3px',
+} as const;


### PR DESCRIPTION
## Summary
- add animation duration, easing and distance tokens
- centralize hover/press/focus logic in `applyControlAnimation`
- update button, link and input helpers to consume animation tokens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b58dc522708328a67f8a0e857ea78b