### PR TITLE
Add auto-scroll speed controls to reader pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,14 @@
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 
+    <label for="scroll-speed">Scroll speed</label>
+    <select id="scroll-speed">
+      <option value="slow">Slow</option>
+      <option value="medium">Medium</option>
+      <option value="fast">Fast</option>
+    </select>
+    <button id="scroll-toggle" type="button" aria-pressed="false" aria-label="Toggle auto scroll">Start Scroll</button>
+
     <ul id="terms-list"></ul>
   </main>
   <footer class="container" aria-label="Contribute">

--- a/layout.html
+++ b/layout.html
@@ -23,15 +23,23 @@
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+    <button id="random-term" type="button" aria-label="Show random term">Random Term</button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+    <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">Toggle Dark Mode</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 
+    <label for="scroll-speed">Scroll speed</label>
+    <select id="scroll-speed">
+      <option value="slow">Slow</option>
+      <option value="medium">Medium</option>
+      <option value="fast">Fast</option>
+    </select>
+    <button id="scroll-toggle" type="button" aria-pressed="false" aria-label="Toggle auto scroll">Start Scroll</button>
+
     <ul id="terms-list"></ul>
   </main>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+  <button id="scrollToTopBtn" type="button" aria-label="Scroll to top">↑</button>
 
   <script src="script.js"></script>
   <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>

--- a/script.js
+++ b/script.js
@@ -5,6 +5,9 @@ const randomButton = document.getElementById("random-term");
 const alphaNav = document.getElementById("alpha-nav");
 const darkModeToggle = document.getElementById("dark-mode-toggle");
 const showFavoritesToggle = document.getElementById("show-favorites");
+const scrollToggle = document.getElementById("scroll-toggle");
+const scrollSpeedSelect = document.getElementById("scroll-speed");
+const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 const favorites = new Set(JSON.parse(localStorage.getItem("favorites") || "[]"));
 const siteUrl = "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/";
 const canonicalLink = document.getElementById("canonical-link");
@@ -253,4 +256,78 @@ scrollBtn.addEventListener("click", () =>
 );
 
 definitionContainer.addEventListener("click", clearDefinition);
+
+if (scrollToggle && scrollSpeedSelect) {
+  const speedMap = { slow: 80, medium: 40, fast: 20 };
+  let scrollTimer = null;
+
+  const savedSpeed = localStorage.getItem("scrollSpeed") || "medium";
+  scrollSpeedSelect.value = savedSpeed;
+
+  function stepScroll() {
+    if (window.innerHeight + window.scrollY >= document.body.scrollHeight) {
+      window.scrollTo({ top: 0, behavior: "auto" });
+    } else {
+      window.scrollBy({ top: 1, left: 0 });
+    }
+  }
+
+  function startScroll() {
+    if (prefersReducedMotion) return;
+    const interval = speedMap[scrollSpeedSelect.value] || 40;
+    scrollToggle.textContent = "Pause Scroll";
+    scrollToggle.setAttribute("aria-pressed", "true");
+    scrollTimer = setInterval(stepScroll, interval);
+    if (document.body.matches(":hover")) {
+      pauseScroll();
+    }
+  }
+
+  function pauseScroll() {
+    if (scrollTimer) {
+      clearInterval(scrollTimer);
+      scrollTimer = null;
+    }
+  }
+
+  function stopScroll() {
+    pauseScroll();
+    scrollToggle.textContent = "Start Scroll";
+    scrollToggle.setAttribute("aria-pressed", "false");
+  }
+
+  function resumeScroll() {
+    if (
+      !scrollTimer &&
+      scrollToggle.getAttribute("aria-pressed") === "true" &&
+      !prefersReducedMotion
+    ) {
+      startScroll();
+    }
+  }
+
+  scrollToggle.addEventListener("click", () => {
+    if (scrollToggle.getAttribute("aria-pressed") === "true") {
+      stopScroll();
+    } else {
+      startScroll();
+    }
+  });
+
+  scrollSpeedSelect.addEventListener("change", () => {
+    localStorage.setItem("scrollSpeed", scrollSpeedSelect.value);
+    if (scrollToggle.getAttribute("aria-pressed") === "true") {
+      pauseScroll();
+      startScroll();
+    }
+  });
+
+  document.body.addEventListener("mouseenter", pauseScroll);
+  document.body.addEventListener("mouseleave", resumeScroll);
+
+  if (prefersReducedMotion) {
+    scrollToggle.disabled = true;
+    scrollSpeedSelect.disabled = true;
+  }
+}
 

--- a/styles.css
+++ b/styles.css
@@ -145,6 +145,30 @@ body.dark-mode mark {
   background-color: #0056b3;
 }
 
+#scroll-speed {
+  margin-top: 10px;
+  padding: 10px;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  min-height: 44px;
+}
+
+#scroll-toggle {
+  margin-top: 10px;
+  padding: 10px;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  background-color: #007bff;
+  color: #fff;
+  cursor: pointer;
+  min-width: 44px;
+  min-height: 44px;
+}
+
+#scroll-toggle:hover {
+  background-color: #0056b3;
+}
+
 label {
   margin-left: 10px;
   margin-top: 10px;
@@ -262,6 +286,18 @@ body.dark-mode #dark-mode-toggle {
   background-color: #333;
   color: #fff;
   border-color: #555;
+}
+
+body.dark-mode #scroll-toggle {
+  background-color: #333;
+  color: #fff;
+  border-color: #555;
+}
+
+body.dark-mode #scroll-speed {
+  background-color: #1e1e1e;
+  color: #fff;
+  border-color: #333;
 }
 
 body.dark-mode li {


### PR DESCRIPTION
## Summary
- add scroll speed selector and toggle to dictionary reader pages
- implement looping auto-scroll with hover pause and speed persistence
- honor `prefers-reduced-motion` to disable auto-scroll when requested

## Testing
- `npm test`
- `npx html-validate layout.html`


------
https://chatgpt.com/codex/tasks/task_e_68b6083dfb0c8328a1eba1750a4d69a4