### PR TITLE
Add learn path chat feature

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,18 @@
     <label for="show-favorites">Show Favorites</label>
 
     <ul id="terms-list"></ul>
+
+    <div id="chat-ui">
+      <div id="messages" aria-live="polite"></div>
+      <label class="learn-path-label">
+        <input type="checkbox" id="learn-path-toggle">
+        Learn Path
+      </label>
+      <div class="chat-input">
+        <input type="text" id="chat-input" placeholder="Type a message..." aria-label="Chat input">
+        <button id="send-btn" type="button">Send</button>
+      </div>
+    </div>
   </main>
   <footer class="container" aria-label="Contribute">
     <p><a href="templates/contribute.html">Contribute</a></p>

--- a/script.js
+++ b/script.js
@@ -254,3 +254,82 @@ scrollBtn.addEventListener("click", () =>
 
 definitionContainer.addEventListener("click", clearDefinition);
 
+// Chat UI and Learn Path feature
+const chatInput = document.getElementById("chat-input");
+const sendBtn = document.getElementById("send-btn");
+const messagesContainer = document.getElementById("messages");
+const learnPathToggle = document.getElementById("learn-path-toggle");
+
+const learnPathSteps = [
+  "Understand basic cybersecurity concepts",
+  "Explore network security fundamentals",
+  "Dive into encryption and cryptography",
+  "Study application security and secure coding",
+  "Investigate incident response and forensics"
+];
+
+let learnPathProgress = parseInt(localStorage.getItem("learnPathProgress"), 10);
+if (isNaN(learnPathProgress)) {
+  learnPathProgress = 0;
+}
+
+function displayMessage(text, type) {
+  const div = document.createElement("div");
+  div.classList.add("message", type);
+  div.textContent = text;
+  if (messagesContainer) {
+    messagesContainer.appendChild(div);
+    messagesContainer.scrollTop = messagesContainer.scrollHeight;
+  }
+}
+
+function showCurrentStep() {
+  if (learnPathProgress < learnPathSteps.length) {
+    displayMessage(
+      `Step ${learnPathProgress + 1}: ${learnPathSteps[learnPathProgress]}`,
+      "system"
+    );
+  } else {
+    displayMessage("Learn path completed!", "system");
+    localStorage.removeItem("learnPathProgress");
+    if (learnPathToggle) {
+      learnPathToggle.checked = false;
+    }
+  }
+}
+
+if (learnPathToggle) {
+  learnPathToggle.addEventListener("change", () => {
+    if (learnPathToggle.checked) {
+      showCurrentStep();
+    }
+  });
+}
+
+if (sendBtn) {
+  sendBtn.addEventListener("click", () => {
+    const msg = chatInput.value.trim();
+    if (!msg) return;
+    displayMessage(msg, "user");
+    chatInput.value = "";
+
+    if (learnPathToggle && learnPathToggle.checked) {
+      learnPathProgress++;
+      localStorage.setItem("learnPathProgress", learnPathProgress);
+      showCurrentStep();
+    }
+  });
+}
+
+if (
+  learnPathToggle &&
+  learnPathProgress > 0 &&
+  learnPathProgress < learnPathSteps.length
+) {
+  learnPathToggle.checked = true;
+  displayMessage(
+    `Resuming step ${learnPathProgress + 1}: ${learnPathSteps[learnPathProgress]}`,
+    "system"
+  );
+}
+

--- a/styles.css
+++ b/styles.css
@@ -347,3 +347,28 @@ body.dark-mode #alpha-nav button.active {
     font-size: 14px;
   }
 }
+
+#chat-ui {
+  border: 1px solid #ccc;
+  padding: 1em;
+  margin-top: 1em;
+}
+
+#chat-ui #messages {
+  max-height: 200px;
+  overflow-y: auto;
+  margin-bottom: 1em;
+}
+
+#chat-ui .message {
+  margin: 0.5em 0;
+}
+
+#chat-ui .message.system {
+  color: #006400;
+}
+
+#chat-ui .message.user {
+  color: #00008b;
+  text-align: right;
+}


### PR DESCRIPTION
## Summary
- add chat interface with Learn Path toggle
- persist Learn Path progress in localStorage and resume unfinished paths
- style chat messages and container

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b58de4531483288f587bc8740da53b