### PR TITLE
Stream retrieval sources ahead of model output

### DIFF
--- a/assets/js/streaming.js
+++ b/assets/js/streaming.js
@@ -1,0 +1,27 @@
+window.addEventListener('DOMContentLoaded', () => {
+  const output = document.getElementById('model-output');
+  const sourcesList = document.getElementById('sources-list');
+  if (!output || !sourcesList) {
+    return;
+  }
+
+  const evtSource = new EventSource('/api/stream');
+
+  evtSource.addEventListener('source', (e) => {
+    const data = JSON.parse(e.data);
+    const li = document.createElement('li');
+    const link = document.createElement('a');
+    link.href = data.url;
+    link.textContent = data.title || data.url;
+    li.appendChild(link);
+    sourcesList.appendChild(li);
+  });
+
+  evtSource.addEventListener('token', (e) => {
+    output.textContent += e.data;
+  });
+
+  evtSource.addEventListener('end', () => {
+    evtSource.close();
+  });
+});

--- a/index.html
+++ b/index.html
@@ -24,6 +24,10 @@
 
     <ul id="terms-list"></ul>
   </main>
+  <div id="model-output" aria-live="polite"></div>
+  <aside id="sources-sidebar" aria-label="Sources">
+    <ul id="sources-list"></ul>
+  </aside>
   <footer class="container" aria-label="Contribute">
     <p><a href="templates/contribute.html">Contribute</a></p>
   </footer>
@@ -33,6 +37,7 @@
     <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
   </footer>
   <script src="script.js"></script>
+  <script src="assets/js/streaming.js"></script>
   <script src="assets/js/app.js"></script>
   <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
   <script src="assets/js/metrics.js"></script>

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "node scripts/build.js",
     "test": "html-validate index.html search.html diagnostics.html && node diagnostics.test.js",
-    "watch": "chokidar \"**/*.html\" -c \"npm run build\""
+    "watch": "chokidar \"**/*.html\" -c \"npm run build\"",
+    "start": "node server.js"
   },
   "keywords": [],
   "author": "",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,47 @@
+const http = require('http');
+
+const server = http.createServer((req, res) => {
+  if (req.url === '/api/stream') {
+    res.writeHead(200, {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+      'Access-Control-Allow-Origin': '*',
+    });
+
+    // Simulated retrieval sources streamed before text output
+    const sources = [
+      { title: 'NIST Glossary', url: 'https://www.nist.gov/itl/applied-cybersecurity/nice/resources/glossary' },
+      { title: 'Wikipedia', url: 'https://en.wikipedia.org/wiki/Cybersecurity' },
+    ];
+
+    sources.forEach((src, idx) => {
+      setTimeout(() => {
+        res.write(`event: source\ndata: ${JSON.stringify(src)}\n\n`);
+      }, idx * 100);
+    });
+
+    // Begin text streaming shortly after the first source is sent
+    const text = 'Streaming definition content from the model.';
+    let i = 0;
+    setTimeout(() => {
+      const interval = setInterval(() => {
+        if (i < text.length) {
+          res.write(`event: token\ndata: ${text[i]}\n\n`);
+          i++;
+        } else {
+          clearInterval(interval);
+          res.write('event: end\ndata: [DONE]\n\n');
+          res.end();
+        }
+      }, 50);
+    }, 20);
+  } else {
+    res.writeHead(404);
+    res.end();
+  }
+});
+
+server.listen(3000, () => {
+  console.log('Streaming server running on http://localhost:3000');
+});

--- a/styles.css
+++ b/styles.css
@@ -316,6 +316,29 @@ body.dark-mode #alpha-nav button {
   color: #fff;
 }
 
+/* Streaming output and sources sidebar */
+#model-output {
+  min-height: 50px;
+  margin: 20px;
+}
+
+#sources-sidebar {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: 200px;
+  height: 100%;
+  overflow-y: auto;
+  background: #f9f9f9;
+  border-left: 1px solid #ccc;
+  padding: 10px;
+}
+
+body.dark-mode #sources-sidebar {
+  background: #1e1e1e;
+  border-left-color: #333;
+}
+
 body.dark-mode #alpha-nav button:hover,
 body.dark-mode #alpha-nav button:focus {
   background-color: #555;


### PR DESCRIPTION
## Summary
- Stream SSE sources before model tokens and finish signal
- Sidebar updates with sources while text tokens stream independently
- Add start script and basic styles for streaming components

## Testing
- `npm test`
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_68b58ddbe6a08328b28ff8320bb5af09