### PR TITLE
feat(search): add voice search microphone

### DIFF
--- a/src/features/search/SearchBar.tsx
+++ b/src/features/search/SearchBar.tsx
@@ -1,0 +1,58 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+export interface SearchBarProps {
+  onSearch?: (value: string) => void;
+}
+
+export const SearchBar: React.FC<SearchBarProps> = ({ onSearch }) => {
+  const [query, setQuery] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
+  const recognitionRef = useRef<SpeechRecognition | null>(null);
+
+  useEffect(() => {
+    const SpeechRecognition =
+      (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition;
+    if (SpeechRecognition) {
+      recognitionRef.current = new SpeechRecognition();
+      recognitionRef.current.addEventListener('result', (e: SpeechRecognitionEvent) => {
+        const transcript = e.results[0][0].transcript;
+        setQuery(transcript);
+        onSearch?.(transcript);
+      });
+    } else {
+      // Web Speech API unsupported, focus the text input
+      inputRef.current?.focus();
+    }
+  }, [onSearch]);
+
+  const startListening = () => {
+    if (recognitionRef.current) {
+      recognitionRef.current.start();
+    } else {
+      inputRef.current?.focus();
+    }
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setQuery(value);
+    onSearch?.(value);
+  };
+
+  return (
+    <div className="search-bar">
+      <input
+        ref={inputRef}
+        type="text"
+        value={query}
+        onChange={handleChange}
+        placeholder="Search terms..."
+      />
+      <button type="button" onClick={startListening} aria-label="Use microphone">
+        🎤
+      </button>
+    </div>
+  );
+};
+
+export default SearchBar;


### PR DESCRIPTION
## Summary
- add SearchBar component with microphone button
- leverage Web Speech API to fill search input
- autofocus text input when speech API unsupported

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5d54ebe288328b85434e78ffc98d5