### PR TITLE
Add theme-aware skeleton tokens and placeholders

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -6,6 +6,8 @@
   --color-card-bg: #ffffff;
   --color-badge-bg: #e9ecef;
   --color-badge-text: #212529;
+  --skeleton-bg: #e5e7eb;
+  --skeleton-fg: #6b7280;
 }
 
 [data-theme="dark"] {
@@ -16,6 +18,8 @@
   --color-card-bg: #1e1e1e;
   --color-badge-bg: #343a40;
   --color-badge-text: #f8f9fa;
+  --skeleton-bg: #374151;
+  --skeleton-fg: #9ca3af;
 }
 
 body {
@@ -64,6 +68,30 @@ a:focus {
   background: var(--color-badge-bg);
   color: var(--color-badge-text);
   border-radius: 0.25rem;
+}
+
+/* Skeleton styles */
+.skeleton {
+  position: relative;
+  overflow: hidden;
+  background: var(--skeleton-bg);
+  border-radius: 4px;
+  color: transparent;
+}
+
+.skeleton::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  transform: translateX(-100%);
+  background: linear-gradient(90deg, transparent, var(--skeleton-fg), transparent);
+  animation: skeleton-shimmer 1.5s infinite;
+}
+
+@keyframes skeleton-shimmer {
+  100% {
+    transform: translateX(100%);
+  }
 }
 
 /* Accessibility */

--- a/script.js
+++ b/script.js
@@ -27,7 +27,19 @@ window.addEventListener("DOMContentLoaded", () => {
   loadTerms();
 });
 
+function showSkeletons() {
+  termsList.innerHTML = "";
+  for (let i = 0; i < 5; i++) {
+    const skel = document.createElement("div");
+    skel.className = "skeleton";
+    skel.style.height = "1.5rem";
+    skel.style.marginBottom = "0.5rem";
+    termsList.appendChild(skel);
+  }
+}
+
 function loadTerms() {
+  showSkeletons();
   fetch("terms.json")
     .then((response) => {
       if (!response.ok) {

--- a/styles.css
+++ b/styles.css
@@ -4,6 +4,16 @@
   box-sizing: border-box;
 }
 
+:root {
+  --skeleton-bg: #e5e7eb;
+  --skeleton-fg: #6b7280;
+}
+
+body.dark-mode {
+  --skeleton-bg: #374151;
+  --skeleton-fg: #9ca3af;
+}
+
 body {
   font-family: Arial, sans-serif;
   line-height: 1.6;
@@ -240,6 +250,30 @@ label {
 
 #scrollToTopBtn:hover {
   background-color: #0056b3;
+}
+
+/* Skeleton styles */
+.skeleton {
+  position: relative;
+  overflow: hidden;
+  background-color: var(--skeleton-bg);
+  border-radius: 4px;
+  color: transparent;
+}
+
+.skeleton::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  transform: translateX(-100%);
+  background-image: linear-gradient(90deg, transparent, var(--skeleton-fg), transparent);
+  animation: skeleton-shimmer 1.5s infinite;
+}
+
+@keyframes skeleton-shimmer {
+  100% {
+    transform: translateX(100%);
+  }
 }
 
 /* Dark Mode styles */


### PR DESCRIPTION
## Summary
- add skeleton foreground/background tokens for light and dark themes
- implement skeleton loader style using these tokens
- show themed skeleton placeholders while terms load

## Testing
- `npm test`
- `npx -y pa11y index.html` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b5fb3970832889bf318783995f01