### PR TITLE
Add RTL-aware animations

### DIFF
--- a/rtl.test.js
+++ b/rtl.test.js
@@ -1,0 +1,36 @@
+const fs = require('fs');
+const { JSDOM } = require('jsdom');
+
+const html = `<!DOCTYPE html><html dir="rtl"><head><link id="canonical-link" rel="canonical" href=""></head><body>
+<div id="terms-list"></div>
+<div id="definition-container"></div>
+<input id="search" />
+<button id="random-term"></button>
+<nav id="alpha-nav"></nav>
+<button id="dark-mode-toggle"></button>
+<input type="checkbox" id="show-favorites" />
+<button id="scrollToTopBtn"></button>
+</body></html>`;
+
+const dom = new JSDOM(html, { runScripts: 'dangerously', url: 'https://example.com' });
+
+dom.window.requestAnimationFrame = (cb) => cb();
+dom.window.fetch = () => Promise.resolve({ ok: true, json: () => Promise.resolve({ terms: [] }) });
+
+const today = new Date().toDateString();
+dom.window.localStorage.setItem(
+  'lastRandomTerm',
+  JSON.stringify({ date: today, term: { term: 't', definition: 'd' } })
+);
+
+const script = fs.readFileSync('script.js', 'utf8');
+dom.window.eval(script);
+
+const rootVar = dom.window.document.documentElement.style.getPropertyValue('--dir-multiplier').trim();
+
+if (rootVar === '-1') {
+  console.log('RTL transition test passed');
+} else {
+  console.error(`Expected -1, got ${rootVar}`);
+  process.exit(1);
+}

--- a/script.js
+++ b/script.js
@@ -8,6 +8,8 @@ const showFavoritesToggle = document.getElementById("show-favorites");
 const favorites = new Set(JSON.parse(localStorage.getItem("favorites") || "[]"));
 const siteUrl = "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/";
 const canonicalLink = document.getElementById("canonical-link");
+const isRTL = document.documentElement.getAttribute("dir") === "rtl";
+document.documentElement.style.setProperty("--dir-multiplier", isRTL ? -1 : 1);
 
 let currentLetterFilter = "All";
 let termsData = { terms: [] };
@@ -190,11 +192,25 @@ function displayDefinition(term) {
       `${siteUrl}#${encodeURIComponent(term.term)}`
     );
   }
+  requestAnimationFrame(() => {
+    definitionContainer.classList.add("visible");
+  });
 }
 
 function clearDefinition() {
-  definitionContainer.style.display = "none";
-  definitionContainer.innerHTML = "";
+  if (definitionContainer.style.display !== "none") {
+    definitionContainer.classList.remove("visible");
+    definitionContainer.addEventListener(
+      "transitionend",
+      () => {
+        definitionContainer.style.display = "none";
+        definitionContainer.innerHTML = "";
+      },
+      { once: true }
+    );
+  } else {
+    definitionContainer.innerHTML = "";
+  }
   history.replaceState(null, "", window.location.pathname + window.location.search);
   if (canonicalLink) {
     canonicalLink.setAttribute("href", siteUrl);

--- a/styles.css
+++ b/styles.css
@@ -4,6 +4,14 @@
   box-sizing: border-box;
 }
 
+:root {
+  --dir-multiplier: 1;
+}
+
+html[dir="rtl"] {
+  --dir-multiplier: -1;
+}
+
 body {
   font-family: Arial, sans-serif;
   line-height: 1.6;
@@ -90,7 +98,7 @@ body.dark-mode mark {
 }
 
 .dictionary-item:hover {
-  transform: scale(1.02);
+  transform: scale(1.02) translateX(calc(var(--dir-multiplier) * 5px));
 }
 
 #definition-container {
@@ -99,6 +107,14 @@ body.dark-mode mark {
   border-radius: 5px;
   box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
   margin-bottom: 20px;
+  transform: translateX(calc(var(--dir-multiplier) * -20px));
+  opacity: 0;
+  transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+#definition-container.visible {
+  transform: translateX(0);
+  opacity: 1;
 }
 
 #search {
@@ -236,6 +252,11 @@ label {
   width: 44px;
   height: 44px;
   border-radius: 50%;
+}
+
+html[dir="rtl"] #scrollToTopBtn {
+  right: auto;
+  left: 20px;
 }
 
 #scrollToTopBtn:hover {


### PR DESCRIPTION
## Summary
- detect `dir="rtl"` and apply directional multiplier for animations
- slide definition panel and term hover based on text direction
- add RTL transition test

## Testing
- `npm test`
- `node rtl.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b58dd0c4088328a931e4b3348ddfab