### PR TITLE
Add revision tracking and draft promotion UI

### DIFF
--- a/assets/js/revision.js
+++ b/assets/js/revision.js
@@ -1,0 +1,52 @@
+const params = new URLSearchParams(window.location.search);
+const termName = params.get("term");
+const titleEl = document.getElementById("term-title");
+const revASelect = document.getElementById("revA");
+const revBSelect = document.getElementById("revB");
+const diffOutput = document.getElementById("diff-output");
+const promoteBtn = document.getElementById("promote-btn");
+let currentTerm;
+
+fetch("terms.json")
+  .then((res) => res.json())
+  .then((data) => {
+    currentTerm = data.terms.find((t) => t.term === termName);
+    if (!currentTerm) {
+      titleEl.textContent = "Term not found";
+      return;
+    }
+    titleEl.textContent = currentTerm.term;
+    currentTerm.revisions.forEach((r) => {
+      const optA = document.createElement("option");
+      optA.value = r.version;
+      optA.textContent = `v${r.version} (${r.updated})`;
+      revASelect.appendChild(optA);
+      const optB = optA.cloneNode(true);
+      revBSelect.appendChild(optB);
+    });
+    revASelect.value = currentTerm.revisions[0].version;
+    revBSelect.value =
+      currentTerm.revisions[currentTerm.revisions.length - 1].version;
+    if (currentTerm.status === "draft") {
+      promoteBtn.style.display = "block";
+    }
+  });
+
+document.getElementById("compare").addEventListener("click", () => {
+  if (!currentTerm) return;
+  const revA = currentTerm.revisions.find((r) => r.version == revASelect.value);
+  const revB = currentTerm.revisions.find((r) => r.version == revBSelect.value);
+  const diff = Diff.diffWords(revA.definition, revB.definition);
+  diffOutput.innerHTML = diff
+    .map((part) => {
+      const tag = part.added ? "ins" : part.removed ? "del" : "span";
+      return `<${tag}>${part.value}</${tag}>`;
+    })
+    .join("");
+});
+
+promoteBtn.addEventListener("click", () => {
+  currentTerm.status = "published";
+  promoteBtn.style.display = "none";
+  alert("Term promoted to published (local only)");
+});

--- a/data/terms.yaml
+++ b/data/terms.yaml
@@ -1,5 +1,6 @@
 - name: CVE
   slug: cve
+  status: draft
   definition: >-
     A public catalog of cybersecurity vulnerabilities providing unique identifiers
     for known software flaws.
@@ -12,8 +13,15 @@
     - NVD
   sources:
     - https://cve.mitre.org
+  revisions:
+    - version: 1
+      definition: >-
+        A public catalog of cybersecurity vulnerabilities providing unique identifiers
+        for known software flaws.
+      updated: 2024-01-01
 - name: CWE
   slug: cwe
+  status: published
   definition: >-
     A community-developed list of common software and hardware weakness types.
   category: Weakness Classification
@@ -24,8 +32,14 @@
     - OWASP Top 10
   sources:
     - https://cwe.mitre.org
+  revisions:
+    - version: 1
+      definition: >-
+        A community-developed list of common software and hardware weakness types.
+      updated: 2024-01-01
 - name: CVSS
   slug: cvss
+  status: published
   definition: >-
     A standardized scoring system for rating the severity of security vulnerabilities.
   category: Scoring System
@@ -36,8 +50,14 @@
     - NVD
   sources:
     - https://www.first.org/cvss/
+  revisions:
+    - version: 1
+      definition: >-
+        A standardized scoring system for rating the severity of security vulnerabilities.
+      updated: 2024-01-01
 - name: NVD
   slug: nvd
+  status: published
   definition: >-
     A U.S. government repository of standards-based vulnerability management data.
   category: Database
@@ -48,8 +68,14 @@
     - CVSS
   sources:
     - https://nvd.nist.gov/
+  revisions:
+    - version: 1
+      definition: >-
+        A U.S. government repository of standards-based vulnerability management data.
+      updated: 2024-01-01
 - name: MITRE ATT&CK
   slug: mitre-attack
+  status: published
   definition: >-
     A globally accessible knowledge base of adversary tactics and techniques based
     on real-world observations.
@@ -61,8 +87,15 @@
     - CWE
   sources:
     - https://attack.mitre.org/
+  revisions:
+    - version: 1
+      definition: >-
+        A globally accessible knowledge base of adversary tactics and techniques based
+        on real-world observations.
+      updated: 2024-01-01
 - name: OWASP Top 10
   slug: owasp-top-10
+  status: published
   definition: >-
     A regularly updated report outlining the ten most critical web application
     security risks, published by the Open Web Application Security Project.
@@ -73,3 +106,9 @@
     - CWE
   sources:
     - https://owasp.org/www-project-top-ten/
+  revisions:
+    - version: 1
+      definition: >-
+        A regularly updated report outlining the ten most critical web application
+        security risks, published by the Open Web Application Security Project.
+      updated: 2024-01-01

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "script.js",
   "scripts": {
     "build": "node scripts/build.js",
-    "test": "html-validate index.html search.html diagnostics.html && node diagnostics.test.js",
+    "test": "html-validate index.html search.html diagnostics.html revision.html && node diagnostics.test.js",
     "watch": "chokidar \"**/*.html\" -c \"npm run build\""
   },
   "keywords": [],

--- a/revision.html
+++ b/revision.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Revision Comparison</title>
+    <link rel="stylesheet" href="styles.css">
+  </head>
+  <body>
+    <main class="container">
+      <h1 id="term-title">Loading...</h1>
+      <div>
+        <label for="revA">Revision A:</label>
+        <select id="revA"></select>
+        <label for="revB">Revision B:</label>
+        <select id="revB"></select>
+        <button id="compare" type="button">Compare</button>
+      </div>
+      <pre id="diff-output"></pre>
+      <button id="promote-btn" type="button" style="display: none">
+        Promote to Published
+      </button>
+    </main>
+    <script src="https://cdn.jsdelivr.net/npm/diff@5/dist/diff.min.js"></script>
+    <script src="assets/js/revision.js"></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -5,8 +5,12 @@ const randomButton = document.getElementById("random-term");
 const alphaNav = document.getElementById("alpha-nav");
 const darkModeToggle = document.getElementById("dark-mode-toggle");
 const showFavoritesToggle = document.getElementById("show-favorites");
-const favorites = new Set(JSON.parse(localStorage.getItem("favorites") || "[]"));
+const favorites = new Set(
+  JSON.parse(localStorage.getItem("favorites") || "[]"),
+);
 const siteUrl = "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/";
+const urlParams = new URLSearchParams(window.location.search);
+const isMaintainer = urlParams.get("admin") === "true";
 const canonicalLink = document.getElementById("canonical-link");
 
 let currentLetterFilter = "All";
@@ -19,7 +23,10 @@ if (localStorage.getItem("darkMode") === "true") {
 if (darkModeToggle) {
   darkModeToggle.addEventListener("click", () => {
     document.body.classList.toggle("dark-mode");
-    localStorage.setItem("darkMode", document.body.classList.contains("dark-mode"));
+    localStorage.setItem(
+      "darkMode",
+      document.body.classList.contains("dark-mode"),
+    );
   });
 }
 
@@ -37,15 +44,22 @@ function loadTerms() {
     })
     .then((data) => {
       termsData = data;
+      if (!isMaintainer) {
+        termsData.terms = termsData.terms.filter(
+          (t) => t.status === "published",
+        );
+      }
       removeDuplicateTermsAndDefinitions();
       termsData.terms.sort((a, b) => a.term.localeCompare(b.term));
       buildAlphaNav();
       populateTermsList();
 
       if (window.location.hash) {
-        const termFromHash = decodeURIComponent(window.location.hash.substring(1));
+        const termFromHash = decodeURIComponent(
+          window.location.hash.substring(1),
+        );
         const matchedTerm = termsData.terms.find(
-          (t) => t.term.toLowerCase() === termFromHash.toLowerCase()
+          (t) => t.term.toLowerCase() === termFromHash.toLowerCase(),
         );
         if (matchedTerm) {
           displayDefinition(matchedTerm);
@@ -56,7 +70,7 @@ function loadTerms() {
       console.error("Detailed error fetching data:", error);
       definitionContainer.style.display = "block";
       definitionContainer.innerHTML =
-        '<p>Unable to load dictionary data. Please check your connection and try again.</p>' +
+        "<p>Unable to load dictionary data. Please check your connection and try again.</p>" +
         '<button id="retry-fetch">Retry</button>';
       const retryBtn = document.getElementById("retry-fetch");
       if (retryBtn) {
@@ -97,12 +111,16 @@ function toggleFavorite(term) {
 }
 
 function highlightActiveButton(button) {
-  alphaNav.querySelectorAll("button").forEach((btn) => btn.classList.remove("active"));
+  alphaNav
+    .querySelectorAll("button")
+    .forEach((btn) => btn.classList.remove("active"));
   button.classList.add("active");
 }
 
 function buildAlphaNav() {
-  const letters = Array.from(new Set(termsData.terms.map((t) => t.term.charAt(0).toUpperCase()))).sort();
+  const letters = Array.from(
+    new Set(termsData.terms.map((t) => t.term.charAt(0).toUpperCase())),
+  ).sort();
 
   const allButton = document.createElement("button");
   allButton.textContent = "All";
@@ -134,9 +152,13 @@ function populateTermsList() {
     .sort((a, b) => a.term.localeCompare(b.term))
     .forEach((item) => {
       const matchesSearch = item.term.toLowerCase().includes(searchValue);
-      const matchesFavorites = !showFavoritesToggle || !showFavoritesToggle.checked || favorites.has(item.term);
+      const matchesFavorites =
+        !showFavoritesToggle ||
+        !showFavoritesToggle.checked ||
+        favorites.has(item.term);
       const matchesLetter =
-        currentLetterFilter === "All" || item.term.charAt(0).toUpperCase() === currentLetterFilter;
+        currentLetterFilter === "All" ||
+        item.term.charAt(0).toUpperCase() === currentLetterFilter;
       if (matchesSearch && matchesFavorites && matchesLetter) {
         const termDiv = document.createElement("div");
         termDiv.classList.add("dictionary-item");
@@ -183,11 +205,14 @@ function populateTermsList() {
 function displayDefinition(term) {
   definitionContainer.style.display = "block";
   definitionContainer.innerHTML = `<h3>${term.term}</h3><p>${term.definition}</p>`;
+  if (isMaintainer) {
+    definitionContainer.innerHTML += `<p>Status: ${term.status}</p><p><a href="revision.html?term=${encodeURIComponent(term.term)}">Manage revisions</a></p>`;
+  }
   window.location.hash = encodeURIComponent(term.term);
   if (canonicalLink) {
     canonicalLink.setAttribute(
       "href",
-      `${siteUrl}#${encodeURIComponent(term.term)}`
+      `${siteUrl}#${encodeURIComponent(term.term)}`,
     );
   }
 }
@@ -195,19 +220,27 @@ function displayDefinition(term) {
 function clearDefinition() {
   definitionContainer.style.display = "none";
   definitionContainer.innerHTML = "";
-  history.replaceState(null, "", window.location.pathname + window.location.search);
+  history.replaceState(
+    null,
+    "",
+    window.location.pathname + window.location.search,
+  );
   if (canonicalLink) {
     canonicalLink.setAttribute("href", siteUrl);
   }
 }
 
 function showRandomTerm() {
-  const randomTerm = termsData.terms[Math.floor(Math.random() * termsData.terms.length)];
+  const randomTerm =
+    termsData.terms[Math.floor(Math.random() * termsData.terms.length)];
   displayDefinition(randomTerm);
 
   const today = new Date().toDateString();
   try {
-    localStorage.setItem("lastRandomTerm", JSON.stringify({ date: today, term: randomTerm }));
+    localStorage.setItem(
+      "lastRandomTerm",
+      JSON.stringify({ date: today, term: randomTerm }),
+    );
   } catch (e) {
     // Ignore storage errors
   }
@@ -249,8 +282,7 @@ window.addEventListener("scroll", () => {
   scrollBtn.style.display = window.scrollY > 200 ? "block" : "none";
 });
 scrollBtn.addEventListener("click", () =>
-  window.scrollTo({ top: 0, behavior: "smooth" })
+  window.scrollTo({ top: 0, behavior: "smooth" }),
 );
 
 definitionContainer.addEventListener("click", clearDefinition);
-

--- a/terms.json
+++ b/terms.json
@@ -2,135 +2,399 @@
   "terms": [
     {
       "term": "Phishing",
-      "definition": "An attempt to trick individuals into revealing sensitive information through fraudulent emails, websites, or messages."
+      "definition": "An attempt to trick individuals into revealing sensitive information through fraudulent emails, websites, or messages.",
+      "status": "draft",
+      "revisions": [
+        {
+          "version": 1,
+          "definition": "An attempt to trick individuals into revealing sensitive information through fraudulent emails, websites, or messages.",
+          "updated": "2024-01-01"
+        }
+      ]
     },
     {
       "term": "Phishing Email",
-      "definition": "An email sent by attackers that appears legitimate but aims to trick recipients into revealing sensitive information or performing actions."
+      "definition": "An email sent by attackers that appears legitimate but aims to trick recipients into revealing sensitive information or performing actions.",
+      "status": "published",
+      "revisions": [
+        {
+          "version": 1,
+          "definition": "An email sent by attackers that appears legitimate but aims to trick recipients into revealing sensitive information or performing actions.",
+          "updated": "2024-01-01"
+        }
+      ]
     },
     {
       "term": "Social Engineering Toolkit (SET)",
-      "definition": "A framework for simulating social engineering attacks, helping organizations test their security awareness."
+      "definition": "A framework for simulating social engineering attacks, helping organizations test their security awareness.",
+      "status": "published",
+      "revisions": [
+        {
+          "version": 1,
+          "definition": "A framework for simulating social engineering attacks, helping organizations test their security awareness.",
+          "updated": "2024-01-01"
+        }
+      ]
     },
     {
       "term": "Advanced Persistent Threat (APT)",
-      "definition": "A prolonged and targeted cyber attack in which attackers gain and maintain unauthorized access to a network."
+      "definition": "A prolonged and targeted cyber attack in which attackers gain and maintain unauthorized access to a network.",
+      "status": "published",
+      "revisions": [
+        {
+          "version": 1,
+          "definition": "A prolonged and targeted cyber attack in which attackers gain and maintain unauthorized access to a network.",
+          "updated": "2024-01-01"
+        }
+      ]
     },
     {
       "term": "Cyber Espionage",
-      "definition": "The use of cyber techniques to steal sensitive information from governments, organizations, or individuals."
+      "definition": "The use of cyber techniques to steal sensitive information from governments, organizations, or individuals.",
+      "status": "published",
+      "revisions": [
+        {
+          "version": 1,
+          "definition": "The use of cyber techniques to steal sensitive information from governments, organizations, or individuals.",
+          "updated": "2024-01-01"
+        }
+      ]
     },
     {
       "term": "Zero-Knowledge Proof",
-      "definition": "A cryptographic method that allows a party to prove knowledge of a secret without revealing the secret itself."
+      "definition": "A cryptographic method that allows a party to prove knowledge of a secret without revealing the secret itself.",
+      "status": "published",
+      "revisions": [
+        {
+          "version": 1,
+          "definition": "A cryptographic method that allows a party to prove knowledge of a secret without revealing the secret itself.",
+          "updated": "2024-01-01"
+        }
+      ]
     },
     {
       "term": "Security Operations Center (SOC)",
-      "definition": "A centralized unit that monitors, detects, and responds to cybersecurity incidents and threats in real-time."
+      "definition": "A centralized unit that monitors, detects, and responds to cybersecurity incidents and threats in real-time.",
+      "status": "published",
+      "revisions": [
+        {
+          "version": 1,
+          "definition": "A centralized unit that monitors, detects, and responds to cybersecurity incidents and threats in real-time.",
+          "updated": "2024-01-01"
+        }
+      ]
     },
     {
       "term": "Data Loss Prevention (DLP)",
-      "definition": "A strategy and set of tools to prevent the unauthorized loss or leakage of sensitive data."
+      "definition": "A strategy and set of tools to prevent the unauthorized loss or leakage of sensitive data.",
+      "status": "published",
+      "revisions": [
+        {
+          "version": 1,
+          "definition": "A strategy and set of tools to prevent the unauthorized loss or leakage of sensitive data.",
+          "updated": "2024-01-01"
+        }
+      ]
     },
     {
       "term": "Endpoint Security",
-      "definition": "The protection of devices like laptops, desktops, and smartphones from various security threats."
+      "definition": "The protection of devices like laptops, desktops, and smartphones from various security threats.",
+      "status": "published",
+      "revisions": [
+        {
+          "version": 1,
+          "definition": "The protection of devices like laptops, desktops, and smartphones from various security threats.",
+          "updated": "2024-01-01"
+        }
+      ]
     },
     {
       "term": "Security Token",
-      "definition": "A physical or digital device used to authenticate users or provide one-time passwords for secure access."
+      "definition": "A physical or digital device used to authenticate users or provide one-time passwords for secure access.",
+      "status": "published",
+      "revisions": [
+        {
+          "version": 1,
+          "definition": "A physical or digital device used to authenticate users or provide one-time passwords for secure access.",
+          "updated": "2024-01-01"
+        }
+      ]
     },
     {
       "term": "Network Security",
-      "definition": "The protection of network infrastructure and data from unauthorized access or attacks."
+      "definition": "The protection of network infrastructure and data from unauthorized access or attacks.",
+      "status": "published",
+      "revisions": [
+        {
+          "version": 1,
+          "definition": "The protection of network infrastructure and data from unauthorized access or attacks.",
+          "updated": "2024-01-01"
+        }
+      ]
     },
     {
       "term": "Payload",
-      "definition": "The part of a malware or exploit that performs malicious actions on a victim's system."
+      "definition": "The part of a malware or exploit that performs malicious actions on a victim's system.",
+      "status": "published",
+      "revisions": [
+        {
+          "version": 1,
+          "definition": "The part of a malware or exploit that performs malicious actions on a victim's system.",
+          "updated": "2024-01-01"
+        }
+      ]
     },
     {
       "term": "Cryptography",
-      "definition": "The practice of secure communication by converting plaintext into ciphertext and vice versa."
+      "definition": "The practice of secure communication by converting plaintext into ciphertext and vice versa.",
+      "status": "published",
+      "revisions": [
+        {
+          "version": 1,
+          "definition": "The practice of secure communication by converting plaintext into ciphertext and vice versa.",
+          "updated": "2024-01-01"
+        }
+      ]
     },
     {
       "term": "Social Engineering Attack Vectors",
-      "definition": "Different methods and techniques used in social engineering attacks to manipulate victims."
+      "definition": "Different methods and techniques used in social engineering attacks to manipulate victims.",
+      "status": "published",
+      "revisions": [
+        {
+          "version": 1,
+          "definition": "Different methods and techniques used in social engineering attacks to manipulate victims.",
+          "updated": "2024-01-01"
+        }
+      ]
     },
     {
       "term": "Threat Hunting",
-      "definition": "Proactively searching for and identifying cyber threats that have evaded traditional security measures."
+      "definition": "Proactively searching for and identifying cyber threats that have evaded traditional security measures.",
+      "status": "published",
+      "revisions": [
+        {
+          "version": 1,
+          "definition": "Proactively searching for and identifying cyber threats that have evaded traditional security measures.",
+          "updated": "2024-01-01"
+        }
+      ]
     },
     {
       "term": "Incident Response",
-      "definition": "The process of managing and mitigating the impact of a cybersecurity incident or breach."
+      "definition": "The process of managing and mitigating the impact of a cybersecurity incident or breach.",
+      "status": "published",
+      "revisions": [
+        {
+          "version": 1,
+          "definition": "The process of managing and mitigating the impact of a cybersecurity incident or breach.",
+          "updated": "2024-01-01"
+        }
+      ]
     },
     {
       "term": "Privilege Escalation",
-      "definition": "The act of gaining higher levels of access or permissions in a system or network than originally granted."
+      "definition": "The act of gaining higher levels of access or permissions in a system or network than originally granted.",
+      "status": "published",
+      "revisions": [
+        {
+          "version": 1,
+          "definition": "The act of gaining higher levels of access or permissions in a system or network than originally granted.",
+          "updated": "2024-01-01"
+        }
+      ]
     },
     {
       "term": "Security Assessment",
-      "definition": "A systematic evaluation of an organization's security measures to identify vulnerabilities and weaknesses."
+      "definition": "A systematic evaluation of an organization's security measures to identify vulnerabilities and weaknesses.",
+      "status": "published",
+      "revisions": [
+        {
+          "version": 1,
+          "definition": "A systematic evaluation of an organization's security measures to identify vulnerabilities and weaknesses.",
+          "updated": "2024-01-01"
+        }
+      ]
     },
     {
       "term": "Data Encryption Standard (DES)",
-      "definition": "An early symmetric key encryption algorithm used to secure electronic data."
+      "definition": "An early symmetric key encryption algorithm used to secure electronic data.",
+      "status": "published",
+      "revisions": [
+        {
+          "version": 1,
+          "definition": "An early symmetric key encryption algorithm used to secure electronic data.",
+          "updated": "2024-01-01"
+        }
+      ]
     },
     {
       "term": "Advanced Encryption Standard (AES)",
-      "definition": "A widely used symmetric key encryption algorithm known for its security and efficiency."
+      "definition": "A widely used symmetric key encryption algorithm known for its security and efficiency.",
+      "status": "published",
+      "revisions": [
+        {
+          "version": 1,
+          "definition": "A widely used symmetric key encryption algorithm known for its security and efficiency.",
+          "updated": "2024-01-01"
+        }
+      ]
     },
     {
       "term": "Public Key Infrastructure (PKI)",
-      "definition": "A system for managing digital certificates and public-private key pairs used in asymmetric encryption."
+      "definition": "A system for managing digital certificates and public-private key pairs used in asymmetric encryption.",
+      "status": "published",
+      "revisions": [
+        {
+          "version": 1,
+          "definition": "A system for managing digital certificates and public-private key pairs used in asymmetric encryption.",
+          "updated": "2024-01-01"
+        }
+      ]
     },
     {
       "term": "Certificate Authority (CA)",
-      "definition": "An entity responsible for issuing and managing digital certificates used in PKI."
+      "definition": "An entity responsible for issuing and managing digital certificates used in PKI.",
+      "status": "published",
+      "revisions": [
+        {
+          "version": 1,
+          "definition": "An entity responsible for issuing and managing digital certificates used in PKI.",
+          "updated": "2024-01-01"
+        }
+      ]
     },
     {
       "term": "Secure Sockets Layer (SSL)",
-      "definition": "An older cryptographic protocol that provides secure communication over a computer network."
+      "definition": "An older cryptographic protocol that provides secure communication over a computer network.",
+      "status": "published",
+      "revisions": [
+        {
+          "version": 1,
+          "definition": "An older cryptographic protocol that provides secure communication over a computer network.",
+          "updated": "2024-01-01"
+        }
+      ]
     },
     {
       "term": "Transport Layer Security (TLS)",
-      "definition": "A more secure successor to SSL, providing encryption and authentication for secure communication."
+      "definition": "A more secure successor to SSL, providing encryption and authentication for secure communication.",
+      "status": "published",
+      "revisions": [
+        {
+          "version": 1,
+          "definition": "A more secure successor to SSL, providing encryption and authentication for secure communication.",
+          "updated": "2024-01-01"
+        }
+      ]
     },
     {
       "term": "Key Exchange",
-      "definition": "The process of securely sharing encryption keys between parties to establish a secure communication channel."
+      "definition": "The process of securely sharing encryption keys between parties to establish a secure communication channel.",
+      "status": "published",
+      "revisions": [
+        {
+          "version": 1,
+          "definition": "The process of securely sharing encryption keys between parties to establish a secure communication channel.",
+          "updated": "2024-01-01"
+        }
+      ]
     },
     {
       "term": "Malvertising",
-      "definition": "Malicious online advertisements that deliver malware or lead to malicious websites."
+      "definition": "Malicious online advertisements that deliver malware or lead to malicious websites.",
+      "status": "published",
+      "revisions": [
+        {
+          "version": 1,
+          "definition": "Malicious online advertisements that deliver malware or lead to malicious websites.",
+          "updated": "2024-01-01"
+        }
+      ]
     },
     {
       "term": "Eavesdropping",
-      "definition": "Unauthorized interception and monitoring of private communications, often done surreptitiously."
+      "definition": "Unauthorized interception and monitoring of private communications, often done surreptitiously.",
+      "status": "published",
+      "revisions": [
+        {
+          "version": 1,
+          "definition": "Unauthorized interception and monitoring of private communications, often done surreptitiously.",
+          "updated": "2024-01-01"
+        }
+      ]
     },
     {
       "term": "Identity Theft",
-      "definition": "The fraudulent acquisition and use of an individual's personal information to impersonate them for malicious purposes."
+      "definition": "The fraudulent acquisition and use of an individual's personal information to impersonate them for malicious purposes.",
+      "status": "published",
+      "revisions": [
+        {
+          "version": 1,
+          "definition": "The fraudulent acquisition and use of an individual's personal information to impersonate them for malicious purposes.",
+          "updated": "2024-01-01"
+        }
+      ]
     },
     {
       "term": "Zero-Day Vulnerability",
-      "definition": "A software vulnerability that is not yet known to the vendor or the public, making it highly valuable to attackers."
+      "definition": "A software vulnerability that is not yet known to the vendor or the public, making it highly valuable to attackers.",
+      "status": "published",
+      "revisions": [
+        {
+          "version": 1,
+          "definition": "A software vulnerability that is not yet known to the vendor or the public, making it highly valuable to attackers.",
+          "updated": "2024-01-01"
+        }
+      ]
     },
     {
       "term": "Security Patch",
-      "definition": "An update released by software vendors to fix security vulnerabilities in their products."
+      "definition": "An update released by software vendors to fix security vulnerabilities in their products.",
+      "status": "published",
+      "revisions": [
+        {
+          "version": 1,
+          "definition": "An update released by software vendors to fix security vulnerabilities in their products.",
+          "updated": "2024-01-01"
+        }
+      ]
     },
     {
       "term": "Cross-Site Scripting (XSS)",
-      "definition": "A type of web vulnerability where attackers inject malicious scripts into web pages viewed by other users."
+      "definition": "A type of web vulnerability where attackers inject malicious scripts into web pages viewed by other users.",
+      "status": "published",
+      "revisions": [
+        {
+          "version": 1,
+          "definition": "A type of web vulnerability where attackers inject malicious scripts into web pages viewed by other users.",
+          "updated": "2024-01-01"
+        }
+      ]
     },
     {
       "term": "Cross-Site Request Forgery (CSRF)",
-      "definition": "An attack that tricks a user into unknowingly submitting a malicious request on a trusted website."
+      "definition": "An attack that tricks a user into unknowingly submitting a malicious request on a trusted website.",
+      "status": "published",
+      "revisions": [
+        {
+          "version": 1,
+          "definition": "An attack that tricks a user into unknowingly submitting a malicious request on a trusted website.",
+          "updated": "2024-01-01"
+        }
+      ]
     },
     {
       "term": "Phishing Email",
-      "definition": "An email sent by attackers that appears legitimate but aims to trick recipients into revealing sensitive information or performing actions."
+      "definition": "An email sent by attackers that appears legitimate but aims to trick recipients into revealing sensitive information or performing actions.",
+      "status": "published",
+      "revisions": [
+        {
+          "version": 1,
+          "definition": "An email sent by attackers that appears legitimate but aims to trick recipients into revealing sensitive information or performing actions.",
+          "updated": "2024-01-01"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- extend term data with status fields and revision history
- filter unpublished terms for public users and expose revision management link for maintainers
- add revision comparison page with diff viewer and publish control

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b58dd68c808328876c0b86b43b5265