### PR TITLE
feat: add copy preset selector

### DIFF
--- a/src/components/CopyPresetSelect.tsx
+++ b/src/components/CopyPresetSelect.tsx
@@ -1,0 +1,44 @@
+import React, { useEffect, useState } from "react";
+
+export type Preset = "slack" | "markdown" | "html";
+
+interface Props {
+  onPresetChange?: (preset: Preset) => void;
+}
+
+const STORAGE_KEY = "copyPreset";
+
+export const CopyPresetSelect: React.FC<Props> = ({ onPresetChange }) => {
+  const [preset, setPreset] = useState<Preset>("slack");
+
+  useEffect(() => {
+    const stored = window.localStorage.getItem(STORAGE_KEY) as Preset | null;
+    if (stored) {
+      setPreset(stored);
+    }
+  }, []);
+
+  useEffect(() => {
+    window.localStorage.setItem(STORAGE_KEY, preset);
+    onPresetChange?.(preset);
+  }, [preset, onPresetChange]);
+
+  return (
+    <label
+      style={{ display: "inline-flex", gap: "0.25rem", alignItems: "center" }}
+    >
+      Preset:
+      <select
+        value={preset}
+        onChange={(e) => setPreset(e.target.value as Preset)}
+        aria-label="Copy preset"
+      >
+        <option value="slack">Slack</option>
+        <option value="markdown">Markdown</option>
+        <option value="html">HTML</option>
+      </select>
+    </label>
+  );
+};
+
+export default CopyPresetSelect;


### PR DESCRIPTION
## Summary
- add CopyPresetSelect component
- allow copying definitions in Slack, Markdown, or HTML formats
- remember selected preset for future copies

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5d58c6ba0832888e8db23a5cbd628