### PR TITLE
Add Web Crypto hashing playground

### DIFF
--- a/src/playgrounds/crypto/index.html
+++ b/src/playgrounds/crypto/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Crypto Playground</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <main class="container">
+    <h1>Hashing & Salting Playground</h1>
+    <label for="text-input">Text to hash</label>
+    <textarea id="text-input" rows="4" placeholder="Enter text..."></textarea>
+
+    <div class="slider-group">
+      <label for="salt-size">Salt Size: <span id="salt-size-val">16</span> bytes</label>
+      <input type="range" id="salt-size" min="8" max="64" step="1" value="16">
+    </div>
+
+    <div class="slider-group">
+      <label for="key-length">Key Length: <span id="key-length-val">256</span> bits</label>
+      <input type="range" id="key-length" min="128" max="512" step="32" value="256">
+    </div>
+
+    <div class="buttons">
+      <button id="hash-btn" type="button">Hash</button>
+      <button id="reset-btn" type="button">Reset</button>
+    </div>
+
+    <section id="results" hidden>
+      <p>Salt: <code id="salt-output"></code> <button id="copy-salt" type="button">Copy</button></p>
+      <p>Hash: <code id="hash-output"></code> <button id="copy-hash" type="button">Copy</button></p>
+    </section>
+  </main>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/src/playgrounds/crypto/script.js
+++ b/src/playgrounds/crypto/script.js
@@ -1,0 +1,87 @@
+const textInput = document.getElementById('text-input');
+const saltSizeInput = document.getElementById('salt-size');
+const saltSizeVal = document.getElementById('salt-size-val');
+const keyLengthInput = document.getElementById('key-length');
+const keyLengthVal = document.getElementById('key-length-val');
+const hashBtn = document.getElementById('hash-btn');
+const resetBtn = document.getElementById('reset-btn');
+const saltOutput = document.getElementById('salt-output');
+const hashOutput = document.getElementById('hash-output');
+const copySaltBtn = document.getElementById('copy-salt');
+const copyHashBtn = document.getElementById('copy-hash');
+const results = document.getElementById('results');
+
+function updateSliderDisplays() {
+  saltSizeVal.textContent = saltSizeInput.value;
+  keyLengthVal.textContent = keyLengthInput.value;
+}
+
+saltSizeInput.addEventListener('input', updateSliderDisplays);
+keyLengthInput.addEventListener('input', updateSliderDisplays);
+
+function generateSalt(length) {
+  const salt = new Uint8Array(length);
+  crypto.getRandomValues(salt);
+  return salt;
+}
+
+function bufferToHex(buffer) {
+  const bytes = new Uint8Array(buffer);
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+async function hashText(text, salt, keyLen) {
+  const enc = new TextEncoder();
+  const baseKey = await crypto.subtle.importKey(
+    'raw',
+    enc.encode(text),
+    { name: 'PBKDF2' },
+    false,
+    ['deriveBits']
+  );
+
+  const bits = await crypto.subtle.deriveBits(
+    {
+      name: 'PBKDF2',
+      hash: 'SHA-256',
+      salt,
+      iterations: 100000,
+    },
+    baseKey,
+    keyLen
+  );
+  return bits;
+}
+
+hashBtn.addEventListener('click', async () => {
+  const text = textInput.value;
+  if (!text) {
+    return;
+  }
+  const salt = generateSalt(parseInt(saltSizeInput.value, 10));
+  const derived = await hashText(text, salt, parseInt(keyLengthInput.value, 10));
+  saltOutput.textContent = bufferToHex(salt);
+  hashOutput.textContent = bufferToHex(derived);
+  results.hidden = false;
+});
+
+function copyToClipboard(text) {
+  navigator.clipboard.writeText(text);
+}
+
+copySaltBtn.addEventListener('click', () => {
+  copyToClipboard(saltOutput.textContent);
+});
+
+copyHashBtn.addEventListener('click', () => {
+  copyToClipboard(hashOutput.textContent);
+});
+
+resetBtn.addEventListener('click', () => {
+  textInput.value = '';
+  results.hidden = true;
+});
+
+updateSliderDisplays();

--- a/src/playgrounds/crypto/styles.css
+++ b/src/playgrounds/crypto/styles.css
@@ -1,0 +1,32 @@
+body {
+  font-family: sans-serif;
+  margin: 0;
+  padding: 1rem;
+}
+
+.container {
+  max-width: 700px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+textarea {
+  width: 100%;
+}
+
+.slider-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.buttons {
+  display: flex;
+  gap: 0.5rem;
+}
+
+code {
+  word-break: break-all;
+}


### PR DESCRIPTION
## Summary
- add hashing & salting playground using Web Crypto API
- allow adjusting salt size and key length
- add copy-to-clipboard and reset controls

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5d5551608832896648b8b2d6a6a9c