### PR TITLE
Add transform-based avatar morphing demo

### DIFF
--- a/assets/avatar-morphs.json
+++ b/assets/avatar-morphs.json
@@ -1,0 +1,4 @@
+{
+  "analyst": "M10 10h80v80h-80z",
+  "hacker": "M50 10L90 90H10z"
+}

--- a/assets/js/avatar-demo.js
+++ b/assets/js/avatar-demo.js
@@ -1,0 +1,13 @@
+import { initAvatar } from "./avatar-morph.js";
+
+(async () => {
+  let current = "analyst";
+  const morph = await initAvatar("avatar", current);
+  const btn = document.getElementById("toggle-avatar");
+  if (btn) {
+    btn.addEventListener("click", () => {
+      current = current === "analyst" ? "hacker" : "analyst";
+      morph(current);
+    });
+  }
+})();

--- a/assets/js/avatar-morph.js
+++ b/assets/js/avatar-morph.js
@@ -1,0 +1,31 @@
+export async function initAvatar(containerId, defaultPersona = "analyst") {
+  const container = document.getElementById(containerId);
+  if (!container) {
+    return () => {};
+  }
+  const res = await fetch("assets/avatar-morphs.json");
+  const data = await res.json();
+  const svgNS = "http://www.w3.org/2000/svg";
+  const svg = document.createElementNS(svgNS, "svg");
+  svg.setAttribute("viewBox", "0 0 100 100");
+  svg.setAttribute("class", "avatar-svg");
+  container.appendChild(svg);
+  const personas = {};
+  for (const [id, d] of Object.entries(data)) {
+    const path = document.createElementNS(svgNS, "path");
+    path.setAttribute("d", d);
+    path.setAttribute("class", "avatar-persona");
+    path.setAttribute("fill", "currentColor");
+    path.style.transformOrigin = "50% 50%";
+    path.style.transition = "transform 240ms ease-in-out";
+    path.style.willChange = "transform";
+    path.style.transform = id === defaultPersona ? "scale(1)" : "scale(0)";
+    svg.appendChild(path);
+    personas[id] = path;
+  }
+  return function morph(to) {
+    for (const [id, path] of Object.entries(personas)) {
+      path.style.transform = id === to ? "scale(1)" : "scale(0)";
+    }
+  };
+}

--- a/index.html
+++ b/index.html
@@ -16,6 +16,9 @@
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">
 
+    <div id="avatar" aria-hidden="true"></div>
+    <button id="toggle-avatar" type="button" aria-label="Toggle avatar persona">Toggle Avatar</button>
+
     <button id="random-term" type="button" aria-label="Show random term">Random Term</button>
 
     <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">Toggle Dark Mode</button>
@@ -36,6 +39,6 @@
   <script src="assets/js/app.js"></script>
   <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
   <script src="assets/js/metrics.js"></script>
+  <script type="module" src="assets/js/avatar-demo.js"></script>
 </body>
 </html>
-

--- a/styles.css
+++ b/styles.css
@@ -25,7 +25,7 @@ body {
 
 h1 {
   text-align: center;
-  font-family: 'Cinzel', serif;
+  font-family: "Cinzel", serif;
   font-weight: 700;
   font-size: 48px;
   margin-bottom: 20px;
@@ -111,6 +111,24 @@ body.dark-mode mark {
   min-height: 44px;
 }
 
+#avatar {
+  width: 100px;
+  height: 100px;
+  margin: 1rem auto;
+}
+
+#avatar svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.avatar-persona {
+  transform: scale(0);
+  transition: transform 240ms ease-in-out;
+  transform-origin: 50% 50%;
+  will-change: transform;
+}
 
 /* Controls styling */
 #random-term {
@@ -206,7 +224,9 @@ label {
   border-radius: 4px;
   padding: 10px;
   cursor: pointer;
-  transition: background-color 0.2s, color 0.2s;
+  transition:
+    background-color 0.2s,
+    color 0.2s;
   min-width: 44px;
   min-height: 44px;
 }


### PR DESCRIPTION
## Summary
- add SVG path data for two avatar personas
- create JS modules to morph between personas using 240ms transform transitions
- style and integrate avatar demo without causing layout shifts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5b61601a483289ac74fd3f20137f2