### PR TITLE
Add locale sitemaps and canonical tags

### DIFF
--- a/build.js
+++ b/build.js
@@ -27,6 +27,7 @@ for (const term of data.terms) {
   <meta charset="UTF-8">
   <title>${term.term}</title>
   ${metaRobots}
+  <link rel="canonical" href="${baseUrl}/${slug}.html">
 </head>
 <body>
   <h1>${term.term}</h1>

--- a/diagnostics.html
+++ b/diagnostics.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Diagnostics</title>
   <link rel="stylesheet" href="styles.css">
+  <link rel="canonical" href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/diagnostics.html">
 </head>
 <body>
   <main class="container">

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "script.js",
   "scripts": {
     "build": "node scripts/build.js",
+    "sitemap": "node scripts/generate-sitemaps.js",
     "test": "html-validate index.html search.html diagnostics.html && node diagnostics.test.js",
     "watch": "chokidar \"**/*.html\" -c \"npm run build\""
   },

--- a/scripts/generate-sitemaps.js
+++ b/scripts/generate-sitemaps.js
@@ -1,0 +1,36 @@
+const fs = require('fs');
+const path = require('path');
+
+const terms = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'terms.json'), 'utf8')).terms;
+const config = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'site.config.json'), 'utf8'));
+
+const siteUrl = config.siteUrl.replace(/\/+$/, '');
+const locales = ['en', 'es', 'fr'];
+
+function slugify(term) {
+  return term
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function buildSitemap(locale) {
+  const localeDir = `${siteUrl}/${locale}`;
+  const urls = terms.map((t) => {
+    const slug = slugify(t.term);
+    const loc = `${localeDir}/terms/${slug}.html`;
+    const alternates = locales
+      .map(
+        (alt) =>
+          `    <xhtml:link rel="alternate" hreflang="${alt}" href="${siteUrl}/${alt}/terms/${slug}.html" />`
+      )
+      .join('\n');
+    return `  <url>\n    <loc>${loc}</loc>\n${alternates}\n  </url>`;
+  });
+
+  const content = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">\n${urls.join('\n')}\n</urlset>`;
+  fs.writeFileSync(path.join(__dirname, '..', `sitemap-${locale}.xml`), content);
+  console.log(`Generated sitemap-${locale}.xml with ${urls.length} entries`);
+}
+
+locales.forEach(buildSitemap);

--- a/search.html
+++ b/search.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Search</title>
   <link rel="stylesheet" href="styles.css">
+  <link rel="canonical" href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/search.html">
 </head>
 <body>
   <main class="container">

--- a/sitemap-en.xml
+++ b/sitemap-en.xml
@@ -1,0 +1,201 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/en/terms/phishing.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/phishing.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/phishing.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/phishing.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/en/terms/phishing-email.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/phishing-email.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/phishing-email.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/phishing-email.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/en/terms/social-engineering-toolkit-set.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/social-engineering-toolkit-set.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/social-engineering-toolkit-set.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/social-engineering-toolkit-set.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/en/terms/advanced-persistent-threat-apt.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/advanced-persistent-threat-apt.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/advanced-persistent-threat-apt.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/advanced-persistent-threat-apt.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/en/terms/cyber-espionage.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/cyber-espionage.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/cyber-espionage.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/cyber-espionage.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/en/terms/zero-knowledge-proof.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/zero-knowledge-proof.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/zero-knowledge-proof.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/zero-knowledge-proof.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/en/terms/security-operations-center-soc.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/security-operations-center-soc.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/security-operations-center-soc.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/security-operations-center-soc.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/en/terms/data-loss-prevention-dlp.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/data-loss-prevention-dlp.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/data-loss-prevention-dlp.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/data-loss-prevention-dlp.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/en/terms/endpoint-security.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/endpoint-security.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/endpoint-security.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/endpoint-security.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/en/terms/security-token.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/security-token.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/security-token.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/security-token.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/en/terms/network-security.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/network-security.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/network-security.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/network-security.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/en/terms/payload.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/payload.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/payload.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/payload.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/en/terms/cryptography.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/cryptography.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/cryptography.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/cryptography.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/en/terms/social-engineering-attack-vectors.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/social-engineering-attack-vectors.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/social-engineering-attack-vectors.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/social-engineering-attack-vectors.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/en/terms/threat-hunting.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/threat-hunting.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/threat-hunting.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/threat-hunting.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/en/terms/incident-response.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/incident-response.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/incident-response.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/incident-response.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/en/terms/privilege-escalation.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/privilege-escalation.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/privilege-escalation.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/privilege-escalation.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/en/terms/security-assessment.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/security-assessment.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/security-assessment.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/security-assessment.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/en/terms/data-encryption-standard-des.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/data-encryption-standard-des.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/data-encryption-standard-des.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/data-encryption-standard-des.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/en/terms/advanced-encryption-standard-aes.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/advanced-encryption-standard-aes.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/advanced-encryption-standard-aes.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/advanced-encryption-standard-aes.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/en/terms/public-key-infrastructure-pki.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/public-key-infrastructure-pki.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/public-key-infrastructure-pki.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/public-key-infrastructure-pki.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/en/terms/certificate-authority-ca.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/certificate-authority-ca.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/certificate-authority-ca.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/certificate-authority-ca.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/en/terms/secure-sockets-layer-ssl.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/secure-sockets-layer-ssl.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/secure-sockets-layer-ssl.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/secure-sockets-layer-ssl.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/en/terms/transport-layer-security-tls.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/transport-layer-security-tls.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/transport-layer-security-tls.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/transport-layer-security-tls.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/en/terms/key-exchange.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/key-exchange.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/key-exchange.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/key-exchange.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/en/terms/malvertising.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/malvertising.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/malvertising.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/malvertising.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/en/terms/eavesdropping.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/eavesdropping.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/eavesdropping.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/eavesdropping.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/en/terms/identity-theft.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/identity-theft.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/identity-theft.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/identity-theft.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/en/terms/zero-day-vulnerability.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/zero-day-vulnerability.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/zero-day-vulnerability.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/zero-day-vulnerability.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/en/terms/security-patch.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/security-patch.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/security-patch.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/security-patch.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/en/terms/cross-site-scripting-xss.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/cross-site-scripting-xss.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/cross-site-scripting-xss.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/cross-site-scripting-xss.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/en/terms/cross-site-request-forgery-csrf.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/cross-site-request-forgery-csrf.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/cross-site-request-forgery-csrf.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/cross-site-request-forgery-csrf.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/en/terms/phishing-email.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/phishing-email.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/phishing-email.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/phishing-email.html" />
+  </url>
+</urlset>

--- a/sitemap-es.xml
+++ b/sitemap-es.xml
@@ -1,0 +1,201 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/es/terms/phishing.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/phishing.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/phishing.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/phishing.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/es/terms/phishing-email.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/phishing-email.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/phishing-email.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/phishing-email.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/es/terms/social-engineering-toolkit-set.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/social-engineering-toolkit-set.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/social-engineering-toolkit-set.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/social-engineering-toolkit-set.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/es/terms/advanced-persistent-threat-apt.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/advanced-persistent-threat-apt.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/advanced-persistent-threat-apt.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/advanced-persistent-threat-apt.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/es/terms/cyber-espionage.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/cyber-espionage.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/cyber-espionage.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/cyber-espionage.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/es/terms/zero-knowledge-proof.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/zero-knowledge-proof.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/zero-knowledge-proof.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/zero-knowledge-proof.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/es/terms/security-operations-center-soc.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/security-operations-center-soc.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/security-operations-center-soc.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/security-operations-center-soc.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/es/terms/data-loss-prevention-dlp.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/data-loss-prevention-dlp.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/data-loss-prevention-dlp.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/data-loss-prevention-dlp.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/es/terms/endpoint-security.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/endpoint-security.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/endpoint-security.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/endpoint-security.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/es/terms/security-token.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/security-token.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/security-token.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/security-token.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/es/terms/network-security.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/network-security.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/network-security.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/network-security.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/es/terms/payload.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/payload.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/payload.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/payload.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/es/terms/cryptography.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/cryptography.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/cryptography.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/cryptography.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/es/terms/social-engineering-attack-vectors.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/social-engineering-attack-vectors.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/social-engineering-attack-vectors.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/social-engineering-attack-vectors.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/es/terms/threat-hunting.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/threat-hunting.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/threat-hunting.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/threat-hunting.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/es/terms/incident-response.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/incident-response.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/incident-response.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/incident-response.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/es/terms/privilege-escalation.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/privilege-escalation.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/privilege-escalation.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/privilege-escalation.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/es/terms/security-assessment.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/security-assessment.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/security-assessment.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/security-assessment.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/es/terms/data-encryption-standard-des.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/data-encryption-standard-des.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/data-encryption-standard-des.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/data-encryption-standard-des.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/es/terms/advanced-encryption-standard-aes.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/advanced-encryption-standard-aes.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/advanced-encryption-standard-aes.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/advanced-encryption-standard-aes.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/es/terms/public-key-infrastructure-pki.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/public-key-infrastructure-pki.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/public-key-infrastructure-pki.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/public-key-infrastructure-pki.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/es/terms/certificate-authority-ca.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/certificate-authority-ca.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/certificate-authority-ca.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/certificate-authority-ca.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/es/terms/secure-sockets-layer-ssl.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/secure-sockets-layer-ssl.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/secure-sockets-layer-ssl.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/secure-sockets-layer-ssl.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/es/terms/transport-layer-security-tls.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/transport-layer-security-tls.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/transport-layer-security-tls.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/transport-layer-security-tls.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/es/terms/key-exchange.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/key-exchange.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/key-exchange.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/key-exchange.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/es/terms/malvertising.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/malvertising.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/malvertising.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/malvertising.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/es/terms/eavesdropping.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/eavesdropping.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/eavesdropping.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/eavesdropping.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/es/terms/identity-theft.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/identity-theft.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/identity-theft.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/identity-theft.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/es/terms/zero-day-vulnerability.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/zero-day-vulnerability.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/zero-day-vulnerability.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/zero-day-vulnerability.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/es/terms/security-patch.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/security-patch.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/security-patch.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/security-patch.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/es/terms/cross-site-scripting-xss.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/cross-site-scripting-xss.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/cross-site-scripting-xss.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/cross-site-scripting-xss.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/es/terms/cross-site-request-forgery-csrf.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/cross-site-request-forgery-csrf.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/cross-site-request-forgery-csrf.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/cross-site-request-forgery-csrf.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/es/terms/phishing-email.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/phishing-email.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/phishing-email.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/phishing-email.html" />
+  </url>
+</urlset>

--- a/sitemap-fr.xml
+++ b/sitemap-fr.xml
@@ -1,0 +1,201 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/fr/terms/phishing.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/phishing.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/phishing.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/phishing.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/fr/terms/phishing-email.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/phishing-email.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/phishing-email.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/phishing-email.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/fr/terms/social-engineering-toolkit-set.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/social-engineering-toolkit-set.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/social-engineering-toolkit-set.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/social-engineering-toolkit-set.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/fr/terms/advanced-persistent-threat-apt.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/advanced-persistent-threat-apt.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/advanced-persistent-threat-apt.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/advanced-persistent-threat-apt.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/fr/terms/cyber-espionage.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/cyber-espionage.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/cyber-espionage.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/cyber-espionage.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/fr/terms/zero-knowledge-proof.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/zero-knowledge-proof.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/zero-knowledge-proof.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/zero-knowledge-proof.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/fr/terms/security-operations-center-soc.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/security-operations-center-soc.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/security-operations-center-soc.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/security-operations-center-soc.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/fr/terms/data-loss-prevention-dlp.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/data-loss-prevention-dlp.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/data-loss-prevention-dlp.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/data-loss-prevention-dlp.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/fr/terms/endpoint-security.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/endpoint-security.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/endpoint-security.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/endpoint-security.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/fr/terms/security-token.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/security-token.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/security-token.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/security-token.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/fr/terms/network-security.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/network-security.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/network-security.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/network-security.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/fr/terms/payload.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/payload.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/payload.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/payload.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/fr/terms/cryptography.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/cryptography.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/cryptography.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/cryptography.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/fr/terms/social-engineering-attack-vectors.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/social-engineering-attack-vectors.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/social-engineering-attack-vectors.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/social-engineering-attack-vectors.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/fr/terms/threat-hunting.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/threat-hunting.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/threat-hunting.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/threat-hunting.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/fr/terms/incident-response.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/incident-response.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/incident-response.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/incident-response.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/fr/terms/privilege-escalation.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/privilege-escalation.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/privilege-escalation.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/privilege-escalation.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/fr/terms/security-assessment.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/security-assessment.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/security-assessment.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/security-assessment.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/fr/terms/data-encryption-standard-des.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/data-encryption-standard-des.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/data-encryption-standard-des.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/data-encryption-standard-des.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/fr/terms/advanced-encryption-standard-aes.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/advanced-encryption-standard-aes.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/advanced-encryption-standard-aes.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/advanced-encryption-standard-aes.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/fr/terms/public-key-infrastructure-pki.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/public-key-infrastructure-pki.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/public-key-infrastructure-pki.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/public-key-infrastructure-pki.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/fr/terms/certificate-authority-ca.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/certificate-authority-ca.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/certificate-authority-ca.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/certificate-authority-ca.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/fr/terms/secure-sockets-layer-ssl.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/secure-sockets-layer-ssl.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/secure-sockets-layer-ssl.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/secure-sockets-layer-ssl.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/fr/terms/transport-layer-security-tls.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/transport-layer-security-tls.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/transport-layer-security-tls.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/transport-layer-security-tls.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/fr/terms/key-exchange.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/key-exchange.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/key-exchange.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/key-exchange.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/fr/terms/malvertising.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/malvertising.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/malvertising.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/malvertising.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/fr/terms/eavesdropping.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/eavesdropping.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/eavesdropping.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/eavesdropping.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/fr/terms/identity-theft.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/identity-theft.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/identity-theft.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/identity-theft.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/fr/terms/zero-day-vulnerability.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/zero-day-vulnerability.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/zero-day-vulnerability.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/zero-day-vulnerability.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/fr/terms/security-patch.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/security-patch.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/security-patch.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/security-patch.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/fr/terms/cross-site-scripting-xss.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/cross-site-scripting-xss.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/cross-site-scripting-xss.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/cross-site-scripting-xss.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/fr/terms/cross-site-request-forgery-csrf.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/cross-site-request-forgery-csrf.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/cross-site-request-forgery-csrf.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/cross-site-request-forgery-csrf.html" />
+  </url>
+  <url>
+    <loc>https://<username>.github.io/cybersec-dictionary/fr/terms/phishing-email.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://<username>.github.io/cybersec-dictionary/en/terms/phishing-email.html" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://<username>.github.io/cybersec-dictionary/es/terms/phishing-email.html" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://<username>.github.io/cybersec-dictionary/fr/terms/phishing-email.html" />
+  </url>
+</urlset>

--- a/templates/about.html
+++ b/templates/about.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <title>About</title>
+  <link rel="canonical" href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/templates/about.html">
 </head>
 <body>
   <h1>About this project</h1>

--- a/templates/contribute.html
+++ b/templates/contribute.html
@@ -6,6 +6,7 @@
   <title>Contributing - Cyber Security Dictionary</title>
   <link rel="stylesheet" href="../styles.css">
   <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="canonical" href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/templates/contribute.html">
 </head>
 <body>
   <main class="container">

--- a/templates/guidelines.html
+++ b/templates/guidelines.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Definition Guidelines</title>
   <link rel="stylesheet" href="../styles.css">
+  <link rel="canonical" href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/templates/guidelines.html">
 </head>
 <body>
   <main class="container">


### PR DESCRIPTION
## Summary
- add `generate-sitemaps.js` to build per-locale sitemaps with hreflang alternates
- expose npm `sitemap` script
- include canonical tags on search, diagnostics, templates and generated term pages

## Testing
- `npm run sitemap`
- `npm test`
- `curl -I "https://www.google.com/ping?sitemap=https://example.com/sitemap-en.xml"`
- `curl https://www.googleapis.com/webmasters/v3/sites` *(fails: Request is missing required authentication credential)*

------
https://chatgpt.com/codex/tasks/task_e_68b58dd487288328b8e2786d6866d985