### PR TITLE
Prefetch probable links and capture TTI metrics

### DIFF
--- a/assets/js/diagnostics.js
+++ b/assets/js/diagnostics.js
@@ -17,7 +17,8 @@
       const lcp = s.lcp != null && s.lcp.toFixed ? s.lcp.toFixed(2) : s.lcp;
       const cls = s.cls != null && s.cls.toFixed ? s.cls.toFixed(3) : s.cls;
       const tbt = s.tbt != null && s.tbt.toFixed ? s.tbt.toFixed(2) : s.tbt;
-      tr.innerHTML = `<td>${date}</td><td>${lcp}</td><td>${cls}</td><td>${tbt}</td>`;
+      const tti = s.tti != null && s.tti.toFixed ? s.tti.toFixed(2) : s.tti;
+      tr.innerHTML = `<td>${date}</td><td>${lcp}</td><td>${cls}</td><td>${tbt}</td><td>${tti}</td>`;
       tbody.appendChild(tr);
     });
   }

--- a/assets/js/metrics.js
+++ b/assets/js/metrics.js
@@ -14,7 +14,7 @@
 
   function init() {
     if (!window.webVitals) return;
-    const sample = { timestamp: Date.now(), lcp: 0, cls: 0, tbt: 0 };
+    const sample = { timestamp: Date.now(), lcp: 0, cls: 0, tbt: 0, tti: 0 };
 
     webVitals.onLCP(({ value }) => {
       sample.lcp = value;
@@ -30,7 +30,20 @@
         (sum, task) => sum + Math.max(0, task.duration - 50),
         0
       );
-      setTimeout(() => storeSample(sample), 0);
+      if (
+        window.ttiPolyfill &&
+        typeof window.ttiPolyfill.getFirstConsistentlyInteractive === 'function'
+      ) {
+        window.ttiPolyfill
+          .getFirstConsistentlyInteractive()
+          .then((tti) => {
+            sample.tti = tti;
+            setTimeout(() => storeSample(sample), 0);
+          })
+          .catch(() => setTimeout(() => storeSample(sample), 0));
+      } else {
+        setTimeout(() => storeSample(sample), 0);
+      }
     });
   }
 

--- a/diagnostics.html
+++ b/diagnostics.html
@@ -11,7 +11,7 @@
     <h1>Performance Diagnostics</h1>
     <table>
       <thead>
-        <tr><th>Timestamp</th><th>LCP</th><th>CLS</th><th>TBT</th></tr>
+        <tr><th>Timestamp</th><th>LCP</th><th>CLS</th><th>TBT</th><th>TTI</th></tr>
       </thead>
       <tbody id="metrics-body"></tbody>
     </table>

--- a/diagnostics.test.js
+++ b/diagnostics.test.js
@@ -9,8 +9,8 @@ dom.window.eval(script);
 dom.window.localStorage.setItem(
   'web-vitals',
   JSON.stringify([
-    { timestamp: 1, lcp: 1.1, cls: 0.1, tbt: 10 },
-    { timestamp: 2, lcp: 2.2, cls: 0.2, tbt: 20 }
+    { timestamp: 1, lcp: 1.1, cls: 0.1, tbt: 10, tti: 30 },
+    { timestamp: 2, lcp: 2.2, cls: 0.2, tbt: 20, tti: 40 }
   ])
 );
 
@@ -19,6 +19,11 @@ dom.window.renderDiagnostics();
 const rows = dom.window.document.querySelectorAll('#metrics-body tr');
 if (rows.length !== 2) {
   console.error(`Expected 2 rows, got ${rows.length}`);
+  process.exit(1);
+}
+const cells = rows[0].querySelectorAll('td');
+if (cells.length !== 5) {
+  console.error(`Expected 5 columns, got ${cells.length}`);
   process.exit(1);
 }
 console.log('Diagnostics render test passed');

--- a/index.html
+++ b/index.html
@@ -7,6 +7,17 @@
   <link rel="stylesheet" href="styles.css">
   <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet">
   <link rel="canonical" id="canonical-link" href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/">
+  <script type="speculationrules">
+    {
+      "prefetch": [
+        {
+          "source": "document",
+          "where": { "href_matches": "templates/.*" },
+          "eagerness": "moderate"
+        }
+      ]
+    }
+  </script>
 </head>
 <body>
   <main class="container">
@@ -35,6 +46,7 @@
   <script src="script.js"></script>
   <script src="assets/js/app.js"></script>
   <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
+  <script src="https://unpkg.com/tti-polyfill@0.2.2/dist/tti-polyfill.iife.js"></script>
   <script src="assets/js/metrics.js"></script>
 </body>
 </html>

--- a/layout.html
+++ b/layout.html
@@ -15,6 +15,17 @@
   <meta name="twitter:description" content="An interactive dictionary for cyber security terms.">
   <meta name="twitter:url" content="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/">
   <meta name="twitter:image" content="https://github.com/Alex-Unnippillil/CyberSecuirtyDictionary/assets/24538548/c5a54c56-babb-485d-b01c-4fdfb186325b">
+  <script type="speculationrules">
+    {
+      "prefetch": [
+        {
+          "source": "document",
+          "where": { "href_matches": "templates/.*" },
+          "eagerness": "moderate"
+        }
+      ]
+    }
+  </script>
 </head>
 <body>
   <main class="container">
@@ -35,6 +46,7 @@
 
   <script src="script.js"></script>
   <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
+  <script src="https://unpkg.com/tti-polyfill@0.2.2/dist/tti-polyfill.iife.js"></script>
   <script src="assets/js/metrics.js"></script>
 </body>
 </html>

--- a/search.html
+++ b/search.html
@@ -17,6 +17,7 @@
   </script>
   <script src="assets/js/search.js"></script>
   <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
+  <script src="https://unpkg.com/tti-polyfill@0.2.2/dist/tti-polyfill.iife.js"></script>
   <script src="assets/js/metrics.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add speculation rules to prefetch template links when users are likely to navigate
- load tti-polyfill and track Time To Interactive along with existing metrics
- expose TTI in diagnostics page and test it

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5b5f0ff2c83289a3a2f5fd8c62dd8