### PR TITLE
Show keyboard shortcut hints on Alt key

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,9 +16,9 @@
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" type="button" aria-label="Show random term">Random Term</button>
+    <button id="random-term" type="button" aria-label="Show random term" data-shortcut="R">Random Term</button>
 
-    <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+    <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode" data-shortcut="D">Toggle Dark Mode</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 
@@ -27,7 +27,7 @@
   <footer class="container" aria-label="Contribute">
     <p><a href="templates/contribute.html">Contribute</a></p>
   </footer>
-  <button id="scrollToTopBtn" type="button" aria-label="Scroll to top">↑</button>
+  <button id="scrollToTopBtn" type="button" aria-label="Scroll to top" data-shortcut="T">↑</button>
 
   <footer aria-label="Project contribution">
     <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>

--- a/script.js
+++ b/script.js
@@ -254,3 +254,46 @@ scrollBtn.addEventListener("click", () =>
 
 definitionContainer.addEventListener("click", clearDefinition);
 
+const shortcutButtons = document.querySelectorAll("button[data-shortcut]");
+let hintsVisible = false;
+
+function showShortcutHints() {
+  if (hintsVisible) return;
+  hintsVisible = true;
+  shortcutButtons.forEach((btn) => {
+    const hint = document.createElement("span");
+    hint.className = "shortcut-hint";
+    hint.textContent = btn.dataset.shortcut;
+    const rect = btn.getBoundingClientRect();
+    hint.style.top = `${rect.top + window.scrollY - 10}px`;
+    hint.style.left = `${rect.left + window.scrollX + rect.width - 10}px`;
+    document.body.appendChild(hint);
+    btn._hintEl = hint;
+  });
+}
+
+function hideShortcutHints() {
+  if (!hintsVisible) return;
+  hintsVisible = false;
+  shortcutButtons.forEach((btn) => {
+    if (btn._hintEl) {
+      btn._hintEl.remove();
+      delete btn._hintEl;
+    }
+  });
+}
+
+document.addEventListener("keydown", (e) => {
+  if (e.key === "Alt" && !e.repeat) {
+    showShortcutHints();
+  }
+});
+
+document.addEventListener("keyup", (e) => {
+  if (e.key === "Alt") {
+    hideShortcutHints();
+  }
+});
+
+document.addEventListener("click", hideShortcutHints);
+

--- a/styles.css
+++ b/styles.css
@@ -242,6 +242,22 @@ label {
   background-color: #0056b3;
 }
 
+.shortcut-hint {
+  position: absolute;
+  background-color: #333;
+  color: #fff;
+  padding: 2px 4px;
+  border-radius: 3px;
+  font-size: 12px;
+  pointer-events: none;
+  z-index: 1000;
+}
+
+body.dark-mode .shortcut-hint {
+  background-color: #eee;
+  color: #000;
+}
+
 /* Dark Mode styles */
 body.dark-mode {
   background-color: #121212;


### PR DESCRIPTION
## Summary
- show hints for buttons with `data-shortcut` when Alt is pressed
- position hint overlays next to controls and hide on release or click

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5d594a4e48328b1e264d697a78bbc