### PR TITLE
Add high contrast media queries for accessibility

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -22,7 +22,14 @@ body {
   margin: 0;
   background: var(--color-bg);
   color: var(--color-text);
-  font-family: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  font-family:
+    system-ui,
+    -apple-system,
+    "Segoe UI",
+    Roboto,
+    Helvetica,
+    Arial,
+    sans-serif;
   line-height: 1.6;
 }
 
@@ -53,7 +60,7 @@ a:focus {
 .card {
   background: var(--color-card-bg);
   border-radius: 0.5rem;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   padding: 1rem;
 }
 
@@ -83,11 +90,34 @@ a:focus {
 }
 
 /* Typography */
-h1,h2,h3,h4,h5,h6 {
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
   line-height: 1.25;
 }
 
 p {
   margin-top: 0;
   margin-bottom: 1rem;
+}
+
+/* High contrast mode */
+@media (prefers-contrast: more) {
+  a,
+  .card,
+  .badge,
+  .skip-link {
+    outline: 2px solid currentColor;
+  }
+
+  a {
+    text-decoration: underline;
+  }
+
+  .card {
+    box-shadow: none;
+  }
 }

--- a/styles.css
+++ b/styles.css
@@ -25,7 +25,7 @@ body {
 
 h1 {
   text-align: center;
-  font-family: 'Cinzel', serif;
+  font-family: "Cinzel", serif;
   font-weight: 700;
   font-size: 48px;
   margin-bottom: 20px;
@@ -110,7 +110,6 @@ body.dark-mode mark {
   box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
   min-height: 44px;
 }
-
 
 /* Controls styling */
 #random-term {
@@ -206,7 +205,9 @@ label {
   border-radius: 4px;
   padding: 10px;
   cursor: pointer;
-  transition: background-color 0.2s, color 0.2s;
+  transition:
+    background-color 0.2s,
+    color 0.2s;
   min-width: 44px;
   min-height: 44px;
 }
@@ -345,5 +346,27 @@ body.dark-mode #alpha-nav button.active {
 
   #alpha-nav button {
     font-size: 14px;
+  }
+}
+
+/* High contrast mode adjustments */
+@media (prefers-contrast: more) {
+  body,
+  h1 {
+    text-shadow: none;
+  }
+
+  .container,
+  li,
+  .dictionary-item,
+  #definition-container,
+  #search,
+  #random-term,
+  #dark-mode-toggle,
+  .favorite-star,
+  .badge,
+  #alpha-nav button {
+    outline: 2px solid currentColor;
+    box-shadow: none;
   }
 }


### PR DESCRIPTION
## Summary
- increase outlines and remove translucent shadows when user prefers higher contrast
- respect high-contrast preferences in cards, badges and navigation elements

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5b5fe56dc83289c75cb3a7342f94e