### PR TITLE
Add author dashboard with duplicate review and role gating

### DIFF
--- a/author.html
+++ b/author.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Author Dashboard - Cyber Security Dictionary</title>
+    <link rel="stylesheet" href="styles.css" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <main class="container" id="author-dashboard">
+      <h1>Author Dashboard</h1>
+      <section id="review-queue">
+        <h2>Review Queue</h2>
+        <ul id="queue-list"></ul>
+      </section>
+      <section id="validation-errors">
+        <h2>Validation Errors</h2>
+        <ul id="error-list"></ul>
+      </section>
+    </main>
+    <script src="author.js"></script>
+  </body>
+</html>

--- a/author.js
+++ b/author.js
@@ -1,0 +1,70 @@
+const dashboard = document.getElementById("author-dashboard");
+const queueList = document.getElementById("queue-list");
+const errorList = document.getElementById("error-list");
+
+function hasAccess() {
+  return localStorage.getItem("role") === "author";
+}
+
+if (!hasAccess()) {
+  dashboard.innerHTML = "<p>Access denied. Author role required.</p>";
+} else {
+  initDashboard();
+}
+
+function initDashboard() {
+  fetch("terms.json")
+    .then((response) => response.json())
+    .then((data) => {
+      const existingTerms = data.terms.map((t) => t.term.toLowerCase());
+      const pending = JSON.parse(localStorage.getItem("pendingTerms") || "[]");
+
+      if (pending.length === 0) {
+        queueList.innerHTML = "<li>No items in review queue.</li>";
+        return;
+      }
+
+      pending.forEach((item, idx) => {
+        const li = document.createElement("li");
+        li.textContent = item.term;
+        queueList.appendChild(li);
+
+        if (existingTerms.includes(item.term.toLowerCase())) {
+          const errItem = document.createElement("li");
+          errItem.innerHTML = `Duplicate term: ${item.term} <button data-index="${idx}" class="merge-btn">Merge</button>`;
+          errorList.appendChild(errItem);
+        }
+        if (!item.definition) {
+          const errItem = document.createElement("li");
+          errItem.textContent = `Missing definition for ${item.term}`;
+          errorList.appendChild(errItem);
+        }
+      });
+
+      document.querySelectorAll(".merge-btn").forEach((btn) => {
+        btn.addEventListener("click", (e) => {
+          const index = Number(e.target.dataset.index);
+          mergeTerm(pending[index], data);
+          pending.splice(index, 1);
+          localStorage.setItem("pendingTerms", JSON.stringify(pending));
+          window.location.reload();
+        });
+      });
+    })
+    .catch((err) => {
+      errorList.innerHTML = `<li>Failed to load terms: ${err.message}</li>`;
+    });
+}
+
+function mergeTerm(pendingTerm, termsData) {
+  const existing = termsData.terms.find(
+    (t) => t.term.toLowerCase() === pendingTerm.term.toLowerCase(),
+  );
+  if (existing) {
+    const synonyms = new Set([
+      ...(existing.synonyms || []),
+      ...(pendingTerm.synonyms || []),
+    ]);
+    existing.synonyms = Array.from(synonyms);
+  }
+}


### PR DESCRIPTION
## Summary
- Add author dashboard page to surface review queue and validation errors
- Detect duplicate submissions and provide merge action
- Restrict dashboard access to users with author role

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b58df8ea988328aaffad6934d5a7fd