### PR TITLE
Add centralized spring presets with validation and tests

### DIFF
--- a/assets/js/spring.js
+++ b/assets/js/spring.js
@@ -1,0 +1,57 @@
+// Utilities for working with spring animations.
+// Provides runtime validation and helpers to compute overshoot.
+
+const PRESETS = require("./springPresets");
+
+const CLAMP_RANGES = {
+  stiffness: [1, 1000],
+  damping: [0, 100],
+  mass: [0.1, 10],
+};
+
+const MIN_ZETA = 0.78; // damping ratio to keep overshoot < 2%
+
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value));
+}
+
+function validateSpring(cfg) {
+  const clamped = {};
+  for (const key of Object.keys(CLAMP_RANGES)) {
+    const [min, max] = CLAMP_RANGES[key];
+    clamped[key] = clamp(cfg[key], min, max);
+  }
+
+  // Ensure damping high enough to keep overshoot under 2%
+  const minDamping = 2 * Math.sqrt(clamped.stiffness * clamped.mass) * MIN_ZETA;
+  if (clamped.damping < minDamping) {
+    clamped.damping = clamp(
+      minDamping,
+      CLAMP_RANGES.damping[0],
+      CLAMP_RANGES.damping[1],
+    );
+  }
+
+  return clamped;
+}
+
+function getSpringPreset(name) {
+  const preset = PRESETS[name];
+  if (!preset) throw new Error(`Unknown spring preset: ${name}`);
+  return validateSpring(preset);
+}
+
+function calculateOvershoot(cfg) {
+  const { stiffness, damping, mass } = cfg;
+  const zeta = damping / (2 * Math.sqrt(stiffness * mass));
+  if (zeta >= 1) return 0;
+  const overshoot = Math.exp((-zeta * Math.PI) / Math.sqrt(1 - zeta * zeta));
+  return overshoot * 100;
+}
+
+module.exports = {
+  PRESETS,
+  getSpringPreset,
+  validateSpring,
+  calculateOvershoot,
+};

--- a/assets/js/springPresets.js
+++ b/assets/js/springPresets.js
@@ -1,0 +1,10 @@
+// Centralized spring presets shared across the application.
+// Each preset defines the physical parameters for a spring animation.
+
+const SPRING_PRESETS = {
+  gentle: { stiffness: 120, damping: 20, mass: 1 },
+  wobbly: { stiffness: 180, damping: 24, mass: 1 },
+  stiff: { stiffness: 300, damping: 40, mass: 1 },
+};
+
+module.exports = SPRING_PRESETS;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "script.js",
   "scripts": {
     "build": "node scripts/build.js",
-    "test": "html-validate index.html search.html diagnostics.html && node diagnostics.test.js",
+    "test": "html-validate index.html search.html diagnostics.html && node diagnostics.test.js && node spring.test.js",
     "watch": "chokidar \"**/*.html\" -c \"npm run build\""
   },
   "keywords": [],

--- a/spring.test.js
+++ b/spring.test.js
@@ -1,0 +1,30 @@
+const {
+  PRESETS,
+  getSpringPreset,
+  validateSpring,
+  calculateOvershoot,
+} = require("./assets/js/spring");
+
+// Ensure each preset stays within overshoot limits
+Object.keys(PRESETS).forEach((name) => {
+  const cfg = getSpringPreset(name);
+  const overshoot = calculateOvershoot(cfg);
+  if (overshoot > 2) {
+    console.error(
+      `Preset ${name} overshoot ${overshoot.toFixed(2)}% exceeds limit`,
+    );
+    process.exit(1);
+  }
+});
+
+// Validate that clamping keeps custom springs within range and overshoot limit
+const invalid = validateSpring({ stiffness: 2000, damping: 1, mass: 0.01 });
+const overshoot = calculateOvershoot(invalid);
+if (overshoot > 2) {
+  console.error(
+    `Clamped spring overshoot ${overshoot.toFixed(2)}% exceeds limit`,
+  );
+  process.exit(1);
+}
+
+console.log("Spring tests passed");


### PR DESCRIPTION
## Summary
- centralize spring presets in shared module
- clamp and validate spring configs to keep overshoot below 2%
- add tests verifying overshoot limits

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5b5ec7aac8328bcefbff027e78f6d