### PR TITLE
Manage will-change during animations

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
   <footer aria-label="Project contribution">
     <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
   </footer>
+  <script src="will-change.js"></script>
   <script src="script.js"></script>
   <script src="assets/js/app.js"></script>
   <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "script.js",
   "scripts": {
     "build": "node scripts/build.js",
-    "test": "html-validate index.html search.html diagnostics.html && node diagnostics.test.js",
+    "test": "html-validate index.html search.html diagnostics.html && node diagnostics.test.js && node will-change.test.js",
     "watch": "chokidar \"**/*.html\" -c \"npm run build\""
   },
   "keywords": [],

--- a/script.js
+++ b/script.js
@@ -175,10 +175,15 @@ function populateTermsList() {
           displayDefinition(item);
         });
 
+        // Optimise transition by managing will-change during motion
+        if (typeof attachWillChange === "function") {
+          attachWillChange(termDiv, "transform");
+        }
+
         termsList.appendChild(termDiv);
       }
     });
-}
+  }
 
 function displayDefinition(term) {
   definitionContainer.style.display = "block";

--- a/will-change.js
+++ b/will-change.js
@@ -1,0 +1,32 @@
+(function (global) {
+  function attachWillChange(element, property) {
+    if (!element) return;
+
+    const set = () => {
+      element.style.willChange = property || 'auto';
+    };
+
+    const clear = () => {
+      element.style.removeProperty('will-change');
+      // verify removal so no lingering will-change remains
+      const computed = element.ownerDocument.defaultView.getComputedStyle(element).willChange;
+      if (computed && computed !== 'auto' && computed !== '') {
+        console.warn('will-change not removed from element', element);
+      }
+    };
+
+    element.addEventListener('transitionstart', set);
+    element.addEventListener('transitionend', clear);
+    element.addEventListener('animationstart', set);
+    element.addEventListener('animationend', clear);
+
+    return { set, clear };
+  }
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { attachWillChange };
+  } else {
+    global.attachWillChange = attachWillChange;
+  }
+})(typeof window !== 'undefined' ? window : globalThis);
+

--- a/will-change.test.js
+++ b/will-change.test.js
@@ -1,0 +1,48 @@
+const { JSDOM } = require('jsdom');
+const { attachWillChange } = require('./will-change.js');
+
+const dom = new JSDOM('<div id="el1"></div><div id="el2"></div>', {
+  pretendToBeVisual: true
+});
+
+const { document } = dom.window;
+
+function testTransition() {
+  const el = document.getElementById('el1');
+  attachWillChange(el, 'transform');
+
+  el.dispatchEvent(new dom.window.Event('transitionstart'));
+  if (dom.window.getComputedStyle(el).willChange !== 'transform') {
+    console.error('will-change not set on transitionstart');
+    process.exit(1);
+  }
+
+  el.dispatchEvent(new dom.window.Event('transitionend'));
+  if (dom.window.getComputedStyle(el).willChange !== '') {
+    console.error('will-change not removed after transitionend');
+    process.exit(1);
+  }
+}
+
+function testAnimation() {
+  const el = document.getElementById('el2');
+  attachWillChange(el, 'transform');
+
+  el.dispatchEvent(new dom.window.Event('animationstart'));
+  if (dom.window.getComputedStyle(el).willChange !== 'transform') {
+    console.error('will-change not set on animationstart');
+    process.exit(1);
+  }
+
+  el.dispatchEvent(new dom.window.Event('animationend'));
+  if (dom.window.getComputedStyle(el).willChange !== '') {
+    console.error('will-change not removed after animationend');
+    process.exit(1);
+  }
+}
+
+testTransition();
+testAnimation();
+
+console.log('Will-change removal tests passed');
+


### PR DESCRIPTION
## Summary
- Add helper to toggle `will-change` during motion and verify it clears
- Integrate helper into dictionary terms for smoother transitions
- Test transitions and animations to ensure `will-change` is removed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5b5eb0f288328ba33f30d49cbb0af