### PR TITLE
feat: add swipe-safe drawer with toggle fallback

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,10 +10,11 @@
 </head>
 <body>
   <main class="container">
-    <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav" aria-label="Site links"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
-    <div id="definition-container" style="display: none;"></div>
-    <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
+      <h1>Cyber Security Dictionary</h1>
+      <button id="drawer-toggle" type="button" aria-label="Toggle navigation">☰</button>
+      <nav class="site-nav" aria-label="Site links"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
+      <div id="definition-container" style="display: none;"></div>
+      <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">
 
     <button id="random-term" type="button" aria-label="Show random term">Random Term</button>

--- a/layout.html
+++ b/layout.html
@@ -19,6 +19,7 @@
 <body>
   <main class="container">
     <h1>Cyber Security Dictionary</h1>
+    <button id="drawer-toggle" type="button" aria-label="Toggle navigation">☰</button>
     <div id="definition-container" style="display: none;"></div>
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">

--- a/script.js
+++ b/script.js
@@ -3,6 +3,7 @@ const definitionContainer = document.getElementById("definition-container");
 const searchInput = document.getElementById("search");
 const randomButton = document.getElementById("random-term");
 const alphaNav = document.getElementById("alpha-nav");
+const drawerToggle = document.getElementById("drawer-toggle");
 const darkModeToggle = document.getElementById("dark-mode-toggle");
 const showFavoritesToggle = document.getElementById("show-favorites");
 const favorites = new Set(JSON.parse(localStorage.getItem("favorites") || "[]"));
@@ -253,4 +254,43 @@ scrollBtn.addEventListener("click", () =>
 );
 
 definitionContainer.addEventListener("click", clearDefinition);
+
+// Drawer toggle fallback button
+if (drawerToggle && alphaNav) {
+  drawerToggle.addEventListener("click", () => {
+    alphaNav.classList.toggle("open");
+  });
+}
+
+// iOS edge-swipe detection for drawer
+const isiOS = /iP(ad|hone|od)/.test(navigator.userAgent);
+if (isiOS && alphaNav) {
+  let touchStartX = null;
+  const edgeMargin = 20; // allow system back gesture in this zone
+  const swipeThreshold = 70;
+
+  document.addEventListener("touchstart", (e) => {
+    if (e.touches.length !== 1) return;
+    touchStartX = e.touches[0].clientX;
+  });
+
+  document.addEventListener("touchend", (e) => {
+    if (touchStartX === null) return;
+    const touchEndX = e.changedTouches[0].clientX;
+    const diffX = touchEndX - touchStartX;
+
+    if (touchStartX > edgeMargin && diffX > swipeThreshold) {
+      // swipe right opens drawer
+      alphaNav.classList.add("open");
+    } else if (
+      alphaNav.classList.contains("open") &&
+      touchStartX > edgeMargin &&
+      diffX < -swipeThreshold
+    ) {
+      // swipe left closes drawer
+      alphaNav.classList.remove("open");
+    }
+    touchStartX = null;
+  });
+}
 

--- a/styles.css
+++ b/styles.css
@@ -242,6 +242,52 @@ label {
   background-color: #0056b3;
 }
 
+/* Drawer toggle hidden by default */
+#drawer-toggle {
+  display: none;
+}
+
+@media (max-width: 600px) {
+  #drawer-toggle {
+    display: block;
+    position: fixed;
+    top: 10px;
+    left: 10px;
+    z-index: 1001;
+    padding: 10px;
+    background-color: #007bff;
+    color: #fff;
+    border: none;
+    border-radius: 4px;
+    min-width: 44px;
+    min-height: 44px;
+  }
+
+  #drawer-toggle:focus {
+    outline: 2px solid #0056b3;
+  }
+
+  #alpha-nav {
+    position: fixed;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 260px;
+    background-color: #fff;
+    flex-direction: column;
+    align-items: flex-start;
+    padding: 20px 10px;
+    transform: translateX(-100%);
+    transition: transform 0.3s ease;
+    z-index: 1000;
+    box-shadow: 2px 0 5px rgba(0, 0, 0, 0.3);
+  }
+
+  #alpha-nav.open {
+    transform: translateX(0);
+  }
+}
+
 /* Dark Mode styles */
 body.dark-mode {
   background-color: #121212;


### PR DESCRIPTION
## Summary
- add mobile drawer toggle button and styles
- handle iOS edge-swipe gestures without blocking browser back
- enable swipe-to-open/close navigation drawer with safe edge margin

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5b60aaad48328824a878e24b22af8