### PR TITLE
Ensure focus rings visible with high-contrast tests

### DIFF
--- a/focus-ring.test.js
+++ b/focus-ring.test.js
@@ -1,0 +1,19 @@
+const fs = require("fs");
+
+const css = fs.readFileSync("styles.css", "utf8");
+
+const focusBlockPattern =
+  /\.dictionary-item:focus,[\s\S]*?#scrollToTopBtn:focus\s*\{[^}]*outline[^}]*\}/m;
+if (!focusBlockPattern.test(css)) {
+  console.error("Missing focus ring styles");
+  process.exit(1);
+}
+
+const forcedBlockPattern =
+  /@media\s*\(forced-colors:\s*active\)\s*\{[\s\S]*?\.dictionary-item:focus,[\s\S]*?#scrollToTopBtn:focus\s*\{[^}]*ButtonText[^}]*\}[\s\S]*?\}/m;
+if (!forcedBlockPattern.test(css)) {
+  console.error("Missing high-contrast focus ring styles");
+  process.exit(1);
+}
+
+console.log("Focus ring high-contrast test passed");

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "script.js",
   "scripts": {
     "build": "node scripts/build.js",
-    "test": "html-validate index.html search.html diagnostics.html && node diagnostics.test.js",
+    "test": "html-validate index.html search.html diagnostics.html && node diagnostics.test.js && node focus-ring.test.js",
     "watch": "chokidar \"**/*.html\" -c \"npm run build\""
   },
   "keywords": [],

--- a/styles.css
+++ b/styles.css
@@ -25,7 +25,7 @@ body {
 
 h1 {
   text-align: center;
-  font-family: 'Cinzel', serif;
+  font-family: "Cinzel", serif;
   font-weight: 700;
   font-size: 48px;
   margin-bottom: 20px;
@@ -89,7 +89,8 @@ body.dark-mode mark {
   color: #666;
 }
 
-.dictionary-item:hover {
+.dictionary-item:hover,
+.dictionary-item:focus {
   transform: scale(1.02);
 }
 
@@ -111,7 +112,6 @@ body.dark-mode mark {
   min-height: 44px;
 }
 
-
 /* Controls styling */
 #random-term {
   margin-top: 10px;
@@ -125,7 +125,8 @@ body.dark-mode mark {
   min-height: 44px;
 }
 
-#random-term:hover {
+#random-term:hover,
+#random-term:focus {
   background-color: #0056b3;
 }
 
@@ -141,7 +142,8 @@ body.dark-mode mark {
   min-height: 44px;
 }
 
-#dark-mode-toggle:hover {
+#dark-mode-toggle:hover,
+#dark-mode-toggle:focus {
   background-color: #0056b3;
 }
 
@@ -206,7 +208,9 @@ label {
   border-radius: 4px;
   padding: 10px;
   cursor: pointer;
-  transition: background-color 0.2s, color 0.2s;
+  transition:
+    background-color 0.2s,
+    color 0.2s;
   min-width: 44px;
   min-height: 44px;
 }
@@ -238,8 +242,32 @@ label {
   border-radius: 50%;
 }
 
-#scrollToTopBtn:hover {
+#scrollToTopBtn:hover,
+#scrollToTopBtn:focus {
   background-color: #0056b3;
+}
+
+/* Focus ring visibility */
+.dictionary-item:focus,
+#alpha-nav button:focus,
+#random-term:focus,
+#dark-mode-toggle:focus,
+.favorite-star:focus,
+#scrollToTopBtn:focus {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
+}
+
+@media (forced-colors: active) {
+  .dictionary-item:focus,
+  #alpha-nav button:focus,
+  #random-term:focus,
+  #dark-mode-toggle:focus,
+  .favorite-star:focus,
+  #scrollToTopBtn:focus {
+    outline: 2px solid ButtonText;
+    outline-offset: 2px;
+  }
 }
 
 /* Dark Mode styles */


### PR DESCRIPTION
## Summary
- keep focus rings visible by extending hover styles to focusable animations
- add explicit outlines and forced-colors support for high-contrast mode
- cover focus ring behavior with a regression test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5b6030a988328823fe1e4daa6ae40