### PR TITLE
feat: add FPS telemetry and dashboard

### DIFF
--- a/assets/js/diagnostics.js
+++ b/assets/js/diagnostics.js
@@ -1,18 +1,19 @@
 (function () {
-  const KEY = 'web-vitals';
+  const KEY = "web-vitals";
+  const FPS_KEY = "fps-metrics";
 
   function renderDiagnostics() {
-    const tbody = document.getElementById('metrics-body');
+    const tbody = document.getElementById("metrics-body");
     if (!tbody) return;
     let samples = [];
     try {
-      samples = JSON.parse(localStorage.getItem(KEY) || '[]');
+      samples = JSON.parse(localStorage.getItem(KEY) || "[]");
     } catch (e) {
       samples = [];
     }
-    tbody.innerHTML = '';
+    tbody.innerHTML = "";
     samples.forEach((s) => {
-      const tr = document.createElement('tr');
+      const tr = document.createElement("tr");
       const date = new Date(s.timestamp).toISOString();
       const lcp = s.lcp != null && s.lcp.toFixed ? s.lcp.toFixed(2) : s.lcp;
       const cls = s.cls != null && s.cls.toFixed ? s.cls.toFixed(3) : s.cls;
@@ -20,8 +21,38 @@
       tr.innerHTML = `<td>${date}</td><td>${lcp}</td><td>${cls}</td><td>${tbt}</td>`;
       tbody.appendChild(tr);
     });
+
+    renderFps();
+  }
+
+  function renderFps() {
+    const tbody = document.getElementById("fps-body");
+    if (!tbody) return;
+    let samples = [];
+    try {
+      samples = JSON.parse(localStorage.getItem(FPS_KEY) || "[]");
+    } catch (e) {
+      samples = [];
+    }
+    const byRoute = {};
+    samples.forEach((s) => {
+      if (!byRoute[s.route]) byRoute[s.route] = [];
+      byRoute[s.route].push(s.fps);
+    });
+    tbody.innerHTML = "";
+    Object.keys(byRoute).forEach((route) => {
+      const fpsList = byRoute[route].sort((a, b) => a - b);
+      const mid = Math.floor(fpsList.length / 2);
+      const median =
+        fpsList.length % 2
+          ? fpsList[mid]
+          : (fpsList[mid - 1] + fpsList[mid]) / 2;
+      const tr = document.createElement("tr");
+      tr.innerHTML = `<td>${route}</td><td>${median.toFixed(1)}</td>`;
+      tbody.appendChild(tr);
+    });
   }
 
   window.renderDiagnostics = renderDiagnostics;
-  window.addEventListener('DOMContentLoaded', renderDiagnostics);
+  window.addEventListener("DOMContentLoaded", renderDiagnostics);
 })();

--- a/assets/js/metrics.js
+++ b/assets/js/metrics.js
@@ -1,9 +1,20 @@
+/**
+ * Collects performance metrics and samples FPS during active sessions.
+ * Metrics are persisted to localStorage and periodically sent to a
+ * telemetry endpoint with no identifying information.
+ */
 (function () {
-  const KEY = 'web-vitals';
+  const KEY = "web-vitals";
+  const FPS_KEY = "fps-metrics";
+  const TELEMETRY_URL = "https://example.com/telemetry";
+
+  let fpsBuffer = [];
+  let frameCount = 0;
+  let lastFrame = performance.now();
 
   function storeSample(sample) {
     try {
-      const samples = JSON.parse(localStorage.getItem(KEY) || '[]');
+      const samples = JSON.parse(localStorage.getItem(KEY) || "[]");
       samples.push(sample);
       while (samples.length > 20) samples.shift();
       localStorage.setItem(KEY, JSON.stringify(samples));
@@ -11,6 +22,67 @@
       // ignore storage errors
     }
   }
+
+  function storeFpsSample(sample) {
+    try {
+      const samples = JSON.parse(localStorage.getItem(FPS_KEY) || "[]");
+      samples.push(sample);
+      while (samples.length > 50) samples.shift();
+      localStorage.setItem(FPS_KEY, JSON.stringify(samples));
+    } catch (e) {
+      // ignore storage errors
+    }
+  }
+
+  function sendTelemetry() {
+    if (!fpsBuffer.length) return;
+    const payload = { samples: fpsBuffer.slice() };
+    fpsBuffer = [];
+    try {
+      const body = JSON.stringify(payload);
+      if (navigator.sendBeacon) {
+        navigator.sendBeacon(TELEMETRY_URL, body);
+      } else {
+        fetch(TELEMETRY_URL, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body,
+          keepalive: true,
+        });
+      }
+    } catch (e) {
+      // ignore network errors
+    }
+  }
+
+  function sampleFps(now) {
+    frameCount++;
+    const diff = now - lastFrame;
+    if (diff >= 1000) {
+      const fps = Math.round((frameCount * 1000) / diff);
+      const sample = { timestamp: Date.now(), route: location.pathname, fps };
+      storeFpsSample(sample);
+      fpsBuffer.push(sample);
+      frameCount = 0;
+      lastFrame = now;
+    }
+    if (!document.hidden) {
+      requestAnimationFrame(sampleFps);
+    }
+  }
+
+  function startSampler() {
+    lastFrame = performance.now();
+    frameCount = 0;
+    requestAnimationFrame(sampleFps);
+  }
+
+  document.addEventListener("visibilitychange", () => {
+    if (!document.hidden) startSampler();
+  });
+
+  setInterval(sendTelemetry, 30000);
+  window.addEventListener("beforeunload", sendTelemetry);
 
   function init() {
     if (!window.webVitals) return;
@@ -24,19 +96,21 @@
       sample.cls = value;
     });
 
-    window.addEventListener('load', () => {
-      const tasks = performance.getEntriesByType('longtask');
+    window.addEventListener("load", () => {
+      const tasks = performance.getEntriesByType("longtask");
       sample.tbt = tasks.reduce(
         (sum, task) => sum + Math.max(0, task.duration - 50),
-        0
+        0,
       );
       setTimeout(() => storeSample(sample), 0);
     });
+
+    startSampler();
   }
 
-  if (document.readyState === 'complete') {
+  if (document.readyState === "complete") {
     init();
   } else {
-    window.addEventListener('DOMContentLoaded', init);
+    window.addEventListener("DOMContentLoaded", init);
   }
 })();

--- a/diagnostics.html
+++ b/diagnostics.html
@@ -1,21 +1,36 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Diagnostics</title>
-  <link rel="stylesheet" href="styles.css">
-</head>
-<body>
-  <main class="container">
-    <h1>Performance Diagnostics</h1>
-    <table>
-      <thead>
-        <tr><th>Timestamp</th><th>LCP</th><th>CLS</th><th>TBT</th></tr>
-      </thead>
-      <tbody id="metrics-body"></tbody>
-    </table>
-  </main>
-  <script src="assets/js/diagnostics.js"></script>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Diagnostics</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="container">
+      <h1>Performance Diagnostics</h1>
+      <table>
+        <thead>
+          <tr>
+            <th>Timestamp</th>
+            <th>LCP</th>
+            <th>CLS</th>
+            <th>TBT</th>
+          </tr>
+        </thead>
+        <tbody id="metrics-body"></tbody>
+      </table>
+      <h2>Median FPS Per Route</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Route</th>
+            <th>Median FPS</th>
+          </tr>
+        </thead>
+        <tbody id="fps-body"></tbody>
+      </table>
+    </main>
+    <script src="assets/js/diagnostics.js"></script>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- capture frames-per-second during active sessions
- periodically send anonymized FPS metrics to telemetry endpoint
- display median FPS per route on diagnostics page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5b6666e7c83289d908d338be2ca2f