### PR TITLE
feat: add CSP nonce middleware and report handling

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,51 @@
+import crypto from 'crypto';
+import type { Request, Response, NextFunction } from 'express';
+
+/**
+ * Middleware that generates a nonce for each request and applies a
+ * Content-Security-Policy header. The nonce is exposed through both a
+ * response header and `res.locals` so that downstream handlers or
+ * templates can apply it to inline scripts.
+ */
+export function cspNonceMiddleware(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void {
+  const nonce = crypto.randomBytes(16).toString('base64');
+  // Make the nonce available to templates
+  (res.locals as any).nonce = nonce;
+  // Also expose the nonce via a response header
+  res.setHeader('X-CSP-Nonce', nonce);
+
+  const directives = [
+    "default-src 'self'",
+    `script-src 'self' 'nonce-${nonce}'`,
+    "style-src 'self' 'unsafe-inline'",
+    "object-src 'none'",
+    "base-uri 'none'",
+    "report-uri /csp-report"
+  ].join('; ');
+
+  // Start in report-only mode so violations are logged without blocking.
+  // Once the site reports zero violations this can be flipped to enforce
+  // the policy by setting the `CSP_ENFORCE` environment variable.
+  if (process.env.CSP_ENFORCE === 'true') {
+    res.setHeader('Content-Security-Policy', directives);
+  } else {
+    res.setHeader('Content-Security-Policy-Report-Only', directives);
+  }
+
+  next();
+}
+
+/**
+ * Endpoint to receive CSP violation reports. It simply logs the report so
+ * that administrators can monitor for any unexpected resource loads.
+ */
+export function cspReportLogger(req: Request, res: Response): void {
+  console.log('CSP Violation Report:', req.body);
+  res.status(204).end();
+}
+
+export default cspNonceMiddleware;

--- a/search.html
+++ b/search.html
@@ -12,7 +12,7 @@
     <input id="search-box" type="text" placeholder="Search terms...">
     <div id="results"></div>
   </main>
-  <script>
+  <script nonce="__CSP_NONCE__">
     window.__BASE_URL__ = window.__BASE_URL__ || '';
   </script>
   <script src="assets/js/search.js"></script>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -22,11 +22,11 @@
   <link rel="icon" href="{{ favicon_url }}" />
   <link rel="stylesheet" href="{{ stylesheet_url }}" />
 
-  <script>
+  <script nonce="__CSP_NONCE__">
     const BASE_URL = "{{ base_url }}";
   </script>
 
-  <script type="application/ld+json">
+  <script nonce="__CSP_NONCE__" type="application/ld+json">
     {{ json_ld }}
   </script>
 </head>


### PR DESCRIPTION
## Summary
- add middleware to inject per-request CSP nonces and toggle report-only vs enforcement
- log CSP violation reports via dedicated handler
- include nonce attribute on inline scripts so CSP can permit them

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b58de6b49883289db6ac4ba6e9d675