### PR TITLE
Add audio player loop markers and offline caching

### DIFF
--- a/assets/js/audio-player.js
+++ b/assets/js/audio-player.js
@@ -1,0 +1,111 @@
+(function () {
+  function formatTime(sec) {
+    const minutes = Math.floor(sec / 60)
+      .toString()
+      .padStart(2, "0");
+    const seconds = Math.floor(sec % 60)
+      .toString()
+      .padStart(2, "0");
+    return `${minutes}:${seconds}`;
+  }
+
+  async function cacheAudio(url) {
+    try {
+      const cache = await caches.open("audio-cache");
+      const cached = await cache.match(url);
+      if (!cached) {
+        const response = await fetch(url);
+        await cache.put(url, response.clone());
+      }
+    } catch (e) {
+      // ignore caching errors
+    }
+  }
+
+  function setup(container) {
+    const src = container.dataset.src;
+    if (!src) return;
+
+    const audio = document.createElement("audio");
+    audio.src = src;
+    container.appendChild(audio);
+
+    const startSlider = document.createElement("input");
+    startSlider.type = "range";
+    startSlider.min = 0;
+    startSlider.value = 0;
+    startSlider.step = 0.01;
+
+    const endSlider = document.createElement("input");
+    endSlider.type = "range";
+    endSlider.min = 0;
+    endSlider.step = 0.01;
+
+    const timecodes = document.createElement("div");
+    const startLabel = document.createElement("span");
+    const endLabel = document.createElement("span");
+    timecodes.appendChild(startLabel);
+    timecodes.append(" - ");
+    timecodes.appendChild(endLabel);
+
+    const playBtn = document.createElement("button");
+    playBtn.textContent = "Play";
+    const stopBtn = document.createElement("button");
+    stopBtn.textContent = "Stop";
+
+    container.appendChild(startSlider);
+    container.appendChild(endSlider);
+    container.appendChild(timecodes);
+    container.appendChild(playBtn);
+    container.appendChild(stopBtn);
+
+    audio.addEventListener("loadedmetadata", () => {
+      startSlider.max = endSlider.max = audio.duration;
+      endSlider.value = audio.duration;
+      startLabel.textContent = formatTime(startSlider.value);
+      endLabel.textContent = formatTime(endSlider.value);
+    });
+
+    startSlider.addEventListener("input", () => {
+      if (+startSlider.value >= +endSlider.value) {
+        startSlider.value = Math.max(0, +endSlider.value - 0.1);
+      }
+      startLabel.textContent = formatTime(startSlider.value);
+    });
+
+    endSlider.addEventListener("input", () => {
+      if (+endSlider.value <= +startSlider.value) {
+        endSlider.value = +startSlider.value + 0.1;
+      }
+      endLabel.textContent = formatTime(endSlider.value);
+    });
+
+    playBtn.addEventListener("click", () => {
+      audio.currentTime = +startSlider.value;
+      audio.play();
+    });
+
+    stopBtn.addEventListener("click", () => {
+      audio.pause();
+      audio.currentTime = +startSlider.value;
+    });
+
+    audio.addEventListener("timeupdate", () => {
+      if (audio.currentTime >= +endSlider.value) {
+        audio.currentTime = +startSlider.value;
+      }
+    });
+
+    audio.addEventListener(
+      "play",
+      () => {
+        cacheAudio(audio.currentSrc || audio.src);
+      },
+      { once: true }
+    );
+  }
+
+  window.addEventListener("DOMContentLoaded", () => {
+    document.querySelectorAll(".audio-player").forEach(setup);
+  });
+})();

--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
     <label for="show-favorites">Show Favorites</label>
 
     <ul id="terms-list"></ul>
+    <div class="audio-player" data-src="https://www.w3schools.com/html/horse.mp3"></div>
   </main>
   <footer class="container" aria-label="Contribute">
     <p><a href="templates/contribute.html">Contribute</a></p>
@@ -34,6 +35,7 @@
   </footer>
   <script src="script.js"></script>
   <script src="assets/js/app.js"></script>
+  <script src="assets/js/audio-player.js"></script>
   <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
   <script src="assets/js/metrics.js"></script>
 </body>

--- a/layout.html
+++ b/layout.html
@@ -33,7 +33,10 @@
   </main>
   <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
 
+  <div class="audio-player" data-src="https://www.w3schools.com/html/horse.mp3"></div>
+
   <script src="script.js"></script>
+  <script src="assets/js/audio-player.js"></script>
   <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
   <script src="assets/js/metrics.js"></script>
 </body>

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,5 @@
 const CACHE_NAME = 'csd-cache-v1';
+const AUDIO_CACHE = 'audio-cache-v1';
 const URLS_TO_CACHE = [
   '/',
   '/index.html',
@@ -17,16 +18,36 @@ self.addEventListener('activate', event => {
   event.waitUntil(
     caches.keys().then(keys =>
       Promise.all(
-        keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key))
+        keys
+          .filter(key => key !== CACHE_NAME && key !== AUDIO_CACHE)
+          .map(key => caches.delete(key))
       )
     )
   );
 });
 
 self.addEventListener('fetch', event => {
+  if (event.request.destination === 'audio') {
+    event.respondWith(
+      caches.open(AUDIO_CACHE).then(cache =>
+        cache.match(event.request).then(response => {
+          if (response) {
+            return response;
+          }
+          return fetch(event.request).then(networkResponse => {
+            cache.put(event.request, networkResponse.clone());
+            return networkResponse;
+          });
+        })
+      )
+    );
+    return;
+  }
+
   event.respondWith(
     caches.match(event.request).then(response =>
-      response || fetch(event.request).catch(() => {
+      response ||
+      fetch(event.request).catch(() => {
         if (event.request.mode === 'navigate') {
           return caches.match('/index.html');
         }

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -46,6 +46,7 @@
       <li><a href="{{ contact_url }}">{{ contact_label }}</a></li>
     </ul>
   </footer>
+  <script src="{{ base_url }}/assets/js/audio-player.js"></script>
   <script src="{{ base_url }}/assets/js/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add reusable audio player script with draggable loop markers, timecode display, and play/stop controls
- cache audio after first play and serve from service worker for offline use
- include audio player on index and layout templates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b60840db288328a7ea38b11e3d71ff