### PR TITLE
Reduce animations on high refresh displays

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,41 +1,63 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Cyber Security Dictionary</title>
-  <link rel="stylesheet" href="styles.css">
-  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet">
-  <link rel="canonical" id="canonical-link" href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/">
-</head>
-<body>
-  <main class="container">
-    <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav" aria-label="Site links"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
-    <div id="definition-container" style="display: none;"></div>
-    <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
-    <input type="text" id="search" placeholder="Search...">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cyber Security Dictionary</title>
+    <link rel="stylesheet" href="styles.css">
+    <link
+      href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap"
+      rel="stylesheet"
+   >
+    <link
+      rel="canonical"
+      id="canonical-link"
+      href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/"
+   >
+  </head>
+  <body>
+    <main class="container">
+      <h1>Cyber Security Dictionary</h1>
+      <nav class="site-nav" aria-label="Site links">
+        <a href="templates/guidelines.html">Definition Guidelines</a>
+      </nav>
+      <div id="definition-container" style="display: none"></div>
+      <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
+        <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" type="button" aria-label="Show random term">Random Term</button>
+      <button id="random-term" type="button" aria-label="Show random term">
+        Random Term
+      </button>
 
-    <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">Toggle Dark Mode</button>
-    <input type="checkbox" id="show-favorites" aria-label="Show favorites">
-    <label for="show-favorites">Show Favorites</label>
+        <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">
+          Toggle Dark Mode
+        </button>
+        <input type="checkbox" id="show-favorites">
+      <label for="show-favorites">Show Favorites</label>
+        <input
+          type="checkbox"
+          id="reduce-motion-toggle"
+          checked
+       >
+        <label for="reduce-motion-toggle"
+         >Auto-adjust animations for high refresh rate displays</label
+       >
 
-    <ul id="terms-list"></ul>
-  </main>
-  <footer class="container" aria-label="Contribute">
-    <p><a href="templates/contribute.html">Contribute</a></p>
-  </footer>
-  <button id="scrollToTopBtn" type="button" aria-label="Scroll to top">↑</button>
+      <ul id="terms-list"></ul>
+    </main>
+    <footer class="container" aria-label="Contribute">
+      <p><a href="templates/contribute.html">Contribute</a></p>
+    </footer>
+    <button id="scrollToTopBtn" type="button" aria-label="Scroll to top">
+      ↑
+    </button>
 
-  <footer aria-label="Project contribution">
-    <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
-  </footer>
-  <script src="script.js"></script>
-  <script src="assets/js/app.js"></script>
-  <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
-  <script src="assets/js/metrics.js"></script>
-</body>
+    <footer aria-label="Project contribution">
+      <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
+    </footer>
+    <script src="script.js"></script>
+    <script src="assets/js/app.js"></script>
+    <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
+    <script src="assets/js/metrics.js"></script>
+  </body>
 </html>
-

--- a/layout.html
+++ b/layout.html
@@ -1,40 +1,70 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Cyber Security Dictionary</title>
-  <link rel="stylesheet" href="styles.css">
-  <meta property="og:title" content="Cyber Security Dictionary">
-  <meta property="og:description" content="An interactive dictionary for cyber security terms.">
-  <meta property="og:type" content="website">
-  <meta property="og:url" content="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/">
-  <meta property="og:image" content="https://github.com/Alex-Unnippillil/CyberSecuirtyDictionary/assets/24538548/c5a54c56-babb-485d-b01c-4fdfb186325b">
-  <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Cyber Security Dictionary">
-  <meta name="twitter:description" content="An interactive dictionary for cyber security terms.">
-  <meta name="twitter:url" content="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/">
-  <meta name="twitter:image" content="https://github.com/Alex-Unnippillil/CyberSecuirtyDictionary/assets/24538548/c5a54c56-babb-485d-b01c-4fdfb186325b">
-</head>
-<body>
-  <main class="container">
-    <h1>Cyber Security Dictionary</h1>
-    <div id="definition-container" style="display: none;"></div>
-    <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
-    <input type="text" id="search" placeholder="Search...">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cyber Security Dictionary</title>
+    <link rel="stylesheet" href="styles.css">
+    <meta property="og:title" content="Cyber Security Dictionary">
+    <meta
+      property="og:description"
+      content="An interactive dictionary for cyber security terms."
+   >
+    <meta property="og:type" content="website">
+    <meta
+      property="og:url"
+      content="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/"
+   >
+    <meta
+      property="og:image"
+      content="https://github.com/Alex-Unnippillil/CyberSecuirtyDictionary/assets/24538548/c5a54c56-babb-485d-b01c-4fdfb186325b"
+   >
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Cyber Security Dictionary">
+    <meta
+      name="twitter:description"
+      content="An interactive dictionary for cyber security terms."
+   >
+    <meta
+      name="twitter:url"
+      content="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/"
+   >
+    <meta
+      name="twitter:image"
+      content="https://github.com/Alex-Unnippillil/CyberSecuirtyDictionary/assets/24538548/c5a54c56-babb-485d-b01c-4fdfb186325b"
+   >
+  </head>
+  <body>
+    <main class="container">
+      <h1>Cyber Security Dictionary</h1>
+      <div id="definition-container" style="display: none"></div>
+      <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
+      <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+      <button id="random-term" aria-label="Show random term">
+        Random Term
+      </button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
-    <input type="checkbox" id="show-favorites" aria-label="Show favorites">
-    <label for="show-favorites">Show Favorites</label>
+      <button id="dark-mode-toggle" aria-label="Toggle dark mode">
+        Toggle Dark Mode
+      </button>
+      <input type="checkbox" id="show-favorites">
+      <label for="show-favorites">Show Favorites</label>
+      <input
+        type="checkbox"
+        id="reduce-motion-toggle"
+        checked
+     >
+      <label for="reduce-motion-toggle"
+       >Auto-adjust animations for high refresh rate displays</label
+     >
 
-    <ul id="terms-list"></ul>
-  </main>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+      <ul id="terms-list"></ul>
+    </main>
+    <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
 
-  <script src="script.js"></script>
-  <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
-  <script src="assets/js/metrics.js"></script>
-</body>
+    <script src="script.js"></script>
+    <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
+    <script src="assets/js/metrics.js"></script>
+  </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -5,7 +5,10 @@ const randomButton = document.getElementById("random-term");
 const alphaNav = document.getElementById("alpha-nav");
 const darkModeToggle = document.getElementById("dark-mode-toggle");
 const showFavoritesToggle = document.getElementById("show-favorites");
-const favorites = new Set(JSON.parse(localStorage.getItem("favorites") || "[]"));
+const reduceMotionToggle = document.getElementById("reduce-motion-toggle");
+const favorites = new Set(
+  JSON.parse(localStorage.getItem("favorites") || "[]"),
+);
 const siteUrl = "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/";
 const canonicalLink = document.getElementById("canonical-link");
 
@@ -19,12 +22,29 @@ if (localStorage.getItem("darkMode") === "true") {
 if (darkModeToggle) {
   darkModeToggle.addEventListener("click", () => {
     document.body.classList.toggle("dark-mode");
-    localStorage.setItem("darkMode", document.body.classList.contains("dark-mode"));
+    localStorage.setItem(
+      "darkMode",
+      document.body.classList.contains("dark-mode"),
+    );
+  });
+}
+
+if (reduceMotionToggle) {
+  const disabled =
+    localStorage.getItem("disableHighRefreshAnimations") === "true";
+  reduceMotionToggle.checked = !disabled;
+  reduceMotionToggle.addEventListener("change", () => {
+    localStorage.setItem(
+      "disableHighRefreshAnimations",
+      (!reduceMotionToggle.checked).toString(),
+    );
+    applyRefreshRateAdjustment();
   });
 }
 
 window.addEventListener("DOMContentLoaded", () => {
   loadTerms();
+  applyRefreshRateAdjustment();
 });
 
 function loadTerms() {
@@ -43,9 +63,11 @@ function loadTerms() {
       populateTermsList();
 
       if (window.location.hash) {
-        const termFromHash = decodeURIComponent(window.location.hash.substring(1));
+        const termFromHash = decodeURIComponent(
+          window.location.hash.substring(1),
+        );
         const matchedTerm = termsData.terms.find(
-          (t) => t.term.toLowerCase() === termFromHash.toLowerCase()
+          (t) => t.term.toLowerCase() === termFromHash.toLowerCase(),
         );
         if (matchedTerm) {
           displayDefinition(matchedTerm);
@@ -56,7 +78,7 @@ function loadTerms() {
       console.error("Detailed error fetching data:", error);
       definitionContainer.style.display = "block";
       definitionContainer.innerHTML =
-        '<p>Unable to load dictionary data. Please check your connection and try again.</p>' +
+        "<p>Unable to load dictionary data. Please check your connection and try again.</p>" +
         '<button id="retry-fetch">Retry</button>';
       const retryBtn = document.getElementById("retry-fetch");
       if (retryBtn) {
@@ -97,12 +119,16 @@ function toggleFavorite(term) {
 }
 
 function highlightActiveButton(button) {
-  alphaNav.querySelectorAll("button").forEach((btn) => btn.classList.remove("active"));
+  alphaNav
+    .querySelectorAll("button")
+    .forEach((btn) => btn.classList.remove("active"));
   button.classList.add("active");
 }
 
 function buildAlphaNav() {
-  const letters = Array.from(new Set(termsData.terms.map((t) => t.term.charAt(0).toUpperCase()))).sort();
+  const letters = Array.from(
+    new Set(termsData.terms.map((t) => t.term.charAt(0).toUpperCase())),
+  ).sort();
 
   const allButton = document.createElement("button");
   allButton.textContent = "All";
@@ -134,9 +160,13 @@ function populateTermsList() {
     .sort((a, b) => a.term.localeCompare(b.term))
     .forEach((item) => {
       const matchesSearch = item.term.toLowerCase().includes(searchValue);
-      const matchesFavorites = !showFavoritesToggle || !showFavoritesToggle.checked || favorites.has(item.term);
+      const matchesFavorites =
+        !showFavoritesToggle ||
+        !showFavoritesToggle.checked ||
+        favorites.has(item.term);
       const matchesLetter =
-        currentLetterFilter === "All" || item.term.charAt(0).toUpperCase() === currentLetterFilter;
+        currentLetterFilter === "All" ||
+        item.term.charAt(0).toUpperCase() === currentLetterFilter;
       if (matchesSearch && matchesFavorites && matchesLetter) {
         const termDiv = document.createElement("div");
         termDiv.classList.add("dictionary-item");
@@ -187,7 +217,7 @@ function displayDefinition(term) {
   if (canonicalLink) {
     canonicalLink.setAttribute(
       "href",
-      `${siteUrl}#${encodeURIComponent(term.term)}`
+      `${siteUrl}#${encodeURIComponent(term.term)}`,
     );
   }
 }
@@ -195,19 +225,67 @@ function displayDefinition(term) {
 function clearDefinition() {
   definitionContainer.style.display = "none";
   definitionContainer.innerHTML = "";
-  history.replaceState(null, "", window.location.pathname + window.location.search);
+  history.replaceState(
+    null,
+    "",
+    window.location.pathname + window.location.search,
+  );
   if (canonicalLink) {
     canonicalLink.setAttribute("href", siteUrl);
   }
 }
 
+async function detectHighRefreshRate() {
+  if (
+    window.matchMedia &&
+    window.matchMedia("(min-resolution: 120dpi)").matches
+  ) {
+    return true;
+  }
+  return await new Promise((resolve) => {
+    let frames = 0;
+    let start = performance.now();
+    function frame() {
+      frames++;
+      const now = performance.now();
+      if (now - start >= 500) {
+        const fps = (frames * 1000) / (now - start);
+        resolve(fps >= 120);
+      } else {
+        requestAnimationFrame(frame);
+      }
+    }
+    requestAnimationFrame(frame);
+  });
+}
+
+function applyRefreshRateAdjustment() {
+  const disabled =
+    localStorage.getItem("disableHighRefreshAnimations") === "true";
+  if (disabled) {
+    document.body.classList.remove("high-refresh");
+    return;
+  }
+  detectHighRefreshRate().then((isHigh) => {
+    if (isHigh) {
+      document.body.classList.add("high-refresh");
+    } else {
+      document.body.classList.remove("high-refresh");
+    }
+  });
+}
+
 function showRandomTerm() {
-  const randomTerm = termsData.terms[Math.floor(Math.random() * termsData.terms.length)];
+  const randomTerm =
+    termsData.terms[Math.floor(Math.random() * termsData.terms.length)];
   displayDefinition(randomTerm);
 
   const today = new Date().toDateString();
   try {
-    localStorage.setItem("lastRandomTerm", JSON.stringify({ date: today, term: randomTerm }));
+    localStorage.setItem(
+      "lastRandomTerm",
+      JSON.stringify({ date: today, term: randomTerm }),
+    );
   } catch (e) {
     // Ignore storage errors
   }
@@ -249,8 +327,7 @@ window.addEventListener("scroll", () => {
   scrollBtn.style.display = window.scrollY > 200 ? "block" : "none";
 });
 scrollBtn.addEventListener("click", () =>
-  window.scrollTo({ top: 0, behavior: "smooth" })
+  window.scrollTo({ top: 0, behavior: "smooth" }),
 );
 
 definitionContainer.addEventListener("click", clearDefinition);
-

--- a/styles.css
+++ b/styles.css
@@ -4,6 +4,14 @@
   box-sizing: border-box;
 }
 
+:root {
+  --transition-duration: 0.2s;
+}
+
+body.high-refresh {
+  --transition-duration: 0.1s;
+}
+
 body {
   font-family: Arial, sans-serif;
   line-height: 1.6;
@@ -25,7 +33,7 @@ body {
 
 h1 {
   text-align: center;
-  font-family: 'Cinzel', serif;
+  font-family: "Cinzel", serif;
   font-weight: 700;
   font-size: 48px;
   margin-bottom: 20px;
@@ -44,7 +52,7 @@ li {
   background-color: #fff;
   border-bottom: 1px solid #e0e0e0;
   cursor: pointer;
-  transition: background-color 0.2s;
+  transition: background-color var(--transition-duration);
   min-height: 44px;
 }
 
@@ -72,7 +80,7 @@ body.dark-mode mark {
   border: 1px solid #ccc;
   border-radius: 5px;
   cursor: pointer;
-  transition: transform 0.2s;
+  transition: transform var(--transition-duration);
   min-height: 44px;
 }
 
@@ -110,7 +118,6 @@ body.dark-mode mark {
   box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
   min-height: 44px;
 }
-
 
 /* Controls styling */
 #random-term {
@@ -158,13 +165,19 @@ label {
   margin-right: 5px;
 }
 
+#reduce-motion-toggle {
+  width: 44px;
+  height: 44px;
+  margin-right: 5px;
+}
+
 /* Favorite star styles */
 .favorite-star {
   font-size: 20px;
   color: #ccc;
   cursor: pointer;
   margin-left: 5px;
-  transition: color 0.2s;
+  transition: color var(--transition-duration);
   width: 44px;
   height: 44px;
   display: inline-flex;
@@ -206,7 +219,9 @@ label {
   border-radius: 4px;
   padding: 10px;
   cursor: pointer;
-  transition: background-color 0.2s, color 0.2s;
+  transition:
+    background-color var(--transition-duration),
+    color var(--transition-duration);
   min-width: 44px;
   min-height: 44px;
 }


### PR DESCRIPTION
## Summary
- detect high display refresh rates via `matchMedia('(min-resolution: 120dpi)')` and timing
- cut animation transition durations when a high refresh display is detected
- add settings toggle to disable automatic animation adjustment

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5d57e4fe0832885b76faf19f4f940