### PR TITLE
feat: add comparison page with diff highlighting

### DIFF
--- a/app/compare/[a]-vs-[b]/page.module.css
+++ b/app/compare/[a]-vs-[b]/page.module.css
@@ -1,0 +1,35 @@
+.controls {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.compareGrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+.callout {
+  position: relative;
+  animation: fadeIn 0.3s ease-out;
+  padding: 0.1rem;
+  border-radius: 0.25rem;
+}
+
+.diff {
+  background: rgba(255, 99, 132, 0.3);
+}
+
+.same {
+  background: rgba(75, 192, 192, 0.3);
+}
+
+@keyframes fadeIn {
+  from {
+    background-color: transparent;
+  }
+  to {
+    background-color: inherit;
+  }
+}

--- a/app/compare/[a]-vs-[b]/page.tsx
+++ b/app/compare/[a]-vs-[b]/page.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useState, useEffect, useMemo } from "react";
+import styles from "./page.module.css";
+import termsData from "../../../terms.json";
+
+type Term = { term: string; definition: string };
+
+type Params = { a: string; b: string };
+
+function findTerm(slug: string): Term | undefined {
+  const normalized = decodeURIComponent(slug).replace(/-/g, " ").toLowerCase();
+  return termsData.terms.find((t: Term) => t.term.toLowerCase() === normalized);
+}
+
+function highlight(
+  def: string,
+  other: string,
+  showDiff: boolean,
+  showSame: boolean,
+) {
+  const words = def.split(/(\s+)/);
+  const otherSet = new Set(other.toLowerCase().split(/\s+/));
+  return words.map((w, i) => {
+    const lw = w.toLowerCase();
+    const isWord = /\w/.test(w);
+    const isDiff = showDiff && isWord && !otherSet.has(lw);
+    const isSame = showSame && isWord && otherSet.has(lw);
+    const className = isDiff
+      ? `${styles.callout} ${styles.diff}`
+      : isSame
+        ? `${styles.callout} ${styles.same}`
+        : undefined;
+    return (
+      <span key={i} className={className}>
+        {w}
+      </span>
+    );
+  });
+}
+
+export default function ComparePage({ params }: { params: Params }) {
+  const { a, b } = params;
+  const search = useSearchParams();
+  const router = useRouter();
+
+  const [showDiff, setShowDiff] = useState(search.get("diff") === "1");
+  const [showSame, setShowSame] = useState(search.get("same") === "1");
+
+  useEffect(() => {
+    const sp = new URLSearchParams(Array.from(search.entries()));
+    showDiff ? sp.set("diff", "1") : sp.delete("diff");
+    showSame ? sp.set("same", "1") : sp.delete("same");
+    router.replace(`?${sp.toString()}`, { scroll: false });
+  }, [showDiff, showSame, router]);
+
+  const termA = useMemo(() => findTerm(a), [a]);
+  const termB = useMemo(() => findTerm(b), [b]);
+
+  const defA = termA?.definition || "Term not found.";
+  const defB = termB?.definition || "Term not found.";
+
+  return (
+    <div>
+      <h1>
+        Compare {termA?.term || a} vs {termB?.term || b}
+      </h1>
+      <div className={styles.controls}>
+        <label>
+          <input
+            type="checkbox"
+            checked={showDiff}
+            onChange={() => setShowDiff((d) => !d)}
+          />
+          Highlight differences
+        </label>
+        <label>
+          <input
+            type="checkbox"
+            checked={showSame}
+            onChange={() => setShowSame((s) => !s)}
+          />
+          Highlight similarities
+        </label>
+      </div>
+      <div className={styles.compareGrid}>
+        <div>
+          <h2>{termA?.term || a}</h2>
+          <p>{highlight(defA, defB, showDiff, showSame)}</p>
+        </div>
+        <div>
+          <h2>{termB?.term || b}</h2>
+          <p>{highlight(defB, defA, showDiff, showSame)}</p>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add comparison page for `[a]-vs-[b]`
- persist diff/similarity state in URL for sharing
- add controls and animated callouts to highlight differences and similarities

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b58df581f48328b917a62f26a63356