### PR TITLE
Add haptic feedback with reduced-motion safeguards

### DIFF
--- a/assets/js/haptics.js
+++ b/assets/js/haptics.js
@@ -1,0 +1,24 @@
+(function () {
+  const reduceMotionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+  function vibrate(pattern) {
+    if (reduceMotionQuery.matches) return;
+    if (typeof navigator.vibrate === 'function' && navigator.maxTouchPoints > 0) {
+      navigator.vibrate(pattern);
+    }
+  }
+
+  function success() {
+    vibrate(20);
+  }
+
+  function error() {
+    vibrate([40, 60, 40]);
+  }
+
+  window.haptics = {
+    vibrate,
+    success,
+    error,
+  };
+})();

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -13,6 +13,9 @@
       })
       .catch(err => {
         console.error('Failed to load terms.json', err);
+        if (window.haptics) {
+          haptics.error();
+        }
       });
 
     searchInput.addEventListener('input', handleSearch);
@@ -32,6 +35,10 @@
     matches.forEach(({ term }) => {
       resultsContainer.appendChild(renderCard(term));
     });
+
+    if (matches.length && window.haptics) {
+      haptics.success();
+    }
   }
 
   function score(term, query){

--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
   <footer aria-label="Project contribution">
     <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
   </footer>
+  <script src="assets/js/haptics.js"></script>
   <script src="script.js"></script>
   <script src="assets/js/app.js"></script>
   <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>

--- a/script.js
+++ b/script.js
@@ -65,6 +65,9 @@ function loadTerms() {
           loadTerms();
         });
       }
+      if (window.haptics) {
+        haptics.error();
+      }
     });
 }
 
@@ -93,6 +96,9 @@ function toggleFavorite(term) {
     localStorage.setItem("favorites", JSON.stringify(Array.from(favorites)));
   } catch (e) {
     // Ignore storage errors
+  }
+  if (window.haptics) {
+    haptics.success();
   }
 }
 
@@ -189,6 +195,9 @@ function displayDefinition(term) {
       "href",
       `${siteUrl}#${encodeURIComponent(term.term)}`
     );
+  }
+  if (window.haptics) {
+    haptics.success();
   }
 }
 

--- a/search.html
+++ b/search.html
@@ -15,6 +15,7 @@
   <script>
     window.__BASE_URL__ = window.__BASE_URL__ || '';
   </script>
+  <script src="assets/js/haptics.js"></script>
   <script src="assets/js/search.js"></script>
   <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
   <script src="assets/js/metrics.js"></script>


### PR DESCRIPTION
## Summary
- add utility for mobile haptic feedback that disables itself when `prefers-reduced-motion` is enabled
- wire haptics into dictionary and search interfaces for success and error feedback
- load new haptics module on relevant pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5b60476188328b8dc9644ceb96d79