### PR TITLE
chore: add secret scanning and rotation docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 node_modules/
+
+# Local environment variables
+.env

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.18.1
+    hooks:
+      - id: gitleaks

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,4 +8,13 @@ If you believe you've found a security vulnerability in this project, please ema
 
 We will acknowledge your report within 48 hours, investigate, and take appropriate action. Please avoid public disclosure until we've addressed the issue.
 
+
+## Secret and API Key Rotation
+
+- Generate new API keys through your provider's dashboard.
+- Update the local `.env` file or secret manager with the new keys.
+- Redeploy the application so it uses the rotated keys.
+- Revoke old keys to prevent unauthorized use.
+- Run `pre-commit run --all-files` to verify no secrets are committed.
+
 Thanks for helping keep our project secure.


### PR DESCRIPTION
## Summary
- ignore `.env` to prevent committing secrets
- document API key rotation steps in `SECURITY.md`
- configure gitleaks pre-commit hook for secret scanning

## Testing
- `pre-commit run --all-files`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b58deadbac83289362f2ab88a4d56a