### PR TITLE
feat(search): add saved searches

### DIFF
--- a/assets/js/saved-searches.js
+++ b/assets/js/saved-searches.js
@@ -1,0 +1,49 @@
+export class SavedSearches {
+  constructor(storageKey = 'saved-searches') {
+    this.storageKey = storageKey;
+    this.searches = this.load();
+  }
+
+  load() {
+    try {
+      const raw = localStorage.getItem(this.storageKey);
+      return raw ? JSON.parse(raw) : [];
+    } catch (e) {
+      return [];
+    }
+  }
+
+  _persist() {
+    try {
+      localStorage.setItem(this.storageKey, JSON.stringify(this.searches));
+    } catch (e) {
+      // ignore storage failures
+    }
+  }
+
+  add(search) {
+    this.searches.push({ ...search, id: Date.now().toString(), starred: false });
+    this._persist();
+  }
+
+  update(id, updates) {
+    const item = this.searches.find((s) => s.id === id);
+    if (item) {
+      Object.assign(item, updates);
+      this._persist();
+    }
+  }
+
+  remove(id) {
+    this.searches = this.searches.filter((s) => s.id !== id);
+    this._persist();
+  }
+
+  reorder(from, to) {
+    if (from === to) return;
+    const list = this.searches;
+    const [moved] = list.splice(from, 1);
+    list.splice(to, 0, moved);
+    this._persist();
+  }
+}

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -1,77 +1,140 @@
-(function(){
-  const resultsContainer = document.getElementById('results');
-  const searchInput = document.getElementById('search-box');
-  let terms = [];
+import { SavedSearches } from './saved-searches.js';
 
-  document.addEventListener('DOMContentLoaded', () => {
-    const baseUrl = window.__BASE_URL__ || '';
-    fetch(`${baseUrl}/terms.json`)
-      .then(r => r.ok ? r.json() : Promise.reject(r.statusText))
-      .then(data => {
-        // terms.json may either be an array or object with terms property
-        terms = Array.isArray(data) ? data : (data.terms || []);
-      })
-      .catch(err => {
-        console.error('Failed to load terms.json', err);
-      });
+const resultsContainer = document.getElementById('results');
+const searchInput = document.getElementById('search-box');
+const saveBtn = document.getElementById('save-search');
+const savedContainer = document.getElementById('saved-searches');
 
-    searchInput.addEventListener('input', handleSearch);
-  });
+let terms = [];
+const store = new SavedSearches();
 
-  function handleSearch(){
-    const query = searchInput.value.trim().toLowerCase();
-    resultsContainer.innerHTML = '';
-    if(!query){
-      return;
-    }
-    const matches = terms
-      .map(term => ({ term, score: score(term, query) }))
-      .filter(item => item.score > 0)
-      .sort((a,b) => b.score - a.score);
-
-    matches.forEach(({ term }) => {
-      resultsContainer.appendChild(renderCard(term));
+document.addEventListener('DOMContentLoaded', () => {
+  const baseUrl = window.__BASE_URL__ || '';
+  fetch(`${baseUrl}/terms.json`)
+    .then((r) => (r.ok ? r.json() : Promise.reject(r.statusText)))
+    .then((data) => {
+      // terms.json may either be an array or object with terms property
+      terms = Array.isArray(data) ? data : data.terms || [];
+    })
+    .catch((err) => {
+      console.error('Failed to load terms.json', err);
     });
+
+  searchInput.addEventListener('input', handleSearch);
+  saveBtn.addEventListener('click', saveCurrentSearch);
+  renderSavedSearches();
+});
+
+function handleSearch() {
+  const query = searchInput.value.trim().toLowerCase();
+  resultsContainer.innerHTML = '';
+  if (!query) {
+    return;
+  }
+  const matches = terms
+    .map((term) => ({ term, score: score(term, query) }))
+    .filter((item) => item.score > 0)
+    .sort((a, b) => b.score - a.score);
+
+  matches.forEach(({ term }) => {
+    resultsContainer.appendChild(renderCard(term));
+  });
+}
+
+function score(term, query) {
+  let s = 0;
+  const name = (term.name || term.term || '').toLowerCase();
+  const def = (term.definition || '').toLowerCase();
+  const category = (term.category || '').toLowerCase();
+  const syns = (term.synonyms || []).map((s) => s.toLowerCase());
+  if (name.includes(query)) s += 3;
+  if (def.includes(query)) s += 1;
+  if (category.includes(query)) s += 1;
+  if (syns.some((syn) => syn.includes(query))) s += 2;
+  return s;
+}
+
+function renderCard(term) {
+  const card = document.createElement('div');
+  card.className = 'result-card';
+
+  const title = document.createElement('h3');
+  title.textContent = term.name || term.term || '';
+  card.appendChild(title);
+
+  if (term.category) {
+    const cat = document.createElement('p');
+    cat.className = 'category';
+    cat.textContent = term.category;
+    card.appendChild(cat);
   }
 
-  function score(term, query){
-    let s = 0;
-    const name = (term.name || term.term || '').toLowerCase();
-    const def = (term.definition || '').toLowerCase();
-    const category = (term.category || '').toLowerCase();
-    const syns = (term.synonyms || []).map(s=>s.toLowerCase());
-    if(name.includes(query)) s += 3;
-    if(def.includes(query)) s += 1;
-    if(category.includes(query)) s += 1;
-    if(syns.some(syn => syn.includes(query))) s += 2;
-    return s;
+  const def = document.createElement('p');
+  def.textContent = term.definition || '';
+  card.appendChild(def);
+
+  if (term.synonyms && term.synonyms.length) {
+    const syn = document.createElement('p');
+    syn.className = 'synonyms';
+    syn.textContent = `Synonyms: ${term.synonyms.join(', ')}`;
+    card.appendChild(syn);
   }
+  return card;
+}
 
-  function renderCard(term){
-    const card = document.createElement('div');
-    card.className = 'result-card';
+function saveCurrentSearch() {
+  const query = searchInput.value.trim();
+  if (!query) return;
+  const name = prompt('Name for saved search', query);
+  if (!name) return;
+  store.add({ name, query });
+  renderSavedSearches();
+}
 
-    const title = document.createElement('h3');
-    title.textContent = term.name || term.term || '';
-    card.appendChild(title);
+function renderSavedSearches() {
+  savedContainer.innerHTML = '';
+  store.searches.forEach((s, index) => {
+    const chip = document.createElement('span');
+    chip.className = 'saved-search-chip';
+    chip.draggable = true;
+    chip.dataset.index = index;
 
-    if(term.category){
-      const cat = document.createElement('p');
-      cat.className = 'category';
-      cat.textContent = term.category;
-      card.appendChild(cat);
-    }
+    const label = document.createElement('span');
+    label.textContent = s.name;
+    chip.appendChild(label);
 
-    const def = document.createElement('p');
-    def.textContent = term.definition || '';
-    card.appendChild(def);
+    const star = document.createElement('span');
+    star.className = 'star' + (s.starred ? ' starred' : '');
+    star.textContent = '★';
+    star.addEventListener('click', (e) => {
+      e.stopPropagation();
+      store.update(s.id, { starred: !s.starred });
+      renderSavedSearches();
+    });
+    chip.appendChild(star);
 
-    if(term.synonyms && term.synonyms.length){
-      const syn = document.createElement('p');
-      syn.className = 'synonyms';
-      syn.textContent = `Synonyms: ${term.synonyms.join(', ')}`;
-      card.appendChild(syn);
-    }
-    return card;
-  }
-})();
+    chip.addEventListener('click', () => {
+      searchInput.value = s.query;
+      handleSearch();
+    });
+
+    chip.addEventListener('dragstart', (e) => {
+      e.dataTransfer.setData('text/plain', index.toString());
+    });
+
+    chip.addEventListener('dragover', (e) => {
+      e.preventDefault();
+    });
+
+    chip.addEventListener('drop', (e) => {
+      e.preventDefault();
+      const from = parseInt(e.dataTransfer.getData('text/plain'), 10);
+      const to = index;
+      store.reorder(from, to);
+      renderSavedSearches();
+    });
+
+    savedContainer.appendChild(chip);
+  });
+}
+

--- a/search.html
+++ b/search.html
@@ -9,13 +9,17 @@
 <body>
   <main class="container">
     <h1>Search</h1>
-    <input id="search-box" type="text" placeholder="Search terms...">
+    <div id="search-controls">
+      <input id="search-box" type="text" placeholder="Search terms...">
+      <button id="save-search" type="button">Save</button>
+    </div>
+    <div id="saved-searches"></div>
     <div id="results"></div>
   </main>
   <script>
     window.__BASE_URL__ = window.__BASE_URL__ || '';
   </script>
-  <script src="assets/js/search.js"></script>
+  <script type="module" src="assets/js/search.js"></script>
   <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
   <script src="assets/js/metrics.js"></script>
 </body>

--- a/src/features/search/savedSearches.js
+++ b/src/features/search/savedSearches.js
@@ -1,0 +1,49 @@
+export class SavedSearches {
+  constructor(storageKey = 'saved-searches') {
+    this.storageKey = storageKey;
+    this.searches = this.load();
+  }
+
+  load() {
+    try {
+      const raw = localStorage.getItem(this.storageKey);
+      return raw ? JSON.parse(raw) : [];
+    } catch (e) {
+      return [];
+    }
+  }
+
+  _persist() {
+    try {
+      localStorage.setItem(this.storageKey, JSON.stringify(this.searches));
+    } catch (e) {
+      // ignore storage failures
+    }
+  }
+
+  add(search) {
+    this.searches.push({ ...search, id: Date.now().toString(), starred: false });
+    this._persist();
+  }
+
+  update(id, updates) {
+    const item = this.searches.find((s) => s.id === id);
+    if (item) {
+      Object.assign(item, updates);
+      this._persist();
+    }
+  }
+
+  remove(id) {
+    this.searches = this.searches.filter((s) => s.id !== id);
+    this._persist();
+  }
+
+  reorder(from, to) {
+    if (from === to) return;
+    const list = this.searches;
+    const [moved] = list.splice(from, 1);
+    list.splice(to, 0, moved);
+    this._persist();
+  }
+}

--- a/styles.css
+++ b/styles.css
@@ -158,6 +158,54 @@ label {
   margin-right: 5px;
 }
 
+/* Saved searches */
+#search-controls {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+#save-search {
+  padding: 10px;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  background-color: #007bff;
+  color: #fff;
+  cursor: pointer;
+  min-width: 44px;
+  min-height: 44px;
+}
+
+#save-search:hover {
+  background-color: #0056b3;
+}
+
+#saved-searches {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  margin-bottom: 10px;
+}
+
+.saved-search-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 8px;
+  background-color: #e0e0e0;
+  border-radius: 16px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.saved-search-chip .star {
+  margin-left: 6px;
+  color: #bbb;
+}
+
+.saved-search-chip .star.starred {
+  color: gold;
+}
+
 /* Favorite star styles */
 .favorite-star {
   font-size: 20px;


### PR DESCRIPTION
## Summary
- add SavedSearches localStorage store
- support naming, starring, drag-reordering and chip UI for saved queries

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5d537fae483288fa3d3c1e0f13906