### PR TITLE
feat: add JSON-LD schema for term and FAQ pages

### DIFF
--- a/app/components/FAQBlock.tsx
+++ b/app/components/FAQBlock.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+
+interface FAQItem {
+  question: string;
+  answer: string;
+}
+
+interface FAQBlockProps {
+  items: FAQItem[];
+}
+
+export function FAQBlock({ items }: FAQBlockProps) {
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: items.map((item) => ({
+      "@type": "Question",
+      name: item.question,
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: item.answer,
+      },
+    })),
+  };
+
+  return (
+    <section>
+      <h2>FAQ</h2>
+      {items.map((item, idx) => (
+        <div key={idx}>
+          <h3>{item.question}</h3>
+          <p>{item.answer}</p>
+        </div>
+      ))}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+    </section>
+  );
+}

--- a/app/terms/[slug]/page.tsx
+++ b/app/terms/[slug]/page.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import terms from "../../../terms.json";
+import { FAQBlock } from "../../components/FAQBlock";
+
+function slugify(term: string) {
+  return term
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+export default function TermPage({ params }: { params: { slug: string } }) {
+  const term = terms.terms.find((t) => slugify(t.term) === params.slug);
+
+  if (!term) {
+    return <div>Term not found</div>;
+  }
+
+  const termJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "DefinedTerm",
+    name: term.term,
+    description: term.definition,
+    url: `https://example.com/terms/${params.slug}`,
+  };
+
+  const faqItems = [
+    {
+      question: `What is ${term.term}?`,
+      answer: term.definition,
+    },
+  ];
+
+  return (
+    <main>
+      <h1>{term.term}</h1>
+      <p>{term.definition}</p>
+      <FAQBlock items={faqItems} />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(termJsonLd) }}
+      />
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add FAQBlock component that renders Q&A and corresponding JSON-LD
- add term page with DefinedTerm schema and FAQ markup

## Testing
- `npm test`
- `curl -sS -D - -o /tmp/rich-results.html -H "Content-Type: text/html" --data-binary @/tmp/rich-snippet.html "https://search.google.com/test/rich-results/preview"` *(fails: 404 Not Found)*

------
https://chatgpt.com/codex/tasks/task_e_68b58dd3d5448328ada0d7527ee7eea2