### PR TITLE
Prefetch route assets and track cache reuse

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,5 +1,60 @@
-if ('serviceWorker' in navigator) {
-  window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/sw.js');
+// Register the service worker and expose a helper to query cache metrics.
+if ("serviceWorker" in navigator) {
+  navigator.serviceWorker.addEventListener("message", (event) => {
+    if (event.data && event.data.type === "CACHE_HIT_COUNT") {
+      console.log("Cache hits:", event.data.count);
+    }
+  });
+
+  window.addEventListener("load", () => {
+    navigator.serviceWorker.register("/sw.js").then(() => {
+      measureCacheHits();
+    });
   });
 }
+
+// Measure cache hits by asking the service worker for its current count.
+function measureCacheHits() {
+  if (navigator.serviceWorker.controller) {
+    const channel = new MessageChannel();
+    channel.port1.onmessage = (event) => {
+      console.log("Cache hits:", event.data.count);
+    };
+    navigator.serviceWorker.controller.postMessage({ type: "GET_CACHE_HITS" }, [
+      channel.port2,
+    ]);
+  }
+}
+
+// Helper wrapper around requestIdleCallback with a fallback.
+function requestIdle(fn) {
+  if ("requestIdleCallback" in window) {
+    window.requestIdleCallback(fn);
+  } else {
+    setTimeout(fn, 1);
+  }
+}
+
+// Prefetch a given URL using a <link rel="prefetch"> tag.
+function prefetch(href) {
+  const connection = navigator.connection;
+  if (connection) {
+    if (connection.saveData || /2g/.test(connection.effectiveType)) {
+      return; // Avoid prefetching on poor connections or data-saver.
+    }
+  }
+  const link = document.createElement("link");
+  link.rel = "prefetch";
+  link.href = href;
+  document.head.appendChild(link);
+}
+
+// Detect potential next navigations and prefetch their assets during idle time.
+window.addEventListener("DOMContentLoaded", () => {
+  document.querySelectorAll("a[href]").forEach((anchor) => {
+    const href = anchor.href;
+    const trigger = () => requestIdle(() => prefetch(href));
+    anchor.addEventListener("mouseenter", trigger, { once: true });
+    anchor.addEventListener("touchstart", trigger, { once: true });
+  });
+});

--- a/diagnostics.html
+++ b/diagnostics.html
@@ -1,21 +1,27 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Diagnostics</title>
-  <link rel="stylesheet" href="styles.css">
-</head>
-<body>
-  <main class="container">
-    <h1>Performance Diagnostics</h1>
-    <table>
-      <thead>
-        <tr><th>Timestamp</th><th>LCP</th><th>CLS</th><th>TBT</th></tr>
-      </thead>
-      <tbody id="metrics-body"></tbody>
-    </table>
-  </main>
-  <script src="assets/js/diagnostics.js"></script>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Diagnostics</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="container">
+      <h1>Performance Diagnostics</h1>
+      <table>
+        <thead>
+          <tr>
+            <th>Timestamp</th>
+            <th>LCP</th>
+            <th>CLS</th>
+            <th>TBT</th>
+          </tr>
+        </thead>
+        <tbody id="metrics-body"></tbody>
+      </table>
+    </main>
+    <script src="assets/js/app.js"></script>
+    <script src="assets/js/diagnostics.js"></script>
+  </body>
 </html>

--- a/search.html
+++ b/search.html
@@ -1,22 +1,23 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Search</title>
-  <link rel="stylesheet" href="styles.css">
-</head>
-<body>
-  <main class="container">
-    <h1>Search</h1>
-    <input id="search-box" type="text" placeholder="Search terms...">
-    <div id="results"></div>
-  </main>
-  <script>
-    window.__BASE_URL__ = window.__BASE_URL__ || '';
-  </script>
-  <script src="assets/js/search.js"></script>
-  <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
-  <script src="assets/js/metrics.js"></script>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Search</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="container">
+      <h1>Search</h1>
+      <input id="search-box" type="text" placeholder="Search terms..." />
+      <div id="results"></div>
+    </main>
+    <script>
+      window.__BASE_URL__ = window.__BASE_URL__ || "";
+    </script>
+    <script src="assets/js/app.js"></script>
+    <script src="assets/js/search.js"></script>
+    <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
+    <script src="assets/js/metrics.js"></script>
+  </body>
 </html>

--- a/sw.js
+++ b/sw.js
@@ -1,36 +1,69 @@
-const CACHE_NAME = 'csd-cache-v1';
+const CACHE_NAME = "csd-cache-v1";
 const URLS_TO_CACHE = [
-  '/',
-  '/index.html',
-  '/styles.css',
-  '/script.js',
-  '/data.json'
+  "/",
+  "/index.html",
+  "/styles.css",
+  "/script.js",
+  "/data.json",
 ];
 
-self.addEventListener('install', event => {
+let cacheHits = 0;
+
+self.addEventListener("install", (event) => {
   event.waitUntil(
-    caches.open(CACHE_NAME).then(cache => cache.addAll(URLS_TO_CACHE))
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(URLS_TO_CACHE)),
   );
 });
 
-self.addEventListener('activate', event => {
+self.addEventListener("activate", (event) => {
   event.waitUntil(
-    caches.keys().then(keys =>
-      Promise.all(
-        keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key))
-      )
-    )
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(
+          keys
+            .filter((key) => key !== CACHE_NAME)
+            .map((key) => caches.delete(key)),
+        ),
+      ),
   );
 });
 
-self.addEventListener('fetch', event => {
+self.addEventListener("fetch", (event) => {
   event.respondWith(
-    caches.match(event.request).then(response =>
-      response || fetch(event.request).catch(() => {
-        if (event.request.mode === 'navigate') {
-          return caches.match('/index.html');
-        }
-      })
-    )
+    caches.match(event.request).then((response) => {
+      if (response) {
+        cacheHits++;
+        return response;
+      }
+      return fetch(event.request)
+        .then((networkResponse) => {
+          if (
+            networkResponse &&
+            networkResponse.status === 200 &&
+            event.request.method === "GET"
+          ) {
+            const copy = networkResponse.clone();
+            event.waitUntil(
+              caches
+                .open(CACHE_NAME)
+                .then((cache) => cache.put(event.request, copy)),
+            );
+          }
+          return networkResponse;
+        })
+        .catch(() => {
+          if (event.request.mode === "navigate") {
+            return caches.match("/index.html");
+          }
+        });
+    }),
   );
+});
+
+// Respond to metric queries from the client.
+self.addEventListener("message", (event) => {
+  if (event.data && event.data.type === "GET_CACHE_HITS") {
+    event.ports[0].postMessage({ type: "CACHE_HIT_COUNT", count: cacheHits });
+  }
 });


### PR DESCRIPTION
## Summary
- Preload next-route documents with `requestIdleCallback` and connection-aware prefetch logic.
- Dynamically cache fetched assets and expose cache hit metrics via service worker messaging.
- Include service worker bootstrapping on search and diagnostics pages.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5b5f0219483289ecee5bfbe77c842