### PR TITLE
feat: add text highlight system

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,12 @@
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 
+    <div id="highlight-legend" class="highlight-legend"></div>
+    <aside id="highlights-panel" class="highlights-panel">
+      <h2>Highlights</h2>
+      <ul id="highlights-list"></ul>
+    </aside>
+
     <ul id="terms-list"></ul>
   </main>
   <footer class="container" aria-label="Contribute">
@@ -33,6 +39,7 @@
     <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
   </footer>
   <script src="script.js"></script>
+  <script type="module" src="src/features/highlights/highlightManager.js"></script>
   <script src="assets/js/app.js"></script>
   <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
   <script src="assets/js/metrics.js"></script>

--- a/src/features/highlights/highlightManager.js
+++ b/src/features/highlights/highlightManager.js
@@ -1,0 +1,132 @@
+// Highlight management system
+// Stores color, serialized range, and optional note ID for each highlight
+
+const PRESET_COLORS = [
+  "#fff59d", // yellow
+  "#ffab91", // orange
+  "#a5d6a7", // green
+  "#90caf9", // blue
+  "#f48fb1", // pink
+];
+
+class HighlightManager {
+  constructor({ legendEl, panelEl } = {}) {
+    this.highlights = [];
+    this.legendEl = legendEl || document.getElementById("highlight-legend");
+    this.panelEl = panelEl || document.getElementById("highlights-list");
+    if (this.legendEl) {
+      this._renderLegend();
+    }
+  }
+
+  _renderLegend() {
+    this.legendEl.innerHTML = "";
+    PRESET_COLORS.forEach((color) => {
+      const btn = document.createElement("button");
+      btn.className = "highlight-color";
+      btn.style.backgroundColor = color;
+      btn.dataset.color = color;
+
+      const count = document.createElement("span");
+      count.className = "count";
+      count.textContent = "0";
+
+      btn.appendChild(count);
+      btn.addEventListener("click", () => this.highlightSelection(color));
+      this.legendEl.appendChild(btn);
+    });
+  }
+
+  highlightSelection(color) {
+    const selection = window.getSelection();
+    if (!selection || selection.rangeCount === 0) return;
+    const range = selection.getRangeAt(0);
+    if (range.collapsed) return;
+
+    const noteId = prompt("Enter note ID (optional)") || "";
+    this.addHighlight(range, color, noteId);
+    selection.removeAllRanges();
+  }
+
+  addHighlight(range, color, noteId = "") {
+    const id = `hl-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    const mark = document.createElement("mark");
+    mark.id = id;
+    mark.dataset.highlightId = id;
+    mark.dataset.noteId = noteId;
+    mark.style.backgroundColor = color;
+    mark.className = "user-highlight";
+
+    const contents = range.extractContents();
+    mark.appendChild(contents);
+    range.insertNode(mark);
+
+    const serialized = this._serializeRange(range);
+    const highlight = { id, color, noteId, range: serialized };
+    this.highlights.push(highlight);
+
+    this._updateLegendCounts();
+    this._updatePanel();
+  }
+
+  _serializeRange(range) {
+    const start = this._nodePath(range.startContainer, range.startOffset);
+    const end = this._nodePath(range.endContainer, range.endOffset);
+    return { start, end };
+  }
+
+  _nodePath(node, offset) {
+    const path = [];
+    let current = node;
+    while (current && current !== document.body) {
+      const parent = current.parentNode;
+      if (!parent) break;
+      const index = Array.prototype.indexOf.call(parent.childNodes, current);
+      path.unshift(index);
+      current = parent;
+    }
+    return { path, offset };
+  }
+
+  _updateLegendCounts() {
+    const counts = PRESET_COLORS.reduce((acc, c) => ({ ...acc, [c]: 0 }), {});
+    this.highlights.forEach((h) => {
+      counts[h.color] = (counts[h.color] || 0) + 1;
+    });
+    if (!this.legendEl) return;
+    Array.from(this.legendEl.querySelectorAll("button")).forEach((btn) => {
+      const color = btn.dataset.color;
+      const countEl = btn.querySelector(".count");
+      if (countEl) {
+        countEl.textContent = counts[color] || 0;
+      }
+    });
+  }
+
+  _updatePanel() {
+    if (!this.panelEl) return;
+    this.panelEl.innerHTML = "";
+    this.highlights.forEach((h) => {
+      const li = document.createElement("li");
+      const link = document.createElement("a");
+      link.href = `#${h.id}`;
+      link.textContent = h.noteId || h.id;
+      li.appendChild(link);
+      this.panelEl.appendChild(li);
+    });
+  }
+}
+
+// Initialize on DOMContentLoaded
+window.addEventListener("DOMContentLoaded", () => {
+  const legendEl = document.getElementById("highlight-legend");
+  const panelList = document.getElementById("highlights-list");
+  if (legendEl && panelList) {
+    window.highlightManager = new HighlightManager({
+      legendEl,
+      panelEl: panelList,
+    });
+  }
+});
+
+export { HighlightManager, PRESET_COLORS };

--- a/styles.css
+++ b/styles.css
@@ -347,3 +347,58 @@ body.dark-mode #alpha-nav button.active {
     font-size: 14px;
   }
 }
+
+.highlight-legend {
+  display: flex;
+  gap: 0.5rem;
+  margin: 1rem 0;
+}
+
+.highlight-legend .highlight-color {
+  border: 1px solid #ccc;
+  width: 1.5rem;
+  height: 1.5rem;
+  cursor: pointer;
+  position: relative;
+  border-radius: 4px;
+}
+
+.highlight-legend .highlight-color .count {
+  position: absolute;
+  bottom: -0.75rem;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 0.75rem;
+}
+
+.highlights-panel {
+  position: fixed;
+  right: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  background-color: #fff;
+  border: 1px solid #ccc;
+  padding: 0.5rem;
+  max-height: 80vh;
+  overflow-y: auto;
+  width: 150px;
+}
+
+.highlights-panel h2 {
+  font-size: 1rem;
+  margin-top: 0;
+}
+
+.highlights-panel ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.highlights-panel li {
+  margin: 0.25rem 0;
+}
+
+.user-highlight {
+  padding: 0 2px;
+}


### PR DESCRIPTION
## Summary
- add highlight manager with five preset colors
- show color legend with counts and panel of highlight jump links

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5d55de7e48328abc174af1681a871