### PR TITLE
feat: add citation links for term responses

### DIFF
--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -1,75 +1,86 @@
-(function(){
-  const resultsContainer = document.getElementById('results');
-  const searchInput = document.getElementById('search-box');
+(function () {
+  const resultsContainer = document.getElementById("results");
+  const searchInput = document.getElementById("search-box");
   let terms = [];
+  const externalSourceMap = {
+    NVD: "https://nvd.nist.gov/",
+    "OWASP Top 10": "https://owasp.org/www-project-top-ten/",
+  };
 
-  document.addEventListener('DOMContentLoaded', () => {
-    const baseUrl = window.__BASE_URL__ || '';
+  document.addEventListener("DOMContentLoaded", () => {
+    const baseUrl = window.__BASE_URL__ || "";
     fetch(`${baseUrl}/terms.json`)
-      .then(r => r.ok ? r.json() : Promise.reject(r.statusText))
-      .then(data => {
+      .then((r) => (r.ok ? r.json() : Promise.reject(r.statusText)))
+      .then((data) => {
         // terms.json may either be an array or object with terms property
-        terms = Array.isArray(data) ? data : (data.terms || []);
+        terms = Array.isArray(data) ? data : data.terms || [];
+        terms.forEach((t) => {
+          const name = t.name || t.term || "";
+          t.url = `${baseUrl}/#${encodeURIComponent(name)}`;
+          if (externalSourceMap[name]) {
+            t.sources = [externalSourceMap[name]];
+          }
+        });
       })
-      .catch(err => {
-        console.error('Failed to load terms.json', err);
+      .catch((err) => {
+        console.error("Failed to load terms.json", err);
       });
 
-    searchInput.addEventListener('input', handleSearch);
+    searchInput.addEventListener("input", handleSearch);
   });
 
-  function handleSearch(){
+  function handleSearch() {
     const query = searchInput.value.trim().toLowerCase();
-    resultsContainer.innerHTML = '';
-    if(!query){
+    resultsContainer.innerHTML = "";
+    if (!query) {
       return;
     }
     const matches = terms
-      .map(term => ({ term, score: score(term, query) }))
-      .filter(item => item.score > 0)
-      .sort((a,b) => b.score - a.score);
+      .map((term) => ({ term, score: score(term, query) }))
+      .filter((item) => item.score > 0)
+      .sort((a, b) => b.score - a.score);
 
     matches.forEach(({ term }) => {
       resultsContainer.appendChild(renderCard(term));
     });
   }
 
-  function score(term, query){
+  function score(term, query) {
     let s = 0;
-    const name = (term.name || term.term || '').toLowerCase();
-    const def = (term.definition || '').toLowerCase();
-    const category = (term.category || '').toLowerCase();
-    const syns = (term.synonyms || []).map(s=>s.toLowerCase());
-    if(name.includes(query)) s += 3;
-    if(def.includes(query)) s += 1;
-    if(category.includes(query)) s += 1;
-    if(syns.some(syn => syn.includes(query))) s += 2;
+    const name = (term.name || term.term || "").toLowerCase();
+    const def = (term.definition || "").toLowerCase();
+    const category = (term.category || "").toLowerCase();
+    const syns = (term.synonyms || []).map((s) => s.toLowerCase());
+    if (name.includes(query)) s += 3;
+    if (def.includes(query)) s += 1;
+    if (category.includes(query)) s += 1;
+    if (syns.some((syn) => syn.includes(query))) s += 2;
     return s;
   }
 
-  function renderCard(term){
-    const card = document.createElement('div');
-    card.className = 'result-card';
+  function renderCard(term) {
+    const card = document.createElement("div");
+    card.className = "result-card";
 
-    const title = document.createElement('h3');
-    title.textContent = term.name || term.term || '';
+    const title = document.createElement("h3");
+    title.textContent = term.name || term.term || "";
     card.appendChild(title);
 
-    if(term.category){
-      const cat = document.createElement('p');
-      cat.className = 'category';
+    if (term.category) {
+      const cat = document.createElement("p");
+      cat.className = "category";
       cat.textContent = term.category;
       card.appendChild(cat);
     }
 
-    const def = document.createElement('p');
-    def.textContent = term.definition || '';
+    const def = document.createElement("p");
+    def.textContent = term.definition || "";
     card.appendChild(def);
 
-    if(term.synonyms && term.synonyms.length){
-      const syn = document.createElement('p');
-      syn.className = 'synonyms';
-      syn.textContent = `Synonyms: ${term.synonyms.join(', ')}`;
+    if (term.synonyms && term.synonyms.length) {
+      const syn = document.createElement("p");
+      syn.className = "synonyms";
+      syn.textContent = `Synonyms: ${term.synonyms.join(", ")}`;
       card.appendChild(syn);
     }
     return card;

--- a/script.js
+++ b/script.js
@@ -5,9 +5,15 @@ const randomButton = document.getElementById("random-term");
 const alphaNav = document.getElementById("alpha-nav");
 const darkModeToggle = document.getElementById("dark-mode-toggle");
 const showFavoritesToggle = document.getElementById("show-favorites");
-const favorites = new Set(JSON.parse(localStorage.getItem("favorites") || "[]"));
+const favorites = new Set(
+  JSON.parse(localStorage.getItem("favorites") || "[]"),
+);
 const siteUrl = "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/";
 const canonicalLink = document.getElementById("canonical-link");
+const externalSourceMap = {
+  NVD: "https://nvd.nist.gov/",
+  "OWASP Top 10": "https://owasp.org/www-project-top-ten/",
+};
 
 let currentLetterFilter = "All";
 let termsData = { terms: [] };
@@ -19,7 +25,10 @@ if (localStorage.getItem("darkMode") === "true") {
 if (darkModeToggle) {
   darkModeToggle.addEventListener("click", () => {
     document.body.classList.toggle("dark-mode");
-    localStorage.setItem("darkMode", document.body.classList.contains("dark-mode"));
+    localStorage.setItem(
+      "darkMode",
+      document.body.classList.contains("dark-mode"),
+    );
   });
 }
 
@@ -38,14 +47,17 @@ function loadTerms() {
     .then((data) => {
       termsData = data;
       removeDuplicateTermsAndDefinitions();
+      attachUrlsAndSources();
       termsData.terms.sort((a, b) => a.term.localeCompare(b.term));
       buildAlphaNav();
       populateTermsList();
 
       if (window.location.hash) {
-        const termFromHash = decodeURIComponent(window.location.hash.substring(1));
+        const termFromHash = decodeURIComponent(
+          window.location.hash.substring(1),
+        );
         const matchedTerm = termsData.terms.find(
-          (t) => t.term.toLowerCase() === termFromHash.toLowerCase()
+          (t) => t.term.toLowerCase() === termFromHash.toLowerCase(),
         );
         if (matchedTerm) {
           displayDefinition(matchedTerm);
@@ -56,7 +68,7 @@ function loadTerms() {
       console.error("Detailed error fetching data:", error);
       definitionContainer.style.display = "block";
       definitionContainer.innerHTML =
-        '<p>Unable to load dictionary data. Please check your connection and try again.</p>' +
+        "<p>Unable to load dictionary data. Please check your connection and try again.</p>" +
         '<button id="retry-fetch">Retry</button>';
       const retryBtn = document.getElementById("retry-fetch");
       if (retryBtn) {
@@ -83,6 +95,32 @@ function removeDuplicateTermsAndDefinitions() {
   termsData.terms = uniqueTermsData;
 }
 
+function attachUrlsAndSources() {
+  termsData.terms.forEach((term) => {
+    term.url = `${siteUrl}#${encodeURIComponent(term.term)}`;
+    if (externalSourceMap[term.term]) {
+      term.sources = [externalSourceMap[term.term]];
+    }
+  });
+}
+
+function formatDefinition(term) {
+  const citations = [];
+  if (term.url) {
+    citations.push(term.url);
+  }
+  if (term.sources) {
+    citations.push(...term.sources);
+  }
+  if (!citations.length) {
+    return `<h3>${term.term}</h3><p>${term.definition}</p>`;
+  }
+  const citationLinks = citations
+    .map((url, i) => `<a href="${url}" target="_blank">[${i + 1}]</a>`)
+    .join(" ");
+  return `<h3>${term.term}</h3><p>${term.definition} <span class="citations">${citationLinks}</span></p>`;
+}
+
 function toggleFavorite(term) {
   if (favorites.has(term)) {
     favorites.delete(term);
@@ -97,12 +135,16 @@ function toggleFavorite(term) {
 }
 
 function highlightActiveButton(button) {
-  alphaNav.querySelectorAll("button").forEach((btn) => btn.classList.remove("active"));
+  alphaNav
+    .querySelectorAll("button")
+    .forEach((btn) => btn.classList.remove("active"));
   button.classList.add("active");
 }
 
 function buildAlphaNav() {
-  const letters = Array.from(new Set(termsData.terms.map((t) => t.term.charAt(0).toUpperCase()))).sort();
+  const letters = Array.from(
+    new Set(termsData.terms.map((t) => t.term.charAt(0).toUpperCase())),
+  ).sort();
 
   const allButton = document.createElement("button");
   allButton.textContent = "All";
@@ -134,9 +176,13 @@ function populateTermsList() {
     .sort((a, b) => a.term.localeCompare(b.term))
     .forEach((item) => {
       const matchesSearch = item.term.toLowerCase().includes(searchValue);
-      const matchesFavorites = !showFavoritesToggle || !showFavoritesToggle.checked || favorites.has(item.term);
+      const matchesFavorites =
+        !showFavoritesToggle ||
+        !showFavoritesToggle.checked ||
+        favorites.has(item.term);
       const matchesLetter =
-        currentLetterFilter === "All" || item.term.charAt(0).toUpperCase() === currentLetterFilter;
+        currentLetterFilter === "All" ||
+        item.term.charAt(0).toUpperCase() === currentLetterFilter;
       if (matchesSearch && matchesFavorites && matchesLetter) {
         const termDiv = document.createElement("div");
         termDiv.classList.add("dictionary-item");
@@ -182,32 +228,37 @@ function populateTermsList() {
 
 function displayDefinition(term) {
   definitionContainer.style.display = "block";
-  definitionContainer.innerHTML = `<h3>${term.term}</h3><p>${term.definition}</p>`;
+  definitionContainer.innerHTML = formatDefinition(term);
   window.location.hash = encodeURIComponent(term.term);
   if (canonicalLink) {
-    canonicalLink.setAttribute(
-      "href",
-      `${siteUrl}#${encodeURIComponent(term.term)}`
-    );
+    canonicalLink.setAttribute("href", term.url);
   }
 }
 
 function clearDefinition() {
   definitionContainer.style.display = "none";
   definitionContainer.innerHTML = "";
-  history.replaceState(null, "", window.location.pathname + window.location.search);
+  history.replaceState(
+    null,
+    "",
+    window.location.pathname + window.location.search,
+  );
   if (canonicalLink) {
     canonicalLink.setAttribute("href", siteUrl);
   }
 }
 
 function showRandomTerm() {
-  const randomTerm = termsData.terms[Math.floor(Math.random() * termsData.terms.length)];
+  const randomTerm =
+    termsData.terms[Math.floor(Math.random() * termsData.terms.length)];
   displayDefinition(randomTerm);
 
   const today = new Date().toDateString();
   try {
-    localStorage.setItem("lastRandomTerm", JSON.stringify({ date: today, term: randomTerm }));
+    localStorage.setItem(
+      "lastRandomTerm",
+      JSON.stringify({ date: today, term: randomTerm }),
+    );
   } catch (e) {
     // Ignore storage errors
   }
@@ -249,8 +300,7 @@ window.addEventListener("scroll", () => {
   scrollBtn.style.display = window.scrollY > 200 ? "block" : "none";
 });
 scrollBtn.addEventListener("click", () =>
-  window.scrollTo({ top: 0, behavior: "smooth" })
+  window.scrollTo({ top: 0, behavior: "smooth" }),
 );
 
 definitionContainer.addEventListener("click", clearDefinition);
-


### PR DESCRIPTION
## Summary
- enrich term data with links to dictionary pages and external NIST/OWASP sources
- format responses with inline clickable citations
- include target URLs in search retrieval data

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b58de31ab08328bc75cb7ec6157597