### PR TITLE
feat: add error boundary with state restore

### DIFF
--- a/assets/js/errorBoundary.js
+++ b/assets/js/errorBoundary.js
@@ -1,0 +1,67 @@
+(function () {
+  class ErrorBoundary {
+    constructor() {
+      this.modal = null;
+    }
+
+    install() {
+      this.restoreIfNeeded();
+      this.setupPersistence();
+      window.addEventListener('error', (e) => this.handleError(e.error || e));
+      window.addEventListener('unhandledrejection', (e) => this.handleError(e.reason));
+    }
+
+    setupPersistence() {
+      const saveRoute = () => {
+        try {
+          sessionStorage.setItem('lastRoute', window.location.href);
+        } catch (_) {}
+      };
+      const saveScroll = () => {
+        try {
+          sessionStorage.setItem('lastScroll', String(window.scrollY));
+        } catch (_) {}
+      };
+      saveRoute();
+      saveScroll();
+      window.addEventListener('hashchange', saveRoute);
+      window.addEventListener('beforeunload', saveRoute);
+      window.addEventListener('scroll', saveScroll);
+    }
+
+    handleError(err) {
+      console.error('Captured error:', err);
+      this.showModal();
+    }
+
+    showModal() {
+      if (this.modal) return;
+      this.modal = document.createElement('div');
+      this.modal.id = 'error-modal';
+      this.modal.innerHTML =
+        '<div class="modal-content"><p>Something went wrong.</p><button id="restore-session" type="button">Restore</button></div>';
+      document.body.appendChild(this.modal);
+      const btn = document.getElementById('restore-session');
+      btn.addEventListener('click', () => {
+        try {
+          sessionStorage.setItem('restoreFlag', 'true');
+        } catch (_) {}
+        const route = sessionStorage.getItem('lastRoute') || window.location.href;
+        window.location.href = route;
+      });
+    }
+
+    restoreIfNeeded() {
+      if (sessionStorage.getItem('restoreFlag') === 'true') {
+        sessionStorage.removeItem('restoreFlag');
+        const scroll = parseInt(sessionStorage.getItem('lastScroll'), 10);
+        if (!isNaN(scroll)) {
+          window.scrollTo(0, scroll);
+        }
+      }
+    }
+  }
+
+  const boundary = new ErrorBoundary();
+  boundary.install();
+})();

--- a/diagnostics.html
+++ b/diagnostics.html
@@ -16,6 +16,7 @@
       <tbody id="metrics-body"></tbody>
     </table>
   </main>
+  <script src="assets/js/errorBoundary.js"></script>
   <script src="assets/js/diagnostics.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
   <footer aria-label="Project contribution">
     <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
   </footer>
+  <script src="assets/js/errorBoundary.js"></script>
   <script src="script.js"></script>
   <script src="assets/js/app.js"></script>
   <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>

--- a/layout.html
+++ b/layout.html
@@ -33,6 +33,7 @@
   </main>
   <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
 
+  <script src="assets/js/errorBoundary.js"></script>
   <script src="script.js"></script>
   <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
   <script src="assets/js/metrics.js"></script>

--- a/search.html
+++ b/search.html
@@ -15,6 +15,7 @@
   <script>
     window.__BASE_URL__ = window.__BASE_URL__ || '';
   </script>
+  <script src="assets/js/errorBoundary.js"></script>
   <script src="assets/js/search.js"></script>
   <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
   <script src="assets/js/metrics.js"></script>

--- a/styles.css
+++ b/styles.css
@@ -326,6 +326,31 @@ body.dark-mode #alpha-nav button.active {
   border-color: #007bff;
 }
 
+#error-modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+#error-modal .modal-content {
+  background-color: #fff;
+  padding: 20px;
+  border-radius: 4px;
+  text-align: center;
+}
+
+#error-modal button {
+  margin-top: 10px;
+  padding: 10px 20px;
+}
+
 @media (max-width: 480px) {
   h1 {
     font-size: 32px;


### PR DESCRIPTION
## Summary
- add global `ErrorBoundary` capturing runtime errors
- persist last route and scroll position in sessionStorage
- provide restore modal and wire into app pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5d577541883289ad354f0bc001acc