### PR TITLE
feat: linkable text selections

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -242,6 +242,32 @@ label {
   background-color: #0056b3;
 }
 
+#selection-link-btn {
+  position: absolute;
+  z-index: 1000;
+  display: none;
+  padding: 5px 8px;
+  background-color: #007bff;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+#selection-link-btn:hover {
+  background-color: #0056b3;
+}
+
+.selection-highlight {
+  background-color: yellow;
+  color: inherit;
+}
+
+body.dark-mode .selection-highlight {
+  background-color: #ffeb3b;
+  color: #000;
+}
+
 /* Dark Mode styles */
 body.dark-mode {
   background-color: #121212;


### PR DESCRIPTION
## Summary
- allow selecting term text without triggering definition or dismissal
- add contextual "Link to this selection" button that copies a URL with encoded text offsets
- support range parameters by highlighting and scrolling to the selected span on load

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5d581467c8328a99ab2bbca72ec0a