### PR TITLE
test: validate color token variants

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -6,6 +6,7 @@
   --color-card-bg: #ffffff;
   --color-badge-bg: #e9ecef;
   --color-badge-text: #212529;
+  --color-skip-link-text: #ffffff;
 }
 
 [data-theme="dark"] {
@@ -16,6 +17,7 @@
   --color-card-bg: #1e1e1e;
   --color-badge-bg: #343a40;
   --color-badge-text: #f8f9fa;
+  --color-skip-link-text: #121212;
 }
 
 body {
@@ -73,7 +75,7 @@ a:focus {
   left: 0;
   padding: 0.5rem 1rem;
   background: var(--color-link);
-  color: #fff;
+  color: var(--color-skip-link-text);
   transform: translateY(-100%);
   transition: transform 0.2s;
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "script.js",
   "scripts": {
     "build": "node scripts/build.js",
-    "test": "html-validate index.html search.html diagnostics.html && node diagnostics.test.js",
+    "test": "html-validate index.html search.html diagnostics.html && node diagnostics.test.js && node tokens.test.js",
     "watch": "chokidar \"**/*.html\" -c \"npm run build\""
   },
   "keywords": [],

--- a/tokens.test.js
+++ b/tokens.test.js
@@ -1,0 +1,70 @@
+const fs = require('fs');
+
+const css = fs.readFileSync('assets/css/style.css', 'utf8');
+
+function getVars(selectorPattern) {
+  const regex = new RegExp(selectorPattern + '\\s*\\{([\\s\\S]*?)\\}', 'm');
+  const match = css.match(regex);
+  if (!match) {
+    console.error(`Missing selector ${selectorPattern}`);
+    process.exit(1);
+  }
+  const body = match[1];
+  const vars = {};
+  body.split(';').forEach((decl) => {
+    const [name, value] = decl.split(':').map((s) => s && s.trim());
+    if (name && value) {
+      vars[name] = value;
+    }
+  });
+  return vars;
+}
+
+const required = [
+  '--color-bg',
+  '--color-text',
+  '--color-link',
+  '--color-link-hover',
+  '--color-card-bg',
+  '--color-badge-bg',
+  '--color-badge-text',
+  '--color-skip-link-text',
+];
+
+function checkVariant(label, vars) {
+  required.forEach((key) => {
+    if (!(key in vars)) {
+      console.error(`${label} missing ${key}`);
+      process.exit(1);
+    }
+  });
+  Object.keys(vars).forEach((key) => {
+    if (!required.includes(key)) {
+      console.error(`${label} has unsupported property ${key}`);
+      process.exit(1);
+    }
+  });
+}
+
+const rootVars = getVars(':root');
+const darkVars = getVars('\\[data-theme="dark"\\]');
+
+checkVariant('default', rootVars);
+checkVariant('dark', darkVars);
+
+const lines = css.split(/\r?\n/);
+for (let i = 0; i < lines.length; i++) {
+  const line = lines[i];
+  const match = line.match(/#([0-9a-fA-F]{3,6})/);
+  if (match && !line.trim().startsWith('--')) {
+    console.error(`Found hard-coded color value on line ${i + 1}`);
+    process.exit(1);
+  }
+}
+
+if (!css.includes('var(--')) {
+  console.error('No token usage found');
+  process.exit(1);
+}
+
+console.log('Token variant tests passed');


### PR DESCRIPTION
## Summary
- add color token for skip-link and rely on CSS variables instead of hard-coded colors
- add unit tests for token variants ensuring required keys and detecting unsupported properties
- run token tests in npm test script

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5b66ade888328921a906f8b0fe453