### PR TITLE
Add print stylesheet and table of contents for printing

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,12 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Cyber Security Dictionary</title>
   <link rel="stylesheet" href="styles.css">
+  <link rel="stylesheet" href="src/styles/print.css" media="print">
   <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet">
   <link rel="canonical" id="canonical-link" href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/">
 </head>
 <body>
   <main class="container">
     <h1>Cyber Security Dictionary</h1>
+    <nav id="print-toc" aria-label="Table of contents" style="display:none;"></nav>
     <nav class="site-nav" aria-label="Site links"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
     <div id="definition-container" style="display: none;"></div>
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>

--- a/layout.html
+++ b/layout.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Cyber Security Dictionary</title>
   <link rel="stylesheet" href="styles.css">
+  <link rel="stylesheet" href="src/styles/print.css" media="print">
   <meta property="og:title" content="Cyber Security Dictionary">
   <meta property="og:description" content="An interactive dictionary for cyber security terms.">
   <meta property="og:type" content="website">
@@ -19,6 +20,7 @@
 <body>
   <main class="container">
     <h1>Cyber Security Dictionary</h1>
+    <nav id="print-toc" aria-label="Table of contents" style="display:none;"></nav>
     <div id="definition-container" style="display: none;"></div>
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">

--- a/script.js
+++ b/script.js
@@ -8,6 +8,7 @@ const showFavoritesToggle = document.getElementById("show-favorites");
 const favorites = new Set(JSON.parse(localStorage.getItem("favorites") || "[]"));
 const siteUrl = "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/";
 const canonicalLink = document.getElementById("canonical-link");
+const printTOC = document.getElementById("print-toc");
 
 let currentLetterFilter = "All";
 let termsData = { terms: [] };
@@ -41,6 +42,7 @@ function loadTerms() {
       termsData.terms.sort((a, b) => a.term.localeCompare(b.term));
       buildAlphaNav();
       populateTermsList();
+      buildPrintTOC();
 
       if (window.location.hash) {
         const termFromHash = decodeURIComponent(window.location.hash.substring(1));
@@ -66,6 +68,24 @@ function loadTerms() {
         });
       }
     });
+}
+
+function buildPrintTOC() {
+  if (!printTOC) {
+    return;
+  }
+  const list = document.createElement("ul");
+  termsData.terms.forEach((item) => {
+    const anchorId = item.term.toLowerCase().replace(/\s+/g, "-");
+    const li = document.createElement("li");
+    const a = document.createElement("a");
+    a.href = `#${anchorId}`;
+    a.textContent = item.term;
+    li.appendChild(a);
+    list.appendChild(li);
+  });
+  printTOC.innerHTML = "<h2>Table of Contents</h2>";
+  printTOC.appendChild(list);
 }
 
 function removeDuplicateTermsAndDefinitions() {
@@ -139,6 +159,8 @@ function populateTermsList() {
         currentLetterFilter === "All" || item.term.charAt(0).toUpperCase() === currentLetterFilter;
       if (matchesSearch && matchesFavorites && matchesLetter) {
         const termDiv = document.createElement("div");
+        const anchorId = item.term.toLowerCase().replace(/\s+/g, "-");
+        termDiv.id = anchorId;
         termDiv.classList.add("dictionary-item");
 
         const termHeader = document.createElement("h3");

--- a/src/styles/print.css
+++ b/src/styles/print.css
@@ -1,0 +1,50 @@
+@media print {
+  body {
+    color: #000;
+    background: #fff;
+  }
+
+  /* Hide interactive elements in print */
+  #alpha-nav,
+  #search,
+  #random-term,
+  #dark-mode-toggle,
+  #show-favorites,
+  label[for="show-favorites"],
+  #scrollToTopBtn {
+    display: none !important;
+  }
+
+  /* Table of contents appears only in print */
+  #print-toc {
+    display: block;
+    margin-bottom: 2rem;
+  }
+  #print-toc ul {
+    list-style: none;
+    padding: 0;
+    columns: 2;
+  }
+
+  /* Prevent terms from breaking across pages */
+  .dictionary-item {
+    break-inside: avoid;
+    page-break-inside: avoid;
+    margin-bottom: 1rem;
+  }
+
+  @page {
+    margin: 20mm;
+  }
+
+  /* Footer source citation */
+  body::after {
+    content: "Source: Cyber Security Dictionary - https://alex-unnippillil.github.io/CyberSecuirtyDictionary/";
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    text-align: center;
+    font-size: 10pt;
+  }
+}


### PR DESCRIPTION
## Summary
- add print-specific stylesheet with page-break handling and citation footers
- link print stylesheet and placeholder TOC in HTML templates
- generate table of contents and anchors for printing via script

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5d567bf1883288429b38e8a272411