### PR TITLE
Log host usage and preconnect to frequent hosts

### DIFF
--- a/assets/js/preconnect.js
+++ b/assets/js/preconnect.js
@@ -1,0 +1,88 @@
+(function () {
+  const STORAGE_KEY = "host-usage";
+  const MAX_PRECONNECTS = 5;
+
+  function getHost(url) {
+    try {
+      return new URL(url).origin;
+    } catch (e) {
+      return null;
+    }
+  }
+
+  function loadStats() {
+    try {
+      return JSON.parse(localStorage.getItem(STORAGE_KEY) || "{}");
+    } catch (e) {
+      return {};
+    }
+  }
+
+  function saveStats(stats) {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(stats));
+    } catch (e) {
+      // ignore storage errors
+    }
+  }
+
+  function preconnectHosts(stats) {
+    const entries = Object.entries(stats);
+    entries.sort((a, b) => (b[1].count || 0) - (a[1].count || 0));
+    const preconnected = [];
+    entries.slice(0, MAX_PRECONNECTS).forEach(([host]) => {
+      const link = document.createElement("link");
+      link.rel = "preconnect";
+      link.href = host;
+      link.crossOrigin = "";
+      document.head.appendChild(link);
+      preconnected.push(host);
+      console.log("preconnecting to", host);
+    });
+    return preconnected;
+  }
+
+  function logUsage(preconnected) {
+    const stats = loadStats();
+    const usedHosts = new Set();
+
+    performance.getEntriesByType("resource").forEach((entry) => {
+      const host = getHost(entry.name);
+      if (!host) return;
+      usedHosts.add(host);
+      if (!stats[host]) stats[host] = { count: 0, wins: 0, losses: 0 };
+      stats[host].count++;
+    });
+
+    preconnected.forEach((host) => {
+      if (!stats[host]) stats[host] = { count: 0, wins: 0, losses: 0 };
+      if (usedHosts.has(host)) {
+        stats[host].wins++;
+      } else {
+        stats[host].losses++;
+      }
+    });
+
+    saveStats(stats);
+
+    const totals = Object.values(stats).reduce(
+      (acc, s) => {
+        acc.wins += s.wins || 0;
+        acc.losses += s.losses || 0;
+        return acc;
+      },
+      { wins: 0, losses: 0 },
+    );
+    const totalPreconnects = totals.wins + totals.losses;
+    if (totalPreconnects > 0) {
+      const efficiency = (totals.wins / totalPreconnects).toFixed(2);
+      console.log(
+        `Preconnect efficiency: ${efficiency} (wins: ${totals.wins}, losses: ${totals.losses})`,
+      );
+    }
+  }
+
+  const stats = loadStats();
+  const preconnected = preconnectHosts(stats);
+  window.addEventListener("load", () => logUsage(preconnected));
+})();

--- a/diagnostics.html
+++ b/diagnostics.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Diagnostics</title>
+  <script src="assets/js/preconnect.js"></script>
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Cyber Security Dictionary</title>
+  <script src="assets/js/preconnect.js"></script>
   <link rel="stylesheet" href="styles.css">
   <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet">
   <link rel="canonical" id="canonical-link" href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/">

--- a/search.html
+++ b/search.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Search</title>
+  <script src="assets/js/preconnect.js"></script>
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>


### PR DESCRIPTION
## Summary
- track resource host usage and preconnect to frequently used hosts
- include preconnect script on all pages and report preconnect efficiency

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5b6329134832883b299aa1a795874