### PR TITLE
Add retry bubble with countdown and backoff

### DIFF
--- a/script.js
+++ b/script.js
@@ -5,12 +5,34 @@ const randomButton = document.getElementById("random-term");
 const alphaNav = document.getElementById("alpha-nav");
 const darkModeToggle = document.getElementById("dark-mode-toggle");
 const showFavoritesToggle = document.getElementById("show-favorites");
-const favorites = new Set(JSON.parse(localStorage.getItem("favorites") || "[]"));
+const favorites = new Set(
+  JSON.parse(localStorage.getItem("favorites") || "[]"),
+);
 const siteUrl = "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/";
 const canonicalLink = document.getElementById("canonical-link");
 
 let currentLetterFilter = "All";
 let termsData = { terms: [] };
+
+const retryBubble = document.createElement("div");
+retryBubble.id = "retry-bubble";
+retryBubble.innerHTML =
+  '<span id="retry-message"></span><button id="retry-now" type="button">Retry Now</button>';
+retryBubble.style.display = "none";
+document.body.appendChild(retryBubble);
+
+const retryMessage = document.getElementById("retry-message");
+const retryNowButton = document.getElementById("retry-now");
+let retryAttempt = 0;
+let retryTimeout;
+let retryInterval;
+
+retryNowButton.addEventListener("click", () => {
+  clearTimeout(retryTimeout);
+  clearInterval(retryInterval);
+  loadTerms();
+  hideRetryBubble();
+});
 
 if (localStorage.getItem("darkMode") === "true") {
   document.body.classList.add("dark-mode");
@@ -19,7 +41,10 @@ if (localStorage.getItem("darkMode") === "true") {
 if (darkModeToggle) {
   darkModeToggle.addEventListener("click", () => {
     document.body.classList.toggle("dark-mode");
-    localStorage.setItem("darkMode", document.body.classList.contains("dark-mode"));
+    localStorage.setItem(
+      "darkMode",
+      document.body.classList.contains("dark-mode"),
+    );
   });
 }
 
@@ -27,7 +52,32 @@ window.addEventListener("DOMContentLoaded", () => {
   loadTerms();
 });
 
+function hideRetryBubble() {
+  retryBubble.style.display = "none";
+  clearTimeout(retryTimeout);
+  clearInterval(retryInterval);
+}
+
+function scheduleRetry() {
+  const delay = Math.min(30000, 2000 * Math.pow(2, retryAttempt - 1));
+  let remaining = Math.ceil(delay / 1000);
+  retryMessage.textContent = `Retrying in ${remaining}s...`;
+  retryBubble.style.display = "block";
+  retryInterval = setInterval(() => {
+    remaining -= 1;
+    if (remaining <= 0) {
+      clearInterval(retryInterval);
+    }
+    retryMessage.textContent = `Retrying in ${remaining}s...`;
+  }, 1000);
+  retryTimeout = setTimeout(() => {
+    hideRetryBubble();
+    loadTerms();
+  }, delay);
+}
+
 function loadTerms() {
+  hideRetryBubble();
   fetch("terms.json")
     .then((response) => {
       if (!response.ok) {
@@ -36,6 +86,7 @@ function loadTerms() {
       return response.json();
     })
     .then((data) => {
+      retryAttempt = 0;
       termsData = data;
       removeDuplicateTermsAndDefinitions();
       termsData.terms.sort((a, b) => a.term.localeCompare(b.term));
@@ -43,9 +94,11 @@ function loadTerms() {
       populateTermsList();
 
       if (window.location.hash) {
-        const termFromHash = decodeURIComponent(window.location.hash.substring(1));
+        const termFromHash = decodeURIComponent(
+          window.location.hash.substring(1),
+        );
         const matchedTerm = termsData.terms.find(
-          (t) => t.term.toLowerCase() === termFromHash.toLowerCase()
+          (t) => t.term.toLowerCase() === termFromHash.toLowerCase(),
         );
         if (matchedTerm) {
           displayDefinition(matchedTerm);
@@ -56,15 +109,9 @@ function loadTerms() {
       console.error("Detailed error fetching data:", error);
       definitionContainer.style.display = "block";
       definitionContainer.innerHTML =
-        '<p>Unable to load dictionary data. Please check your connection and try again.</p>' +
-        '<button id="retry-fetch">Retry</button>';
-      const retryBtn = document.getElementById("retry-fetch");
-      if (retryBtn) {
-        retryBtn.addEventListener("click", (e) => {
-          e.stopPropagation();
-          loadTerms();
-        });
-      }
+        "<p>Unable to load dictionary data. Please check your connection.</p>";
+      retryAttempt += 1;
+      scheduleRetry();
     });
 }
 
@@ -97,12 +144,16 @@ function toggleFavorite(term) {
 }
 
 function highlightActiveButton(button) {
-  alphaNav.querySelectorAll("button").forEach((btn) => btn.classList.remove("active"));
+  alphaNav
+    .querySelectorAll("button")
+    .forEach((btn) => btn.classList.remove("active"));
   button.classList.add("active");
 }
 
 function buildAlphaNav() {
-  const letters = Array.from(new Set(termsData.terms.map((t) => t.term.charAt(0).toUpperCase()))).sort();
+  const letters = Array.from(
+    new Set(termsData.terms.map((t) => t.term.charAt(0).toUpperCase())),
+  ).sort();
 
   const allButton = document.createElement("button");
   allButton.textContent = "All";
@@ -134,9 +185,13 @@ function populateTermsList() {
     .sort((a, b) => a.term.localeCompare(b.term))
     .forEach((item) => {
       const matchesSearch = item.term.toLowerCase().includes(searchValue);
-      const matchesFavorites = !showFavoritesToggle || !showFavoritesToggle.checked || favorites.has(item.term);
+      const matchesFavorites =
+        !showFavoritesToggle ||
+        !showFavoritesToggle.checked ||
+        favorites.has(item.term);
       const matchesLetter =
-        currentLetterFilter === "All" || item.term.charAt(0).toUpperCase() === currentLetterFilter;
+        currentLetterFilter === "All" ||
+        item.term.charAt(0).toUpperCase() === currentLetterFilter;
       if (matchesSearch && matchesFavorites && matchesLetter) {
         const termDiv = document.createElement("div");
         termDiv.classList.add("dictionary-item");
@@ -187,7 +242,7 @@ function displayDefinition(term) {
   if (canonicalLink) {
     canonicalLink.setAttribute(
       "href",
-      `${siteUrl}#${encodeURIComponent(term.term)}`
+      `${siteUrl}#${encodeURIComponent(term.term)}`,
     );
   }
 }
@@ -195,19 +250,27 @@ function displayDefinition(term) {
 function clearDefinition() {
   definitionContainer.style.display = "none";
   definitionContainer.innerHTML = "";
-  history.replaceState(null, "", window.location.pathname + window.location.search);
+  history.replaceState(
+    null,
+    "",
+    window.location.pathname + window.location.search,
+  );
   if (canonicalLink) {
     canonicalLink.setAttribute("href", siteUrl);
   }
 }
 
 function showRandomTerm() {
-  const randomTerm = termsData.terms[Math.floor(Math.random() * termsData.terms.length)];
+  const randomTerm =
+    termsData.terms[Math.floor(Math.random() * termsData.terms.length)];
   displayDefinition(randomTerm);
 
   const today = new Date().toDateString();
   try {
-    localStorage.setItem("lastRandomTerm", JSON.stringify({ date: today, term: randomTerm }));
+    localStorage.setItem(
+      "lastRandomTerm",
+      JSON.stringify({ date: today, term: randomTerm }),
+    );
   } catch (e) {
     // Ignore storage errors
   }
@@ -249,8 +312,7 @@ window.addEventListener("scroll", () => {
   scrollBtn.style.display = window.scrollY > 200 ? "block" : "none";
 });
 scrollBtn.addEventListener("click", () =>
-  window.scrollTo({ top: 0, behavior: "smooth" })
+  window.scrollTo({ top: 0, behavior: "smooth" }),
 );
 
 definitionContainer.addEventListener("click", clearDefinition);
-

--- a/styles.css
+++ b/styles.css
@@ -25,7 +25,7 @@ body {
 
 h1 {
   text-align: center;
-  font-family: 'Cinzel', serif;
+  font-family: "Cinzel", serif;
   font-weight: 700;
   font-size: 48px;
   margin-bottom: 20px;
@@ -110,7 +110,6 @@ body.dark-mode mark {
   box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
   min-height: 44px;
 }
-
 
 /* Controls styling */
 #random-term {
@@ -206,7 +205,9 @@ label {
   border-radius: 4px;
   padding: 10px;
   cursor: pointer;
-  transition: background-color 0.2s, color 0.2s;
+  transition:
+    background-color 0.2s,
+    color 0.2s;
   min-width: 44px;
   min-height: 44px;
 }
@@ -240,6 +241,33 @@ label {
 
 #scrollToTopBtn:hover {
   background-color: #0056b3;
+}
+
+/* Retry bubble */
+#retry-bubble {
+  display: none;
+  position: fixed;
+  bottom: 20px;
+  left: 20px;
+  background-color: #007bff;
+  color: #fff;
+  padding: 10px;
+  border-radius: 5px;
+  z-index: 1000;
+}
+
+#retry-bubble button {
+  margin-left: 10px;
+  background: transparent;
+  border: 1px solid #fff;
+  color: #fff;
+  border-radius: 4px;
+  padding: 2px 6px;
+  cursor: pointer;
+}
+
+#retry-bubble button:hover {
+  background-color: rgba(255, 255, 255, 0.2);
 }
 
 /* Dark Mode styles */
@@ -324,6 +352,15 @@ body.dark-mode #alpha-nav button:focus {
 body.dark-mode #alpha-nav button.active {
   background-color: #007bff;
   border-color: #007bff;
+}
+
+body.dark-mode #retry-bubble {
+  background-color: #333;
+}
+
+body.dark-mode #retry-bubble button {
+  border-color: #fff;
+  color: #fff;
 }
 
 @media (max-width: 480px) {


### PR DESCRIPTION
## Summary
- add retry bubble with visible countdown and manual retry
- implement exponential backoff for loading terms
- style retry bubble with dark mode support

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5b60ee18c832883195ac1ffdafd06