### PR TITLE
feat: add notes store and search integration

### DIFF
--- a/assets/js/notes-store.js
+++ b/assets/js/notes-store.js
@@ -1,0 +1,59 @@
+import { openDB } from 'https://cdn.jsdelivr.net/npm/idb@7/+esm';
+
+class NotesStore {
+  constructor() {
+    this.dbPromise = openDB('csd-notes', 1, {
+      upgrade(db) {
+        const store = db.createObjectStore('notes', { keyPath: 'id', autoIncrement: true });
+        store.createIndex('by-term', 'term');
+        store.createIndex('by-tag', 'tags', { multiEntry: true });
+      },
+    });
+  }
+
+  async addNote(term, paragraph, content, tags = []) {
+    const db = await this.dbPromise;
+    await db.add('notes', { term, paragraph, content, tags });
+  }
+
+  async getNotesForTerm(term) {
+    const db = await this.dbPromise;
+    return db.getAllFromIndex('notes', 'by-term', term);
+  }
+
+  async getAllNotes() {
+    const db = await this.dbPromise;
+    return db.getAll('notes');
+  }
+
+  async searchTermsByContentOrTags(query) {
+    const lower = query.toLowerCase();
+    const db = await this.dbPromise;
+    const tx = db.transaction('notes');
+    const store = tx.store;
+    const terms = new Set();
+    let cursor = await store.openCursor();
+    while (cursor) {
+      const note = cursor.value;
+      if (
+        note.content.toLowerCase().includes(lower) ||
+        note.tags.some((t) => t.toLowerCase().includes(lower))
+      ) {
+        terms.add(note.term);
+      }
+      cursor = await cursor.continue();
+    }
+    await tx.done;
+    return terms;
+  }
+
+  async getTermsByTag(tag) {
+    const db = await this.dbPromise;
+    const notes = await db.getAllFromIndex('notes', 'by-tag', tag);
+    return new Set(notes.map((n) => n.term));
+  }
+}
+
+const notesStore = new NotesStore();
+window.notesStore = notesStore;
+export default notesStore;

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -1,7 +1,9 @@
 (function(){
   const resultsContainer = document.getElementById('results');
   const searchInput = document.getElementById('search-box');
+  const notesStore = window.notesStore;
   let terms = [];
+  let notesByTerm = {};
 
   document.addEventListener('DOMContentLoaded', () => {
     const baseUrl = window.__BASE_URL__ || '';
@@ -13,6 +15,18 @@
       })
       .catch(err => {
         console.error('Failed to load terms.json', err);
+      });
+
+    notesStore.getAllNotes()
+      .then(allNotes => {
+        notesByTerm = allNotes.reduce((acc, note) => {
+          acc[note.term] = acc[note.term] || [];
+          acc[note.term].push(note);
+          return acc;
+        }, {});
+      })
+      .catch(err => {
+        console.error('Failed to load notes', err);
       });
 
     searchInput.addEventListener('input', handleSearch);
@@ -44,6 +58,9 @@
     if(def.includes(query)) s += 1;
     if(category.includes(query)) s += 1;
     if(syns.some(syn => syn.includes(query))) s += 2;
+    const notes = notesByTerm[term.term || term.name] || [];
+    if(notes.some(n => n.content.toLowerCase().includes(query))) s += 2;
+    if(notes.some(n => n.tags.some(t => t.toLowerCase().includes(query)))) s += 1;
     return s;
   }
 

--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
   <footer aria-label="Project contribution">
     <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
   </footer>
+  <script type="module" src="assets/js/notes-store.js"></script>
   <script src="script.js"></script>
   <script src="assets/js/app.js"></script>
   <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>

--- a/layout.html
+++ b/layout.html
@@ -33,6 +33,7 @@
   </main>
   <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
 
+  <script type="module" src="assets/js/notes-store.js"></script>
   <script src="script.js"></script>
   <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
   <script src="assets/js/metrics.js"></script>

--- a/script.js
+++ b/script.js
@@ -8,6 +8,7 @@ const showFavoritesToggle = document.getElementById("show-favorites");
 const favorites = new Set(JSON.parse(localStorage.getItem("favorites") || "[]"));
 const siteUrl = "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/";
 const canonicalLink = document.getElementById("canonical-link");
+const notesStore = window.notesStore;
 
 let currentLetterFilter = "All";
 let termsData = { terms: [] };
@@ -127,13 +128,17 @@ function buildAlphaNav() {
   highlightActiveButton(allButton);
 }
 
-function populateTermsList() {
+async function populateTermsList() {
   termsList.innerHTML = "";
   const searchValue = searchInput.value.trim().toLowerCase();
+  const noteMatches = searchValue
+    ? await notesStore.searchTermsByContentOrTags(searchValue)
+    : new Set();
   termsData.terms
     .sort((a, b) => a.term.localeCompare(b.term))
     .forEach((item) => {
-      const matchesSearch = item.term.toLowerCase().includes(searchValue);
+      const matchesSearch =
+        item.term.toLowerCase().includes(searchValue) || noteMatches.has(item.term);
       const matchesFavorites = !showFavoritesToggle || !showFavoritesToggle.checked || favorites.has(item.term);
       const matchesLetter =
         currentLetterFilter === "All" || item.term.charAt(0).toUpperCase() === currentLetterFilter;

--- a/search.html
+++ b/search.html
@@ -15,6 +15,7 @@
   <script>
     window.__BASE_URL__ = window.__BASE_URL__ || '';
   </script>
+  <script type="module" src="assets/js/notes-store.js"></script>
   <script src="assets/js/search.js"></script>
   <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
   <script src="assets/js/metrics.js"></script>

--- a/src/features/notes/NotesStore.ts
+++ b/src/features/notes/NotesStore.ts
@@ -1,0 +1,81 @@
+import { openDB, DBSchema } from 'idb';
+
+export interface Note {
+  id?: number;
+  term: string;
+  paragraph: number;
+  content: string;
+  tags: string[];
+}
+
+interface NotesDB extends DBSchema {
+  notes: {
+    key: number;
+    value: Note;
+    indexes: {
+      'by-term': string;
+      'by-tag': string;
+    };
+  };
+}
+
+export class NotesStore {
+  private dbPromise = openDB<NotesDB>('csd-notes', 1, {
+    upgrade(db) {
+      const store = db.createObjectStore('notes', {
+        keyPath: 'id',
+        autoIncrement: true,
+      });
+      store.createIndex('by-term', 'term');
+      store.createIndex('by-tag', 'tags', { multiEntry: true });
+    },
+  });
+
+  async addNote(term: string, paragraph: number, content: string, tags: string[] = []): Promise<void> {
+    const db = await this.dbPromise;
+    await db.add('notes', { term, paragraph, content, tags });
+  }
+
+  async getNotesForTerm(term: string): Promise<Note[]> {
+    const db = await this.dbPromise;
+    return db.getAllFromIndex('notes', 'by-term', term);
+  }
+
+  async getAllNotes(): Promise<Note[]> {
+    const db = await this.dbPromise;
+    return db.getAll('notes');
+  }
+
+  async searchTermsByContentOrTags(query: string): Promise<Set<string>> {
+    const lower = query.toLowerCase();
+    const db = await this.dbPromise;
+    const tx = db.transaction('notes');
+    const store = tx.store;
+    const terms = new Set<string>();
+    let cursor = await store.openCursor();
+    while (cursor) {
+      const note = cursor.value as Note;
+      if (
+        note.content.toLowerCase().includes(lower) ||
+        note.tags.some((t) => t.toLowerCase().includes(lower))
+      ) {
+        terms.add(note.term);
+      }
+      cursor = await cursor.continue();
+    }
+    await tx.done;
+    return terms;
+  }
+
+  async getTermsByTag(tag: string): Promise<Set<string>> {
+    const db = await this.dbPromise;
+    const notes = await db.getAllFromIndex('notes', 'by-tag', tag);
+    return new Set(notes.map((n) => n.term));
+  }
+}
+
+const notesStore = new NotesStore();
+// Expose globally for non-module scripts
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(window as any).notesStore = notesStore;
+export default notesStore;


### PR DESCRIPTION
## Summary
- add IndexedDB-backed notes store with tagging
- include note content and tags in on-page search
- expand search page scoring to consider notes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5d561bca48328bfbd31762ffcfaf9