### PR TITLE
Add read time badges for term definitions

### DIFF
--- a/script.js
+++ b/script.js
@@ -170,6 +170,7 @@ function populateTermsList() {
         const definitionPara = document.createElement("p");
         definitionPara.textContent = item.definition;
         termDiv.appendChild(definitionPara);
+        renderReadTimeForItem(termHeader, definitionPara);
 
         termDiv.addEventListener("click", () => {
           displayDefinition(item);
@@ -190,6 +191,10 @@ function displayDefinition(term) {
       `${siteUrl}#${encodeURIComponent(term.term)}`
     );
   }
+  updateReadTimeBadge();
+  definitionContainer
+    .querySelectorAll("details")
+    .forEach((det) => det.addEventListener("toggle", updateReadTimeBadge));
 }
 
 function clearDefinition() {
@@ -199,6 +204,52 @@ function clearDefinition() {
   if (canonicalLink) {
     canonicalLink.setAttribute("href", siteUrl);
   }
+}
+
+function countVisibleWords(container) {
+  const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT);
+  let count = 0;
+  while (walker.nextNode()) {
+    const parent = walker.currentNode.parentElement;
+    if (parent && parent.offsetParent !== null) {
+      const words = walker.currentNode.textContent
+        .trim()
+        .split(/\s+/)
+        .filter(Boolean);
+      count += words.length;
+    }
+  }
+  return count;
+}
+
+function updateReadTimeBadge() {
+  const header = definitionContainer.querySelector("h3");
+  if (!header) return;
+  const words = countVisibleWords(definitionContainer);
+  const minutes = Math.max(1, Math.ceil(words / 200));
+  let badge = header.querySelector(".read-time-badge");
+  if (!badge) {
+    badge = document.createElement("span");
+    badge.classList.add("read-time-badge");
+    header.appendChild(badge);
+  }
+  badge.textContent = `${minutes} min read`;
+}
+
+function countWords(text) {
+  return text.trim().split(/\s+/).filter(Boolean).length;
+}
+
+function renderReadTimeForItem(header, definitionElement) {
+  if (!header || !definitionElement) {
+    return;
+  }
+  const words = countWords(definitionElement.textContent);
+  const minutes = Math.max(1, Math.ceil(words / 200));
+  const badge = document.createElement("span");
+  badge.classList.add("read-time-badge");
+  badge.textContent = `${minutes} min read`;
+  header.appendChild(badge);
 }
 
 function showRandomTerm() {

--- a/styles.css
+++ b/styles.css
@@ -191,6 +191,21 @@ label {
   color: #fff;
 }
 
+.read-time-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  font-size: 0.75em;
+  border-radius: 12px;
+  background-color: #eee;
+  color: #333;
+  margin-left: 8px;
+}
+
+body.dark-mode .read-time-badge {
+  background-color: #333;
+  color: #eee;
+}
+
 /* Alphabet navigation styles */
 #alpha-nav {
   display: flex;


### PR DESCRIPTION
## Summary
- compute word counts for visible text and derive read-time estimates
- show a read-time badge for each term and update when collapsible sections toggle
- style read-time badges with light and dark mode support

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6083fefe48328bc763cf86dd46203