### PR TITLE
feat: add public definitions API

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,24 @@ https://alex-unnippillil.github.io/CyberSecuirtyDictionary/
 
 ## Security
 For information on reporting vulnerabilities, please see our [Security Policy](SECURITY.md).
+
+## API
+
+Public clients can fetch individual term definitions via a simple HTTP API.
+
+### `GET /api/definitions/{slug}`
+
+Returns JSON containing the term, its definition, and the source URLs used to
+compile the entry. Example response:
+
+```json
+{
+  "term": "cve",
+  "definition": "A public catalog of cybersecurity vulnerabilities providing unique identifiers for known software flaws.",
+  "sources": ["https://cve.mitre.org"]
+}
+```
+
+The endpoint sets permissive CORS headers and enforces a rate limit of 60
+requests per minute per IP address. Exceeding the limit results in a `429 Too
+Many Requests` response.

--- a/app/api/definitions/[slug]/route.ts
+++ b/app/api/definitions/[slug]/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest, NextResponse } from "next/server";
+import fs from "fs";
+import path from "path";
+import yaml from "js-yaml";
+
+interface TermEntry {
+  name: string;
+  slug: string;
+  definition: string;
+  sources?: string[];
+}
+
+let cache: TermEntry[] | null = null;
+function getTerms(): TermEntry[] {
+  if (cache) return cache;
+  const filePath = path.join(process.cwd(), "data", "terms.yaml");
+  const file = fs.readFileSync(filePath, "utf8");
+  cache = yaml.load(file) as TermEntry[];
+  return cache;
+}
+
+const RATE_LIMIT = 60; // requests per minute per IP
+const WINDOW = 60 * 1000;
+const ipHits = new Map<string, { count: number; start: number }>();
+
+function allowRequest(ip: string): boolean {
+  const now = Date.now();
+  const hit = ipHits.get(ip);
+  if (!hit || now - hit.start > WINDOW) {
+    ipHits.set(ip, { count: 1, start: now });
+    return true;
+  }
+  if (hit.count >= RATE_LIMIT) {
+    return false;
+  }
+  hit.count += 1;
+  return true;
+}
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type"
+};
+
+export function OPTIONS() {
+  return NextResponse.json({}, { headers: corsHeaders });
+}
+
+export function GET(req: NextRequest, { params }: { params: { slug: string } }) {
+  const ip = req.headers.get("x-forwarded-for") || "unknown";
+  if (!allowRequest(ip)) {
+    return new NextResponse("Too Many Requests", { status: 429, headers: corsHeaders });
+  }
+
+  const term = getTerms().find(t => t.slug === params.slug);
+  if (!term) {
+    return new NextResponse("Not Found", { status: 404, headers: corsHeaders });
+  }
+
+  const body = {
+    term: term.name,
+    definition: term.definition,
+    sources: term.sources || []
+  };
+
+  return NextResponse.json(body, { headers: corsHeaders });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,13 @@
       "name": "cybersecuirtydictionary",
       "version": "1.0.0",
       "license": "ISC",
+      "dependencies": {
+        "js-yaml": "^4.1.0"
+      },
       "devDependencies": {
         "chokidar-cli": "^3.0.0",
         "html-validate": "^10.0.0",
         "http-server": "^14.1.1",
-        "js-yaml": "^4.1.0",
         "jsdom": "^26.1.0",
         "prettier": "^3.6.2"
       }
@@ -297,7 +299,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/async": {
@@ -1244,7 +1245,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -11,11 +11,13 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
+  "dependencies": {
+    "js-yaml": "^4.1.0"
+  },
   "devDependencies": {
     "chokidar-cli": "^3.0.0",
     "html-validate": "^10.0.0",
     "http-server": "^14.1.1",
-    "js-yaml": "^4.1.0",
     "prettier": "^3.6.2",
     "jsdom": "^26.1.0"
   }


### PR DESCRIPTION
## Summary
- add `/api/definitions/[slug]` route returning definition and sources
- enable CORS and per-IP rate limiting on the endpoint
- document API usage and schema for external clients

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5b659961c832884e38ca722c878c5