### PR TITLE
feat: add interactive diagram viewer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "cybersecuirtydictionary",
       "version": "1.0.0",
       "license": "ISC",
+      "dependencies": {
+        "hammerjs": "^2.0.8"
+      },
       "devDependencies": {
         "chokidar-cli": "^3.0.0",
         "html-validate": "^10.0.0",
@@ -960,6 +963,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hammerjs": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/hammerjs/-/hammerjs-2.0.8.tgz",
+      "integrity": "sha512-tSQXBXS/MWQOn/RKckawJ61vvsDpCom87JgxiYdGwHdOa0ht0vzUWDlfioofFCRU0L+6NGDt6XzbgoJvZkMeRQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/has-flag": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,10 @@
     "html-validate": "^10.0.0",
     "http-server": "^14.1.1",
     "js-yaml": "^4.1.0",
-    "prettier": "^3.6.2",
-    "jsdom": "^26.1.0"
+    "jsdom": "^26.1.0",
+    "prettier": "^3.6.2"
+  },
+  "dependencies": {
+    "hammerjs": "^2.0.8"
   }
 }

--- a/src/components/DiagramViewer.tsx
+++ b/src/components/DiagramViewer.tsx
@@ -1,0 +1,123 @@
+import React, { useEffect, useRef, useState } from "react";
+import Hammer from "hammerjs";
+
+interface DiagramViewerProps {
+  src: string;
+  alt?: string;
+  onClose: () => void;
+}
+
+const MIN_SCALE = 0.5;
+const MAX_SCALE = 5;
+const SCALE_STEP = 0.1;
+const PAN_STEP = 40;
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, value));
+}
+
+const DiagramViewer: React.FC<DiagramViewerProps> = ({ src, alt, onClose }) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [scale, setScale] = useState(1);
+  const [position, setPosition] = useState({ x: 0, y: 0 });
+  const scaleRef = useRef(scale);
+  const positionRef = useRef(position);
+
+  useEffect(() => {
+    scaleRef.current = scale;
+  }, [scale]);
+
+  useEffect(() => {
+    positionRef.current = position;
+  }, [position]);
+
+  // Setup Hammer.js for pinch and pan
+  useEffect(() => {
+    const element = containerRef.current;
+    if (!element) return;
+
+    const hammer = new Hammer(element);
+    hammer.get("pinch").set({ enable: true });
+    hammer.get("pan").set({ direction: Hammer.DIRECTION_ALL });
+
+    let startScale = 1;
+    hammer.on("pinchstart", () => {
+      startScale = scaleRef.current;
+    });
+    hammer.on("pinchmove", (e) => {
+      setScale(clamp(startScale * e.scale, MIN_SCALE, MAX_SCALE));
+    });
+
+    let startX = 0;
+    let startY = 0;
+    hammer.on("panstart", () => {
+      startX = positionRef.current.x;
+      startY = positionRef.current.y;
+    });
+    hammer.on("panmove", (e) => {
+      setPosition({ x: startX + e.deltaX, y: startY + e.deltaY });
+    });
+
+    return () => {
+      hammer.destroy();
+    };
+  }, []);
+
+  // Keyboard controls for zoom/pan and exit
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      switch (e.key) {
+        case "+":
+        case "=":
+          setScale((s) => clamp(s + SCALE_STEP, MIN_SCALE, MAX_SCALE));
+          break;
+        case "-":
+        case "_":
+          setScale((s) => clamp(s - SCALE_STEP, MIN_SCALE, MAX_SCALE));
+          break;
+        case "ArrowUp":
+          setPosition((p) => ({ ...p, y: p.y + PAN_STEP }));
+          break;
+        case "ArrowDown":
+          setPosition((p) => ({ ...p, y: p.y - PAN_STEP }));
+          break;
+        case "ArrowLeft":
+          setPosition((p) => ({ ...p, x: p.x + PAN_STEP }));
+          break;
+        case "ArrowRight":
+          setPosition((p) => ({ ...p, x: p.x - PAN_STEP }));
+          break;
+        case "Escape":
+          onClose();
+          break;
+        default:
+          return;
+      }
+    };
+
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [onClose]);
+
+  const transform = `translate(${position.x}px, ${position.y}px) scale(${scale})`;
+
+  return (
+    <div
+      ref={containerRef}
+      style={{
+        touchAction: "none",
+        overflow: "hidden",
+        width: "100%",
+        height: "100%",
+      }}
+    >
+      <img
+        src={src}
+        alt={alt}
+        style={{ transform, transformOrigin: "0 0", display: "block" }}
+      />
+    </div>
+  );
+};
+
+export default DiagramViewer;


### PR DESCRIPTION
## Summary
- add new DiagramViewer component with Hammer.js pinch and pan
- support keyboard zoom, pan, and Escape to exit viewer
- include hammerjs dependency

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5d551cf308328be5d56cdfbf62a15