### PR TITLE
Add SVG diagram pins with legend and keyboard navigation

### DIFF
--- a/assets/js/diagram-pins.js
+++ b/assets/js/diagram-pins.js
@@ -1,0 +1,91 @@
+// JavaScript to overlay numbered pins on diagrams and provide legend navigation
+// Scans for elements with the class "diagram" and matches explanatory sections
+// containing data attributes with coordinates.
+
+document.addEventListener('DOMContentLoaded', () => {
+  const diagrams = document.querySelectorAll('.diagram');
+  diagrams.forEach((diagram) => {
+    const baseImage = diagram.querySelector('.diagram-image');
+    const pinLayer = diagram.querySelector('.pin-layer');
+    const legend = diagram.querySelector('.pin-legend');
+    const diagramId = diagram.id;
+    if (!baseImage || !pinLayer || !legend || !diagramId) return;
+
+    const init = () => {
+      const { width, height } = baseImage.getBoundingClientRect();
+      pinLayer.setAttribute('viewBox', `0 0 ${width} ${height}`);
+      pinLayer.setAttribute('width', width);
+      pinLayer.setAttribute('height', height);
+
+      const explanations = document.querySelectorAll(
+        `[data-diagram='${diagramId}'][data-pin]`
+      );
+
+      explanations.forEach((section, index) => {
+        const [xPercent, yPercent] = section.dataset.pin
+          .split(',')
+          .map(Number);
+        const x = (width * xPercent) / 100;
+        const y = (height * yPercent) / 100;
+        const number = index + 1;
+        const label = section.dataset.label || `Pin ${number}`;
+        const targetId = section.id;
+
+        const g = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+        g.setAttribute('tabindex', '0');
+        g.setAttribute('class', 'diagram-pin');
+        g.setAttribute('aria-label', label);
+        g.dataset.target = targetId;
+
+        const circle = document.createElementNS(
+          'http://www.w3.org/2000/svg',
+          'circle'
+        );
+        circle.setAttribute('cx', String(x));
+        circle.setAttribute('cy', String(y));
+        circle.setAttribute('r', '12');
+        g.appendChild(circle);
+
+        const text = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+        text.setAttribute('x', String(x));
+        text.setAttribute('y', String(y + 4));
+        text.setAttribute('text-anchor', 'middle');
+        text.textContent = String(number);
+        g.appendChild(text);
+
+        const activate = () => {
+          const target = document.getElementById(targetId);
+          if (target) {
+            target.scrollIntoView({ behavior: 'smooth' });
+          }
+        };
+
+        g.addEventListener('click', activate);
+        g.addEventListener('keydown', (e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            activate();
+          }
+        });
+
+        pinLayer.appendChild(g);
+
+        const li = document.createElement('li');
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.textContent = `${number}. ${label}`;
+        btn.dataset.target = targetId;
+        btn.addEventListener('click', activate);
+        li.appendChild(btn);
+        legend.appendChild(li);
+      });
+    };
+
+    if (baseImage instanceof SVGSVGElement || baseImage.complete) {
+      init();
+    } else {
+      baseImage.addEventListener('load', init);
+    }
+  });
+});
+

--- a/styles.css
+++ b/styles.css
@@ -347,3 +347,68 @@ body.dark-mode #alpha-nav button.active {
     font-size: 14px;
   }
 }
+
+/* Diagram pin styles */
+.diagram {
+  position: relative;
+  max-width: 100%;
+}
+
+.diagram-image {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.pin-layer {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+
+.diagram-pin {
+  pointer-events: all;
+  cursor: pointer;
+}
+
+.diagram-pin circle {
+  fill: #ff5722;
+  stroke: #fff;
+  stroke-width: 2;
+}
+
+.diagram-pin text {
+  fill: #fff;
+  font-size: 12px;
+  font-weight: bold;
+  pointer-events: none;
+}
+
+.diagram-pin:focus circle {
+  stroke: #000;
+}
+
+.pin-legend {
+  margin-top: 10px;
+  padding-left: 20px;
+}
+
+.pin-legend li button {
+  background: none;
+  border: none;
+  padding: 4px 0;
+  text-align: left;
+  text-decoration: underline;
+  color: #007bff;
+  cursor: pointer;
+  font: inherit;
+}
+
+.pin-legend li button:focus {
+  outline: 2px solid #0056b3;
+  outline-offset: 2px;
+}
+

--- a/templates/diagram-demo.html
+++ b/templates/diagram-demo.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Diagram Pins Demo</title>
+  <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+  <main class="container">
+    <h1>Diagram with Pins</h1>
+    <div class="diagram" id="network-diagram">
+      <svg class="diagram-image" viewBox="0 0 400 200" role="img" aria-labelledby="diagram-title">
+        <title id="diagram-title">Simple network diagram</title>
+        <rect width="400" height="200" fill="#eef" />
+        <rect x="50" y="60" width="80" height="60" fill="#ccc" />
+        <rect x="270" y="60" width="80" height="60" fill="#ccc" />
+        <line x1="130" y1="90" x2="270" y2="90" stroke="#000" />
+      </svg>
+      <svg class="pin-layer"></svg>
+      <h2 id="legend-title">Diagram legend</h2>
+      <ol class="pin-legend" aria-labelledby="legend-title"></ol>
+    </div>
+
+    <section id="workstation" data-diagram="network-diagram" data-pin="25,50" data-label="Workstation">
+      <h2>Workstation</h2>
+      <p>The end-user machine connected to the network.</p>
+    </section>
+
+    <section id="server" data-diagram="network-diagram" data-pin="75,50" data-label="Server">
+      <h2>Server</h2>
+      <p>Hosts the service used by clients on the network.</p>
+    </section>
+
+    <section id="link" data-diagram="network-diagram" data-pin="50,50" data-label="Network Link">
+      <h2>Network Link</h2>
+      <p>The connection that allows data to flow between devices.</p>
+    </section>
+  </main>
+  <script src="../assets/js/diagram-pins.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- overlay numbered pins on diagrams via new `diagram-pins.js`
- build accessible legend that scrolls to matching explanation
- support keyboard navigation for pins (Tab focus, Enter activate)

## Testing
- `npm test`
- `npx html-validate templates/diagram-demo.html`


------
https://chatgpt.com/codex/tasks/task_e_68b5d5934df88328beecf979b7076f12