### PR TITLE
Add scroll progress bar with section navigation

### DIFF
--- a/script.js
+++ b/script.js
@@ -25,6 +25,7 @@ if (darkModeToggle) {
 
 window.addEventListener("DOMContentLoaded", () => {
   loadTerms();
+  initializeProgressBar();
 });
 
 function loadTerms() {
@@ -243,6 +244,58 @@ searchInput.addEventListener("input", () => {
   clearDefinition();
   populateTermsList();
 });
+
+function initializeProgressBar() {
+  const headings = Array.from(document.querySelectorAll("main h2"));
+  if (headings.length === 0) {
+    return;
+  }
+
+  const progressBar = document.createElement("div");
+  progressBar.id = "progress-bar";
+
+  const segments = headings.map((heading) => {
+    const segment = document.createElement("div");
+    segment.className = "progress-segment";
+    segment.addEventListener("click", () => {
+      window.scrollTo({ top: heading.offsetTop, behavior: "smooth" });
+    });
+    progressBar.appendChild(segment);
+    return { heading, segment };
+  });
+
+  document.body.appendChild(progressBar);
+
+  let boundaries = [];
+
+  function computeBoundaries() {
+    boundaries = segments.map((item, index) => {
+      const start = item.heading.offsetTop;
+      const end =
+        index < segments.length - 1
+          ? segments[index + 1].heading.offsetTop
+          : document.documentElement.scrollHeight;
+      return { start, end };
+    });
+    updateActiveSegment();
+  }
+
+  function updateActiveSegment() {
+    const scrollY = window.scrollY;
+    boundaries.forEach((b, i) => {
+      if (scrollY >= b.start && scrollY < b.end) {
+        segments[i].segment.classList.add("active");
+      } else {
+        segments[i].segment.classList.remove("active");
+      }
+    });
+  }
+
+  window.addEventListener("scroll", updateActiveSegment);
+  window.addEventListener("resize", computeBoundaries);
+
+  computeBoundaries();
+}
 
 const scrollBtn = document.getElementById("scrollToTopBtn");
 window.addEventListener("scroll", () => {

--- a/styles.css
+++ b/styles.css
@@ -326,6 +326,35 @@ body.dark-mode #alpha-nav button.active {
   border-color: #007bff;
 }
 
+/* Progress bar */
+#progress-bar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 5px;
+  display: flex;
+  z-index: 1000;
+}
+
+.progress-segment {
+  flex: 1;
+  background-color: #eee;
+  cursor: pointer;
+}
+
+.progress-segment.active {
+  background-color: #007bff;
+}
+
+body.dark-mode .progress-segment {
+  background-color: #333;
+}
+
+body.dark-mode .progress-segment.active {
+  background-color: #007bff;
+}
+
 @media (max-width: 480px) {
   h1 {
     font-size: 32px;


### PR DESCRIPTION
## Summary
- Compute page section boundaries and render a progress bar segmented by headings
- Highlight active segment on scroll and allow clicking segments to jump to sections
- Style the progress bar for light and dark modes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6083efe1c8328bd7d187ea91cb2d1