### PR TITLE
Respect safe-area insets for fixed elements

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -24,6 +24,10 @@ body {
   color: var(--color-text);
   font-family: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
   line-height: 1.6;
+  padding-top: env(safe-area-inset-top);
+  padding-right: env(safe-area-inset-right);
+  padding-bottom: env(safe-area-inset-bottom);
+  padding-left: env(safe-area-inset-left);
 }
 
 .container {
@@ -90,4 +94,27 @@ h1,h2,h3,h4,h5,h6 {
 p {
   margin-top: 0;
   margin-bottom: 1rem;
+}
+
+/* Toast and bottom sheet components */
+.toast {
+  position: fixed;
+  left: 50%;
+  transform: translateX(-50%);
+  bottom: calc(1rem + env(safe-area-inset-bottom));
+  padding: 0.5rem 1rem;
+  border-radius: 0.25rem;
+  background: var(--color-card-bg);
+  color: var(--color-text);
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+.bottom-sheet {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  padding-bottom: env(safe-area-inset-bottom);
+  background: var(--color-card-bg);
+  box-shadow: 0 -2px 8px rgba(0,0,0,0.2);
 }

--- a/styles.css
+++ b/styles.css
@@ -9,7 +9,10 @@ body {
   line-height: 1.6;
   background-color: #f8f8f8;
   margin: 0;
-  padding: 0;
+  padding-top: env(safe-area-inset-top);
+  padding-right: env(safe-area-inset-right);
+  padding-bottom: env(safe-area-inset-bottom);
+  padding-left: env(safe-area-inset-left);
   overflow-x: hidden;
 }
 
@@ -226,8 +229,8 @@ label {
 #scrollToTopBtn {
   display: none;
   position: fixed;
-  bottom: 20px;
-  right: 20px;
+  bottom: calc(20px + env(safe-area-inset-bottom));
+  right: calc(20px + env(safe-area-inset-right));
   font-size: 20px;
   border: none;
   background-color: #007bff;
@@ -240,6 +243,27 @@ label {
 
 #scrollToTopBtn:hover {
   background-color: #0056b3;
+}
+
+/* Toast and bottom sheet styles respecting safe areas */
+.toast {
+  position: fixed;
+  left: 50%;
+  transform: translateX(-50%);
+  bottom: calc(20px + env(safe-area-inset-bottom));
+  padding: 10px 20px;
+  border-radius: 4px;
+  background-color: #333;
+  color: #fff;
+}
+
+.bottom-sheet {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  padding-bottom: env(safe-area-inset-bottom);
+  background-color: #fff;
 }
 
 /* Dark Mode styles */


### PR DESCRIPTION
## Summary
- Pad body with CSS env(safe-area-inset-*) values
- Offset scroll-to-top button, toasts, and bottom sheets away from the home indicator
- Add safe-area aware equivalents in asset styles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5b6092fe88328b0afa972c3f5fa53