### PR TITLE
feat: add transform-based ripple effect

### DIFF
--- a/script.js
+++ b/script.js
@@ -254,3 +254,31 @@ scrollBtn.addEventListener("click", () =>
 
 definitionContainer.addEventListener("click", clearDefinition);
 
+// Ripple effect for buttons
+function createRipple(event) {
+  if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+    return;
+  }
+
+  const button = event.currentTarget;
+  const rect = button.getBoundingClientRect();
+  const ripple = document.createElement("span");
+  ripple.classList.add("ripple");
+
+  const size = Math.max(rect.width, rect.height);
+  ripple.style.width = ripple.style.height = `${size * 2}px`;
+  ripple.style.left = `${event.clientX - rect.left - size}px`;
+  ripple.style.top = `${event.clientY - rect.top - size}px`;
+
+  button.appendChild(ripple);
+  ripple.addEventListener("animationend", () => {
+    ripple.remove();
+  });
+}
+
+document.querySelectorAll("button").forEach((btn) => {
+  const radius = getComputedStyle(btn).borderRadius;
+  btn.style.setProperty("--ripple-clip", `inset(0 round ${radius})`);
+  btn.addEventListener("click", createRipple);
+});
+

--- a/styles.css
+++ b/styles.css
@@ -347,3 +347,33 @@ body.dark-mode #alpha-nav button.active {
     font-size: 14px;
   }
 }
+
+/* Ripple effect */
+button {
+  position: relative;
+  overflow: hidden;
+  clip-path: var(--ripple-clip);
+}
+
+button .ripple {
+  position: absolute;
+  pointer-events: none;
+  border-radius: 50%;
+  transform: scale(0);
+  background: rgba(255, 255, 255, 0.4);
+  opacity: 0.75;
+  animation: ripple-animation 600ms ease-out;
+}
+
+@keyframes ripple-animation {
+  to {
+    transform: scale(1);
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  button .ripple {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add transform-based ripple animation clipped to button border radius
- disable ripple when users prefer reduced motion

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5b60788788328824c43354c0e3590