### PR TITLE
Adjust skeleton loader based on cache

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 
+    <div id="loading-skeleton" class="skeleton" aria-hidden="true"></div>
     <ul id="terms-list"></ul>
   </main>
   <footer class="container" aria-label="Contribute">
@@ -38,4 +39,3 @@
   <script src="assets/js/metrics.js"></script>
 </body>
 </html>
-

--- a/script.js
+++ b/script.js
@@ -5,7 +5,10 @@ const randomButton = document.getElementById("random-term");
 const alphaNav = document.getElementById("alpha-nav");
 const darkModeToggle = document.getElementById("dark-mode-toggle");
 const showFavoritesToggle = document.getElementById("show-favorites");
-const favorites = new Set(JSON.parse(localStorage.getItem("favorites") || "[]"));
+const skeleton = document.getElementById("loading-skeleton");
+const favorites = new Set(
+  JSON.parse(localStorage.getItem("favorites") || "[]")
+);
 const siteUrl = "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/";
 const canonicalLink = document.getElementById("canonical-link");
 
@@ -19,7 +22,10 @@ if (localStorage.getItem("darkMode") === "true") {
 if (darkModeToggle) {
   darkModeToggle.addEventListener("click", () => {
     document.body.classList.toggle("dark-mode");
-    localStorage.setItem("darkMode", document.body.classList.contains("dark-mode"));
+    localStorage.setItem(
+      "darkMode",
+      document.body.classList.contains("dark-mode"),
+    );
   });
 }
 
@@ -27,45 +33,68 @@ window.addEventListener("DOMContentLoaded", () => {
   loadTerms();
 });
 
-function loadTerms() {
-  fetch("terms.json")
-    .then((response) => {
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
-      }
-      return response.json();
-    })
-    .then((data) => {
-      termsData = data;
-      removeDuplicateTermsAndDefinitions();
-      termsData.terms.sort((a, b) => a.term.localeCompare(b.term));
-      buildAlphaNav();
-      populateTermsList();
+async function loadTerms() {
+  const skeletonDelay = showSkeletonBasedOnCache();
+  try {
+    const response = await fetch("terms.json");
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+    const data = await response.json();
+    termsData = data;
+    removeDuplicateTermsAndDefinitions();
+    termsData.terms.sort((a, b) => a.term.localeCompare(b.term));
+    buildAlphaNav();
+    populateTermsList();
 
-      if (window.location.hash) {
-        const termFromHash = decodeURIComponent(window.location.hash.substring(1));
-        const matchedTerm = termsData.terms.find(
-          (t) => t.term.toLowerCase() === termFromHash.toLowerCase()
-        );
-        if (matchedTerm) {
-          displayDefinition(matchedTerm);
-        }
+    if (window.location.hash) {
+      const termFromHash = decodeURIComponent(
+        window.location.hash.substring(1),
+      );
+      const matchedTerm = termsData.terms.find(
+        (t) => t.term.toLowerCase() === termFromHash.toLowerCase(),
+      );
+      if (matchedTerm) {
+        displayDefinition(matchedTerm);
       }
-    })
-    .catch((error) => {
-      console.error("Detailed error fetching data:", error);
-      definitionContainer.style.display = "block";
-      definitionContainer.innerHTML =
-        '<p>Unable to load dictionary data. Please check your connection and try again.</p>' +
-        '<button id="retry-fetch">Retry</button>';
-      const retryBtn = document.getElementById("retry-fetch");
-      if (retryBtn) {
-        retryBtn.addEventListener("click", (e) => {
-          e.stopPropagation();
-          loadTerms();
-        });
-      }
-    });
+    }
+  } catch (error) {
+    console.error("Detailed error fetching data:", error);
+    definitionContainer.style.display = "block";
+    definitionContainer.innerHTML =
+      "<p>Unable to load dictionary data. Please check your connection and try again.</p>" +
+      '<button id="retry-fetch">Retry</button>';
+    const retryBtn = document.getElementById("retry-fetch");
+    if (retryBtn) {
+      retryBtn.addEventListener("click", (e) => {
+        e.stopPropagation();
+        loadTerms();
+      });
+    }
+  } finally {
+    await skeletonDelay;
+    if (skeleton) {
+      skeleton.style.display = "none";
+    }
+  }
+}
+
+async function showSkeletonBasedOnCache() {
+  if (!skeleton) {
+    return Promise.resolve();
+  }
+  let duration = 500;
+  if ("caches" in window) {
+    try {
+      const cached = await caches.match("terms.json");
+      duration = cached ? 100 : 500;
+    } catch (e) {
+      // Ignore cache errors and use fallback duration
+    }
+  }
+  skeleton.style.setProperty("--skeleton-duration", `${duration}ms`);
+  skeleton.style.display = "block";
+  return new Promise((resolve) => setTimeout(resolve, duration));
 }
 
 function removeDuplicateTermsAndDefinitions() {
@@ -97,12 +126,16 @@ function toggleFavorite(term) {
 }
 
 function highlightActiveButton(button) {
-  alphaNav.querySelectorAll("button").forEach((btn) => btn.classList.remove("active"));
+  alphaNav
+    .querySelectorAll("button")
+    .forEach((btn) => btn.classList.remove("active"));
   button.classList.add("active");
 }
 
 function buildAlphaNav() {
-  const letters = Array.from(new Set(termsData.terms.map((t) => t.term.charAt(0).toUpperCase()))).sort();
+  const letters = Array.from(
+    new Set(termsData.terms.map((t) => t.term.charAt(0).toUpperCase())),
+  ).sort();
 
   const allButton = document.createElement("button");
   allButton.textContent = "All";
@@ -134,9 +167,13 @@ function populateTermsList() {
     .sort((a, b) => a.term.localeCompare(b.term))
     .forEach((item) => {
       const matchesSearch = item.term.toLowerCase().includes(searchValue);
-      const matchesFavorites = !showFavoritesToggle || !showFavoritesToggle.checked || favorites.has(item.term);
+      const matchesFavorites =
+        !showFavoritesToggle ||
+        !showFavoritesToggle.checked ||
+        favorites.has(item.term);
       const matchesLetter =
-        currentLetterFilter === "All" || item.term.charAt(0).toUpperCase() === currentLetterFilter;
+        currentLetterFilter === "All" ||
+        item.term.charAt(0).toUpperCase() === currentLetterFilter;
       if (matchesSearch && matchesFavorites && matchesLetter) {
         const termDiv = document.createElement("div");
         termDiv.classList.add("dictionary-item");
@@ -187,7 +224,7 @@ function displayDefinition(term) {
   if (canonicalLink) {
     canonicalLink.setAttribute(
       "href",
-      `${siteUrl}#${encodeURIComponent(term.term)}`
+      `${siteUrl}#${encodeURIComponent(term.term)}`,
     );
   }
 }
@@ -195,19 +232,27 @@ function displayDefinition(term) {
 function clearDefinition() {
   definitionContainer.style.display = "none";
   definitionContainer.innerHTML = "";
-  history.replaceState(null, "", window.location.pathname + window.location.search);
+  history.replaceState(
+    null,
+    "",
+    window.location.pathname + window.location.search,
+  );
   if (canonicalLink) {
     canonicalLink.setAttribute("href", siteUrl);
   }
 }
 
 function showRandomTerm() {
-  const randomTerm = termsData.terms[Math.floor(Math.random() * termsData.terms.length)];
+  const randomTerm =
+    termsData.terms[Math.floor(Math.random() * termsData.terms.length)];
   displayDefinition(randomTerm);
 
   const today = new Date().toDateString();
   try {
-    localStorage.setItem("lastRandomTerm", JSON.stringify({ date: today, term: randomTerm }));
+    localStorage.setItem(
+      "lastRandomTerm",
+      JSON.stringify({ date: today, term: randomTerm }),
+    );
   } catch (e) {
     // Ignore storage errors
   }
@@ -249,8 +294,7 @@ window.addEventListener("scroll", () => {
   scrollBtn.style.display = window.scrollY > 200 ? "block" : "none";
 });
 scrollBtn.addEventListener("click", () =>
-  window.scrollTo({ top: 0, behavior: "smooth" })
+  window.scrollTo({ top: 0, behavior: "smooth" }),
 );
 
 definitionContainer.addEventListener("click", clearDefinition);
-

--- a/styles.css
+++ b/styles.css
@@ -25,7 +25,7 @@ body {
 
 h1 {
   text-align: center;
-  font-family: 'Cinzel', serif;
+  font-family: "Cinzel", serif;
   font-weight: 700;
   font-size: 48px;
   margin-bottom: 20px;
@@ -111,7 +111,26 @@ body.dark-mode mark {
   min-height: 44px;
 }
 
+.skeleton {
+  display: none;
+  width: 100%;
+  height: 1rem;
+  background-color: #eee;
+  border-radius: 4px;
+  animation: pulse var(--skeleton-duration, 500ms) ease-in-out infinite;
+}
 
+@keyframes pulse {
+  0% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+  100% {
+    opacity: 1;
+  }
+}
 /* Controls styling */
 #random-term {
   margin-top: 10px;
@@ -206,7 +225,9 @@ label {
   border-radius: 4px;
   padding: 10px;
   cursor: pointer;
-  transition: background-color 0.2s, color 0.2s;
+  transition:
+    background-color 0.2s,
+    color 0.2s;
   min-width: 44px;
   min-height: 44px;
 }

--- a/sw.js
+++ b/sw.js
@@ -1,36 +1,42 @@
-const CACHE_NAME = 'csd-cache-v1';
+const CACHE_NAME = "csd-cache-v1";
 const URLS_TO_CACHE = [
-  '/',
-  '/index.html',
-  '/styles.css',
-  '/script.js',
-  '/data.json'
+  "/",
+  "/index.html",
+  "/styles.css",
+  "/script.js",
+  "/terms.json",
 ];
 
-self.addEventListener('install', event => {
+self.addEventListener("install", (event) => {
   event.waitUntil(
-    caches.open(CACHE_NAME).then(cache => cache.addAll(URLS_TO_CACHE))
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(URLS_TO_CACHE)),
   );
 });
 
-self.addEventListener('activate', event => {
+self.addEventListener("activate", (event) => {
   event.waitUntil(
-    caches.keys().then(keys =>
-      Promise.all(
-        keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key))
-      )
-    )
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(
+          keys
+            .filter((key) => key !== CACHE_NAME)
+            .map((key) => caches.delete(key)),
+        ),
+      ),
   );
 });
 
-self.addEventListener('fetch', event => {
+self.addEventListener("fetch", (event) => {
   event.respondWith(
-    caches.match(event.request).then(response =>
-      response || fetch(event.request).catch(() => {
-        if (event.request.mode === 'navigate') {
-          return caches.match('/index.html');
-        }
-      })
-    )
+    caches.match(event.request).then(
+      (response) =>
+        response ||
+        fetch(event.request).catch(() => {
+          if (event.request.mode === "navigate") {
+            return caches.match("/index.html");
+          }
+        }),
+    ),
   );
 });


### PR DESCRIPTION
## Summary
- include `terms.json` in service worker cache
- add skeleton loader and trim animation when data is cached
- fall back to longer skeleton animation for cold loads

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5d4831c348328ba64605d93e08048