### PR TITLE
feat: add collections with shareable read-only URLs

### DIFF
--- a/collections/index.html
+++ b/collections/index.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Collection</title>
+  <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+  <main class="container">
+    <h1 id="collection-name"></h1>
+    <ul id="collection-items"></ul>
+  </main>
+  <script src="../src/features/collections/index.js"></script>
+  <script>
+    (function () {
+      const params = new URLSearchParams(window.location.search);
+      const readonly = params.get('readonly') === '1';
+      let id = params.get('id');
+      const parts = window.location.pathname.split('/').filter(Boolean);
+      if (!id && parts.length > 1) {
+        id = parts[parts.length - 1];
+      }
+      const collection = window.CollectionsFeature.getCollection(id);
+      const nameEl = document.getElementById('collection-name');
+      const itemsEl = document.getElementById('collection-items');
+      if (!collection) {
+        nameEl.textContent = 'Collection not found';
+        return;
+      }
+      nameEl.textContent = collection.name + (readonly ? ' (Read-only)' : '');
+      collection.items.forEach((item) => {
+        const li = document.createElement('li');
+        li.textContent = item;
+        itemsEl.appendChild(li);
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -22,6 +22,8 @@
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 
+    <div id="collections-badges" class="collections-badges"></div>
+
     <ul id="terms-list"></ul>
   </main>
   <footer class="container" aria-label="Contribute">
@@ -36,6 +38,7 @@
   <script src="assets/js/app.js"></script>
   <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
   <script src="assets/js/metrics.js"></script>
+  <script src="src/features/collections/index.js"></script>
 </body>
 </html>
 

--- a/src/features/collections/index.js
+++ b/src/features/collections/index.js
@@ -1,0 +1,101 @@
+const STORAGE_KEY = 'collections';
+
+function loadCollections() {
+  try {
+    return JSON.parse(localStorage.getItem(STORAGE_KEY)) || {};
+  } catch (e) {
+    return {};
+  }
+}
+
+function saveCollections(collections) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(collections));
+  } catch (e) {
+    // Ignore storage errors
+  }
+}
+
+function createCollection(name) {
+  const id = Date.now().toString(36);
+  const collections = loadCollections();
+  collections[id] = { id, name, items: [] };
+  saveCollections(collections);
+  return collections[id];
+}
+
+function getCollection(id) {
+  const collections = loadCollections();
+  return collections[id] || null;
+}
+
+function updateCollection(id, data) {
+  const collections = loadCollections();
+  if (!collections[id]) return null;
+  collections[id] = { ...collections[id], ...data };
+  saveCollections(collections);
+  return collections[id];
+}
+
+function deleteCollection(id) {
+  const collections = loadCollections();
+  if (!collections[id]) return;
+  delete collections[id];
+  saveCollections(collections);
+}
+
+function addItemToCollection(id, item) {
+  const collections = loadCollections();
+  if (!collections[id]) return;
+  if (!collections[id].items.includes(item)) {
+    collections[id].items.push(item);
+    saveCollections(collections);
+  }
+}
+
+function removeItemFromCollection(id, item) {
+  const collections = loadCollections();
+  if (!collections[id]) return;
+  collections[id].items = collections[id].items.filter((i) => i !== item);
+  saveCollections(collections);
+}
+
+function getCollectionUrl(id, readonly = false) {
+  const base = `${window.location.origin}/collections/${id}`;
+  return readonly ? `${base}?readonly=1` : base;
+}
+
+function renderCollectionBadges() {
+  const container = document.getElementById('collections-badges');
+  if (!container) return;
+  container.innerHTML = '';
+  const collections = loadCollections();
+  Object.values(collections).forEach((c) => {
+    const link = document.createElement('a');
+    link.href = `/collections/${c.id}`;
+    link.className = 'collection-badge';
+    link.textContent = c.name;
+    const count = document.createElement('span');
+    count.className = 'count';
+    count.textContent = c.items.length;
+    link.appendChild(count);
+    container.appendChild(link);
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  renderCollectionBadges();
+});
+
+window.CollectionsFeature = {
+  loadCollections,
+  saveCollections,
+  createCollection,
+  getCollection,
+  updateCollection,
+  deleteCollection,
+  addItemToCollection,
+  removeItemFromCollection,
+  renderCollectionBadges,
+  getCollectionUrl,
+};

--- a/styles.css
+++ b/styles.css
@@ -326,6 +326,29 @@ body.dark-mode #alpha-nav button.active {
   border-color: #007bff;
 }
 
+.collections-badges {
+  margin: 1rem 0;
+}
+
+.collection-badge {
+  display: inline-block;
+  margin-right: 0.5rem;
+  padding: 0.25rem 0.5rem;
+  background-color: #eee;
+  border-radius: 0.25rem;
+  text-decoration: none;
+  color: inherit;
+}
+
+.collection-badge .count {
+  margin-left: 0.25rem;
+  background-color: #333;
+  color: #fff;
+  border-radius: 0.25rem;
+  padding: 0 0.25rem;
+  font-size: 0.8em;
+}
+
 @media (max-width: 480px) {
   h1 {
     font-size: 32px;


### PR DESCRIPTION
## Summary
- add localStorage-backed collections API with CRUD operations
- display collection badges with item counts and links
- support read-only share URLs and collection view page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5d53964008328bd8cb0cedbee9d03