### PR TITLE
Add long-press term preview modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,6 +32,8 @@
   <footer aria-label="Project contribution">
     <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
   </footer>
+  <div id="term-peek-overlay" class="term-peek-overlay"></div>
+  <div id="term-peek-modal" class="term-peek-modal" role="dialog" aria-modal="true"></div>
   <script src="script.js"></script>
   <script src="assets/js/app.js"></script>
   <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>

--- a/layout.html
+++ b/layout.html
@@ -32,7 +32,8 @@
     <ul id="terms-list"></ul>
   </main>
   <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
-
+  <div id="term-peek-overlay" class="term-peek-overlay"></div>
+  <div id="term-peek-modal" class="term-peek-modal" role="dialog" aria-modal="true"></div>
   <script src="script.js"></script>
   <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
   <script src="assets/js/metrics.js"></script>

--- a/script.js
+++ b/script.js
@@ -254,3 +254,83 @@ scrollBtn.addEventListener("click", () =>
 
 definitionContainer.addEventListener("click", clearDefinition);
 
+const peekModal = document.getElementById("term-peek-modal");
+const peekOverlay = document.getElementById("term-peek-overlay");
+let peekActive = false;
+let longPressTimer = null;
+let activeInlineTerm = null;
+
+function showTermPeek(termName) {
+  if (!peekModal || !peekOverlay) {
+    return;
+  }
+  const term = termsData.terms.find(
+    (t) => t.term.toLowerCase() === termName.toLowerCase()
+  );
+  if (!term) {
+    return;
+  }
+  peekModal.innerHTML = `<h3>${term.term}</h3><p>${term.definition}</p>`;
+  peekModal.style.display = "block";
+  peekOverlay.style.display = "block";
+  peekActive = true;
+}
+
+function hideTermPeek() {
+  if (!peekModal || !peekOverlay) {
+    return;
+  }
+  peekModal.style.display = "none";
+  peekOverlay.style.display = "none";
+  peekActive = false;
+  activeInlineTerm = null;
+}
+
+document.addEventListener(
+  "touchstart",
+  (e) => {
+    const termEl = e.target.closest("[data-term]");
+    if (!termEl) {
+      return;
+    }
+    activeInlineTerm = termEl;
+    longPressTimer = setTimeout(() => {
+      showTermPeek(termEl.getAttribute("data-term"));
+    }, 600);
+  },
+  { passive: true }
+);
+
+document.addEventListener(
+  "touchmove",
+  (e) => {
+    if (!activeInlineTerm) {
+      return;
+    }
+    const touch = e.touches[0];
+    const target = document.elementFromPoint(touch.clientX, touch.clientY);
+    if (!activeInlineTerm.contains(target)) {
+      clearTimeout(longPressTimer);
+      activeInlineTerm = null;
+    }
+  },
+  { passive: true }
+);
+
+document.addEventListener(
+  "touchend",
+  (e) => {
+    clearTimeout(longPressTimer);
+    if (peekActive) {
+      e.preventDefault();
+      hideTermPeek();
+    }
+  },
+  { passive: false }
+);
+
+if (peekOverlay) {
+  peekOverlay.addEventListener("touchend", hideTermPeek);
+  peekOverlay.addEventListener("click", hideTermPeek);
+}
+

--- a/styles.css
+++ b/styles.css
@@ -242,9 +242,41 @@ label {
   background-color: #0056b3;
 }
 
+/* Term peek modal */
+.term-peek-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.3);
+  display: none;
+  z-index: 999;
+}
+
+.term-peek-modal {
+  position: fixed;
+  top: 20%;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #fff;
+  color: #000;
+  padding: 15px;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+  max-width: 90%;
+  z-index: 1000;
+  display: none;
+}
+
 /* Dark Mode styles */
 body.dark-mode {
   background-color: #121212;
+  color: #fff;
+}
+
+body.dark-mode .term-peek-modal {
+  background-color: #1e1e1e;
   color: #fff;
 }
 


### PR DESCRIPTION
## Summary
- detect long-press on inline term references
- show modal card with term preview
- block navigation while peek overlay is active

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6083c6e1883289d2be78d69a1a29a