### PR TITLE
Add bundle size budget check and CI reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,20 @@ jobs:
         uses: lycheeverse/lychee-action@v2
         with:
           args: --no-cache terms.json
+      - name: Bundle size budget
+        id: bundle
+        run: node build-budget.js | tee bundle-report.txt
+      - name: Comment bundle report
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const report = fs.readFileSync('bundle-report.txt', 'utf8');
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `### Bundle size report\n\n\`\`\`\n${report}\n\`\`\``
+            });
+

--- a/build-budget.js
+++ b/build-budget.js
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const { execSync } = require('child_process');
+
+// Define bundle size limits in bytes
+const limits = {
+  'script.js': 15 * 1024, // 15 KB
+  'styles.css': 10 * 1024 // 10 KB
+};
+
+let exitCode = 0;
+const lines = [];
+
+for (const [file, limit] of Object.entries(limits)) {
+  const size = fs.statSync(file).size;
+  let prevSize = 0;
+  try {
+    const prev = execSync(`git show HEAD^:${file}`, { encoding: 'utf8' });
+    prevSize = Buffer.byteLength(prev);
+  } catch {
+    prevSize = 0;
+  }
+  const delta = size - prevSize;
+  const pass = size <= limit;
+  lines.push(
+    `${file}: ${size} bytes (limit ${limit}) delta ${delta >= 0 ? '+' : ''}${delta} -> ${pass ? 'PASS' : 'FAIL'}`
+  );
+  if (!pass) {
+    exitCode = 1;
+  }
+}
+
+console.log(lines.join('\n'));
+process.exit(exitCode);

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "node scripts/build.js",
     "test": "html-validate index.html search.html diagnostics.html && node diagnostics.test.js",
-    "watch": "chokidar \"**/*.html\" -c \"npm run build\""
+    "watch": "chokidar \"**/*.html\" -c \"npm run build\"",
+    "budget": "node build-budget.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add script to enforce bundle size limits for script.js and styles.css
- integrate bundle size check into CI with automatic PR comments

## Testing
- `npm test`
- `node build-budget.js`


------
https://chatgpt.com/codex/tasks/task_e_68b58dc971148328b3e953b094c4a6ce