### PR TITLE
Implement OffscreenCanvas worker demo with fallback

### DIFF
--- a/assets/js/canvas-demo.js
+++ b/assets/js/canvas-demo.js
@@ -1,0 +1,54 @@
+(function () {
+  const canvas = document.getElementById("perf-canvas");
+  const readout = document.getElementById("frame-time");
+  const supportInfo = document.getElementById("support-info");
+  if (!canvas || !readout || !supportInfo) return;
+
+  const supportsOffscreen =
+    typeof OffscreenCanvas !== "undefined" && canvas.transferControlToOffscreen;
+  supportInfo.textContent = supportsOffscreen
+    ? "OffscreenCanvas supported: rendering in worker"
+    : "OffscreenCanvas not supported: rendering on main thread";
+
+  if (supportsOffscreen) {
+    const offscreen = canvas.transferControlToOffscreen();
+    const worker = new Worker("assets/js/canvas-worker.js");
+    worker.postMessage({ canvas: offscreen }, [offscreen]);
+    worker.onmessage = (e) => {
+      if (e.data && e.data.avg) {
+        readout.textContent = `Average frame time: ${e.data.avg.toFixed(2)} ms`;
+      }
+    };
+  } else {
+    const ctx = canvas.getContext("2d");
+    let last = performance.now();
+    let times = [];
+    function draw() {
+      const now = performance.now();
+      times.push(now - last);
+      last = now;
+      if (times.length >= 60) {
+        const avg = times.reduce((a, b) => a + b) / times.length;
+        readout.textContent = `Average frame time: ${avg.toFixed(2)} ms`;
+        times = [];
+      }
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      for (let i = 0; i < 100000; i++) {
+        Math.sqrt(i);
+      }
+      ctx.fillStyle =
+        "#" +
+        Math.floor(Math.random() * 0xffffff)
+          .toString(16)
+          .padStart(6, "0");
+      ctx.fillRect(
+        Math.random() * canvas.width,
+        Math.random() * canvas.height,
+        50,
+        50,
+      );
+      requestAnimationFrame(draw);
+    }
+    draw();
+  }
+})();

--- a/assets/js/canvas-worker.js
+++ b/assets/js/canvas-worker.js
@@ -1,0 +1,38 @@
+self.onmessage = (e) => {
+  const canvas = e.data.canvas;
+  const ctx = canvas.getContext("2d");
+  let last = performance.now();
+  let times = [];
+
+  function draw() {
+    const now = performance.now();
+    times.push(now - last);
+    last = now;
+    if (times.length >= 60) {
+      const avg = times.reduce((a, b) => a + b) / times.length;
+      self.postMessage({ avg });
+      times = [];
+    }
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    for (let i = 0; i < 100000; i++) {
+      Math.sqrt(i);
+    }
+    ctx.fillStyle =
+      "#" +
+      Math.floor(Math.random() * 0xffffff)
+        .toString(16)
+        .padStart(6, "0");
+    ctx.fillRect(
+      Math.random() * canvas.width,
+      Math.random() * canvas.height,
+      50,
+      50,
+    );
+    if (self.requestAnimationFrame) {
+      self.requestAnimationFrame(draw);
+    } else {
+      setTimeout(draw, 16);
+    }
+  }
+  draw();
+};

--- a/canvas.html
+++ b/canvas.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Canvas Performance Demo</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="container">
+      <h1>Canvas Performance Demo</h1>
+      <p id="support-info"></p>
+      <canvas id="perf-canvas" width="300" height="150"></canvas>
+      <p id="frame-time"></p>
+    </main>
+    <script src="assets/js/canvas-demo.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add demo page for measuring rendering performance
- detect OffscreenCanvas support and route rendering to worker when available
- fall back to main-thread canvas rendering when OffscreenCanvas unsupported

## Testing
- `npx html-validate index.html search.html diagnostics.html canvas.html`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5b66557cc8328a49cb157ca729416