### PR TITLE
feat: add locale-specific term variants

### DIFF
--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -39,11 +39,17 @@
     const name = (term.name || term.term || '').toLowerCase();
     const def = (term.definition || '').toLowerCase();
     const category = (term.category || '').toLowerCase();
-    const syns = (term.synonyms || []).map(s=>s.toLowerCase());
+    const syns = (term.synonyms || []).map(s => s.toLowerCase());
+    const variantSyns = term.variants
+      ? Object.values(term.variants).flatMap(v =>
+          [v.spelling, ...(v.synonyms || [])].map(s => s.toLowerCase())
+        )
+      : [];
     if(name.includes(query)) s += 3;
     if(def.includes(query)) s += 1;
     if(category.includes(query)) s += 1;
     if(syns.some(syn => syn.includes(query))) s += 2;
+    if(variantSyns.some(syn => syn.includes(query))) s += 2;
     return s;
   }
 

--- a/build.js
+++ b/build.js
@@ -1,7 +1,9 @@
 const fs = require('fs');
 const path = require('path');
 
-const dataPath = path.join(__dirname, 'data.json');
+const dataPath = fs.existsSync(path.join(__dirname, 'data.json'))
+  ? path.join(__dirname, 'data.json')
+  : path.join(__dirname, 'terms.json');
 const data = JSON.parse(fs.readFileSync(dataPath, 'utf8'));
 
 const termsDir = path.join(__dirname, 'terms');
@@ -21,6 +23,15 @@ function slugify(term) {
 for (const term of data.terms) {
   const slug = slugify(term.term);
   const metaRobots = term.draft ? '<meta name="robots" content="noindex">' : '';
+  let variantHtml = '';
+  if (term.variants) {
+    variantHtml = Object.entries(term.variants)
+      .map(([locale, info]) => {
+        const example = info.example ? `<p><em>${info.example}</em></p>` : '';
+        return `<section><h2>${info.spelling} (${locale})</h2>${example}</section>`;
+      })
+      .join('');
+  }
   const html = `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -31,6 +42,7 @@ for (const term of data.terms) {
 <body>
   <h1>${term.term}</h1>
   <p>${term.definition}</p>
+  ${variantHtml}
 </body>
 </html>`;
   fs.writeFileSync(path.join(termsDir, `${slug}.html`), html);

--- a/data/terms.yaml
+++ b/data/terms.yaml
@@ -73,3 +73,19 @@
     - CWE
   sources:
     - https://owasp.org/www-project-top-ten/
+- name: Security Operations Center (SOC)
+  slug: security-operations-center
+  definition: >-
+    A centralized unit that monitors, detects, and responds to cybersecurity incidents and threats in real time.
+  category: Operations
+  variants:
+    en-US:
+      spelling: Security Operations Center
+      example: Many companies run a Security Operations Center to monitor threats.
+      synonyms:
+        - SOC
+    en-GB:
+      spelling: Security Operations Centre
+      example: The bank operates a Security Operations Centre for round-the-clock monitoring.
+      synonyms:
+        - SOC

--- a/terms.json
+++ b/terms.json
@@ -26,7 +26,19 @@
     },
     {
       "term": "Security Operations Center (SOC)",
-      "definition": "A centralized unit that monitors, detects, and responds to cybersecurity incidents and threats in real-time."
+      "definition": "A centralized unit that monitors, detects, and responds to cybersecurity incidents and threats in real-time.",
+      "variants": {
+        "en-US": {
+          "spelling": "Security Operations Center",
+          "example": "Many companies run a Security Operations Center to monitor threats.",
+          "synonyms": ["SOC"]
+        },
+        "en-GB": {
+          "spelling": "Security Operations Centre",
+          "example": "The bank operates a Security Operations Centre for round-the-clock monitoring.",
+          "synonyms": ["SOC"]
+        }
+      }
     },
     {
       "term": "Data Loss Prevention (DLP)",


### PR DESCRIPTION
## Summary
- support locale-based term variants in schema and build pipeline
- display en-US vs en-GB spellings and examples on term pages
- expand search to match regional synonyms

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b58dd1b3748328a1242722a5055830