### PR TITLE
Introduce token stream scheduler with bounded delay variance

### DIFF
--- a/assets/js/tokenScheduler.js
+++ b/assets/js/tokenScheduler.js
@@ -1,0 +1,36 @@
+class TokenScheduler {
+  constructor({ baseDelay = 50, variance = 20, maxStep = 5 } = {}) {
+    this.baseDelay = baseDelay;
+    this.variance = variance;
+    this.maxStep = maxStep;
+    this.currentDelay = baseDelay;
+    this.minDelay = Math.max(0, baseDelay - variance);
+    this.maxDelay = baseDelay + variance;
+  }
+
+  nextDelay() {
+    const step = (Math.random() * 2 - 1) * this.maxStep;
+    this.currentDelay += step;
+    if (this.currentDelay < this.minDelay) {
+      this.currentDelay = this.minDelay;
+    } else if (this.currentDelay > this.maxDelay) {
+      this.currentDelay = this.maxDelay;
+    }
+    return this.currentDelay;
+  }
+
+  schedule(tokens, callback) {
+    let index = 0;
+    const send = () => {
+      if (index >= tokens.length) {
+        return;
+      }
+      callback(tokens[index], index);
+      index += 1;
+      setTimeout(send, this.nextDelay());
+    };
+    send();
+  }
+}
+
+module.exports = { TokenScheduler };

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "script.js",
   "scripts": {
     "build": "node scripts/build.js",
-    "test": "html-validate index.html search.html diagnostics.html && node diagnostics.test.js",
+    "test": "html-validate index.html search.html diagnostics.html && node diagnostics.test.js && node tokenScheduler.test.js",
     "watch": "chokidar \"**/*.html\" -c \"npm run build\""
   },
   "keywords": [],

--- a/tokenScheduler.test.js
+++ b/tokenScheduler.test.js
@@ -1,0 +1,23 @@
+const assert = require("assert");
+const { TokenScheduler } = require("./assets/js/tokenScheduler");
+
+const baseDelay = 40;
+const variance = 10;
+const maxStep = 5;
+const scheduler = new TokenScheduler({ baseDelay, variance, maxStep });
+
+let previous = baseDelay;
+for (let i = 0; i < 100; i++) {
+  const delay = scheduler.nextDelay();
+  assert(
+    delay >= baseDelay - variance && delay <= baseDelay + variance,
+    `delay ${delay} out of bounds`,
+  );
+  assert(
+    Math.abs(delay - previous) <= maxStep,
+    `step too large between ${previous} and ${delay}`,
+  );
+  previous = delay;
+}
+
+console.log("TokenScheduler variance test passed");


### PR DESCRIPTION
## Summary
- implement `TokenScheduler` to emit tokens with smooth delay variance
- add boundary tests for scheduler delay steps and range
- run token scheduler test as part of `npm test`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5b60c29f4832887fb0a3d47b7c4b1