### PR TITLE
Add data export/import utilities and settings UI

### DIFF
--- a/assets/js/exportImport.js
+++ b/assets/js/exportImport.js
@@ -1,0 +1,53 @@
+export function collectData() {
+  const settings = {
+    darkMode: localStorage.getItem('darkMode') === 'true',
+    favorites: JSON.parse(localStorage.getItem('favorites') || '[]'),
+  };
+  const notes = JSON.parse(localStorage.getItem('notes') || '{}');
+  return { settings, notes };
+}
+
+export function exportToJSON() {
+  return JSON.stringify(collectData(), null, 2);
+}
+
+export function downloadExport(filename = 'cyber-dictionary-data.json') {
+  const blob = new Blob([exportToJSON()], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+export function readImport(file) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      try {
+        const data = JSON.parse(reader.result);
+        resolve(data);
+      } catch (err) {
+        reject(err);
+      }
+    };
+    reader.onerror = () => reject(reader.error);
+    reader.readAsText(file);
+  });
+}
+
+export function diffExport(current, incoming) {
+  return [
+    'Current Data:',
+    JSON.stringify(current, null, 2),
+    'Incoming Data:',
+    JSON.stringify(incoming, null, 2),
+  ].join('\n\n');
+}
+
+export function applyImport(data) {
+  localStorage.setItem('darkMode', String(data.settings.darkMode));
+  localStorage.setItem('favorites', JSON.stringify(data.settings.favorites));
+  localStorage.setItem('notes', JSON.stringify(data.notes));
+}

--- a/assets/js/settings.js
+++ b/assets/js/settings.js
@@ -1,0 +1,47 @@
+import { downloadExport, collectData, readImport, diffExport, applyImport } from './exportImport.js';
+
+const exportBtn = document.getElementById('exportData');
+const importBtn = document.getElementById('importData');
+const importInput = document.getElementById('importFile');
+const diffSection = document.getElementById('diffSection');
+const diffPreview = document.getElementById('diffPreview');
+const confirmBtn = document.getElementById('confirmImport');
+const cancelBtn = document.getElementById('cancelImport');
+let incomingData = null;
+
+if (exportBtn) {
+  exportBtn.addEventListener('click', () => downloadExport());
+}
+
+if (importBtn && importInput) {
+  importBtn.addEventListener('click', () => importInput.click());
+  importInput.addEventListener('change', async () => {
+    const file = importInput.files[0];
+    if (!file) return;
+    try {
+      incomingData = await readImport(file);
+      const current = collectData();
+      diffPreview.textContent = diffExport(current, incomingData);
+      diffSection.style.display = 'block';
+    } catch (err) {
+      alert('Failed to read file');
+    }
+  });
+}
+
+if (confirmBtn) {
+  confirmBtn.addEventListener('click', () => {
+    if (incomingData) {
+      applyImport(incomingData);
+      diffSection.style.display = 'none';
+      incomingData = null;
+    }
+  });
+}
+
+if (cancelBtn) {
+  cancelBtn.addEventListener('click', () => {
+    diffSection.style.display = 'none';
+    incomingData = null;
+  });
+}

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 <body>
   <main class="container">
     <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav" aria-label="Site links"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
+    <nav class="site-nav" aria-label="Site links"><a href="templates/guidelines.html">Definition Guidelines</a> | <a href="settings.html">Settings</a></nav>
     <div id="definition-container" style="display: none;"></div>
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">

--- a/settings.html
+++ b/settings.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Settings</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <main class="container">
+    <h1>Settings</h1>
+    <button id="exportData" type="button">Export Data</button>
+    <input id="importFile" type="file" accept="application/json" style="display:none" />
+    <button id="importData" type="button">Import Data</button>
+    <section id="diffSection" style="display:none">
+      <h2>Import Preview</h2>
+      <pre id="diffPreview"></pre>
+      <button id="confirmImport" type="button">Confirm Import</button>
+      <button id="cancelImport" type="button">Cancel</button>
+    </section>
+  </main>
+  <script type="module" src="assets/js/settings.js"></script>
+</body>
+</html>

--- a/src/utils/exportImport.ts
+++ b/src/utils/exportImport.ts
@@ -1,0 +1,67 @@
+export interface Settings {
+  darkMode: boolean;
+  favorites: string[];
+}
+
+export interface Notes {
+  [key: string]: string;
+}
+
+export interface ExportData {
+  settings: Settings;
+  notes: Notes;
+}
+
+export function collectData(): ExportData {
+  const settings: Settings = {
+    darkMode: localStorage.getItem('darkMode') === 'true',
+    favorites: JSON.parse(localStorage.getItem('favorites') || '[]'),
+  };
+  const notes: Notes = JSON.parse(localStorage.getItem('notes') || '{}');
+  return { settings, notes };
+}
+
+export function exportToJSON(): string {
+  return JSON.stringify(collectData(), null, 2);
+}
+
+export function downloadExport(filename = 'cyber-dictionary-data.json'): void {
+  const blob = new Blob([exportToJSON()], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+export function readImport(file: File): Promise<ExportData> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      try {
+        const data = JSON.parse(reader.result as string);
+        resolve(data as ExportData);
+      } catch (err) {
+        reject(err);
+      }
+    };
+    reader.onerror = () => reject(reader.error);
+    reader.readAsText(file);
+  });
+}
+
+export function diffExport(current: ExportData, incoming: ExportData): string {
+  return [
+    'Current Data:',
+    JSON.stringify(current, null, 2),
+    'Incoming Data:',
+    JSON.stringify(incoming, null, 2),
+  ].join('\n\n');
+}
+
+export function applyImport(data: ExportData): void {
+  localStorage.setItem('darkMode', String(data.settings.darkMode));
+  localStorage.setItem('favorites', JSON.stringify(data.settings.favorites));
+  localStorage.setItem('notes', JSON.stringify(data.notes));
+}


### PR DESCRIPTION
## Summary
- Add utility for exporting and importing settings/notes with JSON serialization and diff preview
- Introduce settings page with export and import controls
- Link settings from navigation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5d56264608328895fbfda4f60060b