### PR TITLE
Add client-side quiz with related distractors and local scoring

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,10 @@
 <body>
   <main class="container">
     <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav" aria-label="Site links"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
+    <nav class="site-nav" aria-label="Site links">
+      <a href="templates/guidelines.html">Definition Guidelines</a>
+      <a href="quiz.html">Quiz</a>
+    </nav>
     <div id="definition-container" style="display: none;"></div>
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">

--- a/quiz.html
+++ b/quiz.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Quiz</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <main class="container">
+    <h1>Quiz</h1>
+    <div id="score-container">
+      <p>Score: <span id="score">0/0</span></p>
+      <button id="reset-score" type="button">Reset Score</button>
+    </div>
+    <div id="question-container">
+      <p id="question"></p>
+      <div id="options" class="quiz-options"></div>
+      <p id="feedback" aria-live="polite"></p>
+      <button id="next-question" type="button" style="display: none;">Next Question</button>
+    </div>
+  </main>
+  <script src="quiz.js"></script>
+  <script src="assets/js/app.js"></script>
+  <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
+  <script src="assets/js/metrics.js"></script>
+</body>
+</html>

--- a/quiz.js
+++ b/quiz.js
@@ -1,0 +1,134 @@
+const questionElement = document.getElementById("question");
+const optionsContainer = document.getElementById("options");
+const feedbackElement = document.getElementById("feedback");
+const nextButton = document.getElementById("next-question");
+const scoreElement = document.getElementById("score");
+const resetButton = document.getElementById("reset-score");
+
+let terms = [];
+let currentTerm = null;
+let score = parseInt(localStorage.getItem("quizScore") || "0", 10);
+let total = parseInt(localStorage.getItem("quizTotal") || "0", 10);
+
+updateScore();
+
+fetch("terms.json")
+  .then((res) => res.json())
+  .then((data) => {
+    terms = data.terms;
+    newQuestion();
+  });
+
+const stopWords = new Set([
+  "the",
+  "a",
+  "an",
+  "and",
+  "or",
+  "of",
+  "to",
+  "in",
+  "on",
+  "for",
+  "with",
+  "is",
+  "by",
+  "that",
+  "this",
+  "from",
+  "as",
+  "at",
+  "it",
+  "its",
+  "be",
+  "are",
+  "was",
+  "were",
+]);
+
+function updateScore() {
+  scoreElement.textContent = `${score}/${total}`;
+}
+
+function storeScore() {
+  try {
+    localStorage.setItem("quizScore", score);
+    localStorage.setItem("quizTotal", total);
+  } catch (e) {
+    // Ignore storage errors
+  }
+}
+
+function getTokens(text) {
+  return text
+    .toLowerCase()
+    .replace(/[^\w\s]/g, "")
+    .split(/\s+/)
+    .filter((w) => !stopWords.has(w) && w);
+}
+
+function getRelatedDistractors(term, count) {
+  const termTokens = new Set(getTokens(term.definition));
+  const related = terms.filter(
+    (t) =>
+      t.term !== term.term &&
+      getTokens(t.definition).some((w) => termTokens.has(w))
+  );
+  const pool = related.length >= count ? related : terms.filter((t) => t.term !== term.term);
+  const result = [];
+  const temp = [...pool];
+  while (result.length < count && temp.length) {
+    const idx = Math.floor(Math.random() * temp.length);
+    result.push(temp.splice(idx, 1)[0]);
+  }
+  return result;
+}
+
+function shuffle(arr) {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+}
+
+function newQuestion() {
+  feedbackElement.textContent = "";
+  nextButton.style.display = "none";
+  optionsContainer.innerHTML = "";
+  currentTerm = terms[Math.floor(Math.random() * terms.length)];
+  questionElement.textContent = `Which term matches the following definition?\n${currentTerm.definition}`;
+  const choices = [currentTerm, ...getRelatedDistractors(currentTerm, 3)];
+  shuffle(choices);
+  choices.forEach((choice) => {
+    const btn = document.createElement("button");
+    btn.textContent = choice.term;
+    btn.addEventListener("click", () => selectAnswer(choice));
+    optionsContainer.appendChild(btn);
+  });
+}
+
+function selectAnswer(selected) {
+  const correct = selected.term === currentTerm.term;
+  total++;
+  if (correct) {
+    score++;
+    feedbackElement.textContent = `Correct! ${currentTerm.term}: ${currentTerm.definition}`;
+    feedbackElement.style.color = "green";
+  } else {
+    feedbackElement.textContent = `Incorrect. The correct answer is ${currentTerm.term}. ${currentTerm.definition}`;
+    feedbackElement.style.color = "red";
+  }
+  storeScore();
+  updateScore();
+  Array.from(optionsContainer.children).forEach((btn) => (btn.disabled = true));
+  nextButton.style.display = "block";
+}
+
+nextButton.addEventListener("click", newQuestion);
+
+resetButton.addEventListener("click", () => {
+  score = 0;
+  total = 0;
+  storeScore();
+  updateScore();
+});

--- a/styles.css
+++ b/styles.css
@@ -326,6 +326,11 @@ body.dark-mode #alpha-nav button.active {
   border-color: #007bff;
 }
 
+.quiz-options button {
+  display: block;
+  margin: 5px 0;
+}
+
 @media (max-width: 480px) {
   h1 {
     font-size: 32px;


### PR DESCRIPTION
## Summary
- Add quiz page that generates multiple-choice questions from dictionary terms
- Pull distractors from terms with overlapping definition keywords
- Track quiz score locally with immediate feedback and reset option

## Testing
- `npm test`
- `npx html-validate quiz.html`


------
https://chatgpt.com/codex/tasks/task_e_68b60843db888328b621adff57a1aad6