### PR TITLE
feat: add citation highlighting and navigation

### DIFF
--- a/script.js
+++ b/script.js
@@ -183,6 +183,7 @@ function populateTermsList() {
 function displayDefinition(term) {
   definitionContainer.style.display = "block";
   definitionContainer.innerHTML = `<h3>${term.term}</h3><p>${term.definition}</p>`;
+  processCitations(definitionContainer);
   window.location.hash = encodeURIComponent(term.term);
   if (canonicalLink) {
     canonicalLink.setAttribute(
@@ -253,4 +254,39 @@ scrollBtn.addEventListener("click", () =>
 );
 
 definitionContainer.addEventListener("click", clearDefinition);
+
+function processCitations(container) {
+  const chunks = container.querySelectorAll("p, div");
+  chunks.forEach((chunk) => {
+    const cites = chunk.querySelectorAll("a[data-cite]");
+    if (cites.length === 0) return;
+
+    const list = document.createElement("ol");
+    list.className = "citation-group";
+
+    cites.forEach((cite) => {
+      const label = cite.dataset.cite || cite.textContent;
+      const targetId = cite.getAttribute("href").slice(1);
+
+      const item = document.createElement("li");
+      item.textContent = label;
+      item.addEventListener("click", (e) => {
+        e.preventDefault();
+        const target = container.querySelector(`#${CSS.escape(targetId)}`);
+        if (target) {
+          target.scrollIntoView({ behavior: "smooth", block: "center" });
+          target.classList.add("pulse");
+          setTimeout(() => target.classList.remove("pulse"), 1000);
+        }
+      });
+
+      list.appendChild(item);
+
+      cite.classList.add("citation-highlight");
+      requestAnimationFrame(() => cite.classList.add("revealed"));
+    });
+
+    chunk.appendChild(list);
+  });
+}
 

--- a/styles.css
+++ b/styles.css
@@ -347,3 +347,50 @@ body.dark-mode #alpha-nav button.active {
     font-size: 14px;
   }
 }
+
+.citation-group {
+  margin-top: 0.5rem;
+  font-size: 0.9em;
+  padding-left: 1.2em;
+}
+
+.citation-group li {
+  cursor: pointer;
+}
+
+.citation-highlight {
+  position: relative;
+}
+
+.citation-highlight::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  height: 100%;
+  background: #fff59d;
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.3s ease-in-out;
+}
+
+.citation-highlight.revealed::after {
+  transform: scaleX(1);
+}
+
+.pulse {
+  animation: pulse 1s ease;
+}
+
+@keyframes pulse {
+  0% {
+    box-shadow: 0 0 0 0 rgba(255, 193, 7, 0.7);
+  }
+  70% {
+    box-shadow: 0 0 0 10px rgba(255, 193, 7, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(255, 193, 7, 0);
+  }
+}


### PR DESCRIPTION
## Summary
- group citations within displayed definitions
- animate highlighted citations and pulse target on navigation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5b60fdc0483289f711b58b2cf65a3