### PR TITLE
Add animation A/B testing and metrics tracking

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -326,6 +326,16 @@ body.dark-mode #alpha-nav button.active {
   border-color: #007bff;
 }
 
+/* Animation A/B test styles */
+body.low-animation * {
+  transition: none !important;
+  animation: none !important;
+}
+
+body.low-animation .dictionary-item:hover {
+  transform: none;
+}
+
 @media (max-width: 480px) {
   h1 {
     font-size: 32px;


### PR DESCRIPTION
## Summary
- assign visitors to high or low animation groups and track dictionary usage metrics
- collect definition views and reading time to recommend the more engaging animation level
- add low-animation styles to disable transitions and transforms

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b58dfadb008328acb46b741d196270