### PR TITLE
Add security headers middleware and documentation

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,12 @@
+# Security Headers
+
+The API routes are protected by middleware that adds several security headers:
+
+- **Strict-Transport-Security**: `max-age=63072000; includeSubDomains; preload` enforces HTTPS with HSTS.
+- **X-DNS-Prefetch-Control**: `off` disables DNS prefetching to prevent information leakage.
+- **CORS**: Only requests from `https://alex-unnippillil.github.io` are allowed.
+  - `Access-Control-Allow-Methods`: `GET,POST,OPTIONS`
+  - `Access-Control-Allow-Headers`: `Content-Type, Authorization`
+  - Preflight requests receive a `204` response.
+
+Run [securityheaders.com](https://securityheaders.com/) after deployment to confirm the site scores grade **A**.

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+// Define the allowed origin for CORS
+const allowedOrigin = process.env.ALLOWED_ORIGIN || 'https://alex-unnippillil.github.io';
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+  const origin = request.headers.get('origin');
+
+  // Only apply headers to API routes
+  if (pathname.startsWith('/api')) {
+    // Enforce strict CORS policy
+    if (origin && origin !== allowedOrigin) {
+      return new NextResponse(null, { status: 403 });
+    }
+
+    const response = NextResponse.next();
+
+    response.headers.set('Strict-Transport-Security', 'max-age=63072000; includeSubDomains; preload');
+    response.headers.set('X-DNS-Prefetch-Control', 'off');
+    response.headers.set('Access-Control-Allow-Origin', allowedOrigin);
+    response.headers.set('Access-Control-Allow-Methods', 'GET,POST,OPTIONS');
+    response.headers.set('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+    response.headers.set('Vary', 'Origin');
+
+    // Handle preflight requests
+    if (request.method === 'OPTIONS') {
+      return new NextResponse(null, {
+        status: 204,
+        headers: response.headers,
+      });
+    }
+
+    return response;
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: '/api/:path*',
+};


### PR DESCRIPTION
## Summary
- add middleware for API routes enforcing HSTS, DNS prefetch control, and strict CORS
- document security header configuration

## Testing
- `npm test`
- `curl https://securityheaders.com/?q=https://alex-unnippillil.github.io/CyberSecuirtyDictionary/&followRedirects=on&hide=on`

------
https://chatgpt.com/codex/tasks/task_e_68b58de826548328a747cf2a2421802d