### PR TITLE
feat: add chat hook with abort and retry

### DIFF
--- a/assets/js/chat-app.js
+++ b/assets/js/chat-app.js
@@ -1,0 +1,34 @@
+import { useChat } from "./useChat.js";
+
+const chat = useChat({ endpoint: "/api/chat" });
+
+const listEl = document.getElementById("chat-messages");
+const inputEl = document.getElementById("chat-input");
+const sendBtn = document.getElementById("send");
+const stopBtn = document.getElementById("stop");
+const regenBtn = document.getElementById("regen");
+
+chat.subscribe((messages) => {
+  listEl.innerHTML = "";
+  messages.forEach((m) => {
+    const li = document.createElement("li");
+    li.className = `msg-${m.role}`;
+    li.textContent = `${m.role}: ${m.content}`;
+    listEl.appendChild(li);
+  });
+  listEl.scrollTop = listEl.scrollHeight;
+});
+
+sendBtn.addEventListener("click", async () => {
+  const msg = inputEl.value.trim();
+  if (!msg) return;
+  inputEl.value = "";
+  try {
+    await chat.send(msg);
+  } catch (err) {
+    console.error(err);
+  }
+});
+
+stopBtn.addEventListener("click", () => chat.stop());
+regenBtn.addEventListener("click", () => chat.regenerate());

--- a/assets/js/useChat.js
+++ b/assets/js/useChat.js
@@ -1,0 +1,90 @@
+export function useChat({
+  endpoint = "/api/chat",
+  maxRetries = 2,
+  retryDelay = 500,
+  throttleMs = 100,
+} = {}) {
+  const state = { messages: [] };
+  let controller = null;
+  const listeners = new Set();
+  let throttleTimeout = null;
+
+  function notify() {
+    if (throttleTimeout) return;
+    throttleTimeout = setTimeout(() => {
+      throttleTimeout = null;
+      const snapshot = state.messages.slice();
+      listeners.forEach((fn) => fn(snapshot));
+    }, throttleMs);
+  }
+
+  function subscribe(fn) {
+    listeners.add(fn);
+    fn(state.messages.slice());
+    return () => listeners.delete(fn);
+  }
+
+  async function performRequest(message, retriesLeft) {
+    controller = new AbortController();
+    try {
+      const res = await fetch(endpoint, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ message }),
+        signal: controller.signal,
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = await res.json();
+      state.messages.push({ role: "assistant", content: data.reply });
+      notify();
+      controller = null;
+      return data;
+    } catch (err) {
+      if (err.name === "AbortError") {
+        state.messages.push({ role: "system", content: "Request aborted" });
+        notify();
+        controller = null;
+        throw err;
+      }
+      if (retriesLeft > 0) {
+        await new Promise((r) => setTimeout(r, retryDelay));
+        return performRequest(message, retriesLeft - 1);
+      }
+      state.messages.push({ role: "error", content: err.message });
+      notify();
+      controller = null;
+      throw err;
+    }
+  }
+
+  async function send(message, { retries = maxRetries } = {}) {
+    state.messages.push({ role: "user", content: message });
+    notify();
+    return performRequest(message, retries);
+  }
+
+  function stop() {
+    if (controller) {
+      controller.abort();
+    }
+  }
+
+  function regenerate() {
+    const lastUser = [...state.messages]
+      .reverse()
+      .find((m) => m.role === "user");
+    if (lastUser) {
+      return send(lastUser.content);
+    }
+  }
+
+  return {
+    send,
+    stop,
+    regenerate,
+    subscribe,
+    get messages() {
+      return state.messages.slice();
+    },
+  };
+}

--- a/chat.html
+++ b/chat.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Chat</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <main class="container">
+    <h1>Chat</h1>
+    <ul id="chat-messages"></ul>
+    <input id="chat-input" type="text" placeholder="Type a message">
+    <button id="send" type="button">Send</button>
+    <button id="stop" type="button">Stop</button>
+    <button id="regen" type="button">Regenerate</button>
+  </main>
+  <script type="module" src="assets/js/chat-app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `useChat` hook with abort signal support, retry logic and throttled updates
- wire up chat UI with Stop and Regenerate controls
- create standalone chat page using new hook

## Testing
- `npm test`
- `npx html-validate chat.html`

------
https://chatgpt.com/codex/tasks/task_e_68b58ddde4f88328a3362a00484d2260