### PR TITLE
Add streaming progress demo using createStreamableValue

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "node scripts/build.js",
     "test": "html-validate index.html search.html diagnostics.html && node diagnostics.test.js",
-    "watch": "chokidar \"**/*.html\" -c \"npm run build\""
+    "watch": "chokidar \"**/*.html\" -c \"npm run build\"",
+    "start": "node stream-server.mjs"
   },
   "keywords": [],
   "author": "",
@@ -16,7 +17,7 @@
     "html-validate": "^10.0.0",
     "http-server": "^14.1.1",
     "js-yaml": "^4.1.0",
-    "prettier": "^3.6.2",
-    "jsdom": "^26.1.0"
+    "jsdom": "^26.1.0",
+    "prettier": "^3.6.2"
   }
 }

--- a/progress.html
+++ b/progress.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Streaming Progress Demo</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <main class="container">
+    <h1>Streaming Progress Demo</h1>
+    <button id="start-progress" type="button">Start Long Task</button>
+    <ul id="progress-list" aria-live="polite"></ul>
+  </main>
+  <script type="module" src="progress.js"></script>
+</body>
+</html>
+

--- a/progress.js
+++ b/progress.js
@@ -1,0 +1,25 @@
+const button = document.getElementById('start-progress');
+const list = document.getElementById('progress-list');
+
+button.addEventListener('click', async () => {
+  list.innerHTML = '';
+  const response = await fetch('/api/progress');
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split('\n');
+    buffer = lines.pop();
+    for (const line of lines) {
+      if (line.startsWith('data: ')) {
+        const item = document.createElement('li');
+        item.textContent = line.replace(/^data: /, '').trim();
+        list.appendChild(item);
+      }
+    }
+  }
+});
+

--- a/stream-server.mjs
+++ b/stream-server.mjs
@@ -1,0 +1,69 @@
+import http from 'http';
+import { readFile } from 'fs/promises';
+import { extname, join } from 'path';
+
+function createStreamableValue(initial) {
+  let controller;
+  const stream = new ReadableStream({
+    start(c) {
+      controller = c;
+      if (initial !== undefined) c.enqueue(initial);
+    }
+  });
+  return {
+    value: stream,
+    update(v) {
+      controller.enqueue(v);
+    },
+    done(v) {
+      if (v !== undefined) controller.enqueue(v);
+      controller.close();
+    }
+  };
+}
+
+const server = http.createServer(async (req, res) => {
+  if (req.url === '/api/progress') {
+    res.writeHead(200, {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+    });
+
+    const stream = createStreamableValue();
+
+    (async () => {
+      const steps = ['Starting task', 'Halfway there', 'Almost done'];
+      for (const step of steps) {
+        stream.update(step);
+        await new Promise((r) => setTimeout(r, 1000));
+      }
+      stream.done('Task complete');
+    })();
+
+    for await (const chunk of stream.value) {
+      res.write(`data: ${chunk}\n\n`);
+    }
+    res.end();
+    return;
+  }
+
+  let filePath = req.url === '/' ? 'index.html' : req.url.slice(1);
+  try {
+    const ext = extname(filePath);
+    let contentType = 'text/html';
+    if (ext === '.js') contentType = 'application/javascript';
+    else if (ext === '.css') contentType = 'text/css';
+    const data = await readFile(join(process.cwd(), filePath));
+    res.writeHead(200, { 'Content-Type': contentType });
+    res.end(data);
+  } catch (err) {
+    res.writeHead(404);
+    res.end('Not found');
+  }
+});
+
+server.listen(3000, () => {
+  console.log('Server listening on http://localhost:3000');
+});
+


### PR DESCRIPTION
## Summary
- add server with `createStreamableValue` to stream long task progress
- add demo page and script that display live progress updates
- expose npm start script for running the streaming demo

## Testing
- `npm test`
- `npm start` followed by `curl -N http://localhost:3000/api/progress`


------
https://chatgpt.com/codex/tasks/task_e_68b58ddf22c883289048406015893473