### PR TITLE
Add offline SRS reminders with daily silence option

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
     <button id="random-term" type="button" aria-label="Show random term">Random Term</button>
 
     <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+    <button id="silence-day" type="button" aria-label="Silence reminders for a day">Silence for a Day</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 

--- a/script.js
+++ b/script.js
@@ -5,7 +5,10 @@ const randomButton = document.getElementById("random-term");
 const alphaNav = document.getElementById("alpha-nav");
 const darkModeToggle = document.getElementById("dark-mode-toggle");
 const showFavoritesToggle = document.getElementById("show-favorites");
-const favorites = new Set(JSON.parse(localStorage.getItem("favorites") || "[]"));
+const silenceDayBtn = document.getElementById("silence-day");
+const favorites = new Set(
+  JSON.parse(localStorage.getItem("favorites") || "[]"),
+);
 const siteUrl = "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/";
 const canonicalLink = document.getElementById("canonical-link");
 
@@ -19,7 +22,10 @@ if (localStorage.getItem("darkMode") === "true") {
 if (darkModeToggle) {
   darkModeToggle.addEventListener("click", () => {
     document.body.classList.toggle("dark-mode");
-    localStorage.setItem("darkMode", document.body.classList.contains("dark-mode"));
+    localStorage.setItem(
+      "darkMode",
+      document.body.classList.contains("dark-mode"),
+    );
   });
 }
 
@@ -43,9 +49,11 @@ function loadTerms() {
       populateTermsList();
 
       if (window.location.hash) {
-        const termFromHash = decodeURIComponent(window.location.hash.substring(1));
+        const termFromHash = decodeURIComponent(
+          window.location.hash.substring(1),
+        );
         const matchedTerm = termsData.terms.find(
-          (t) => t.term.toLowerCase() === termFromHash.toLowerCase()
+          (t) => t.term.toLowerCase() === termFromHash.toLowerCase(),
         );
         if (matchedTerm) {
           displayDefinition(matchedTerm);
@@ -56,7 +64,7 @@ function loadTerms() {
       console.error("Detailed error fetching data:", error);
       definitionContainer.style.display = "block";
       definitionContainer.innerHTML =
-        '<p>Unable to load dictionary data. Please check your connection and try again.</p>' +
+        "<p>Unable to load dictionary data. Please check your connection and try again.</p>" +
         '<button id="retry-fetch">Retry</button>';
       const retryBtn = document.getElementById("retry-fetch");
       if (retryBtn) {
@@ -97,12 +105,16 @@ function toggleFavorite(term) {
 }
 
 function highlightActiveButton(button) {
-  alphaNav.querySelectorAll("button").forEach((btn) => btn.classList.remove("active"));
+  alphaNav
+    .querySelectorAll("button")
+    .forEach((btn) => btn.classList.remove("active"));
   button.classList.add("active");
 }
 
 function buildAlphaNav() {
-  const letters = Array.from(new Set(termsData.terms.map((t) => t.term.charAt(0).toUpperCase()))).sort();
+  const letters = Array.from(
+    new Set(termsData.terms.map((t) => t.term.charAt(0).toUpperCase())),
+  ).sort();
 
   const allButton = document.createElement("button");
   allButton.textContent = "All";
@@ -134,9 +146,13 @@ function populateTermsList() {
     .sort((a, b) => a.term.localeCompare(b.term))
     .forEach((item) => {
       const matchesSearch = item.term.toLowerCase().includes(searchValue);
-      const matchesFavorites = !showFavoritesToggle || !showFavoritesToggle.checked || favorites.has(item.term);
+      const matchesFavorites =
+        !showFavoritesToggle ||
+        !showFavoritesToggle.checked ||
+        favorites.has(item.term);
       const matchesLetter =
-        currentLetterFilter === "All" || item.term.charAt(0).toUpperCase() === currentLetterFilter;
+        currentLetterFilter === "All" ||
+        item.term.charAt(0).toUpperCase() === currentLetterFilter;
       if (matchesSearch && matchesFavorites && matchesLetter) {
         const termDiv = document.createElement("div");
         termDiv.classList.add("dictionary-item");
@@ -187,7 +203,7 @@ function displayDefinition(term) {
   if (canonicalLink) {
     canonicalLink.setAttribute(
       "href",
-      `${siteUrl}#${encodeURIComponent(term.term)}`
+      `${siteUrl}#${encodeURIComponent(term.term)}`,
     );
   }
 }
@@ -195,19 +211,27 @@ function displayDefinition(term) {
 function clearDefinition() {
   definitionContainer.style.display = "none";
   definitionContainer.innerHTML = "";
-  history.replaceState(null, "", window.location.pathname + window.location.search);
+  history.replaceState(
+    null,
+    "",
+    window.location.pathname + window.location.search,
+  );
   if (canonicalLink) {
     canonicalLink.setAttribute("href", siteUrl);
   }
 }
 
 function showRandomTerm() {
-  const randomTerm = termsData.terms[Math.floor(Math.random() * termsData.terms.length)];
+  const randomTerm =
+    termsData.terms[Math.floor(Math.random() * termsData.terms.length)];
   displayDefinition(randomTerm);
 
   const today = new Date().toDateString();
   try {
-    localStorage.setItem("lastRandomTerm", JSON.stringify({ date: today, term: randomTerm }));
+    localStorage.setItem(
+      "lastRandomTerm",
+      JSON.stringify({ date: today, term: randomTerm }),
+    );
   } catch (e) {
     // Ignore storage errors
   }
@@ -249,8 +273,84 @@ window.addEventListener("scroll", () => {
   scrollBtn.style.display = window.scrollY > 200 ? "block" : "none";
 });
 scrollBtn.addEventListener("click", () =>
-  window.scrollTo({ top: 0, behavior: "smooth" })
+  window.scrollTo({ top: 0, behavior: "smooth" }),
 );
 
 definitionContainer.addEventListener("click", clearDefinition);
 
+let alarmTimeout;
+
+function requestNotificationPermission() {
+  if (!("Notification" in window)) {
+    return;
+  }
+  if (Notification.permission === "default") {
+    Notification.requestPermission().then((permission) => {
+      if (permission === "granted") {
+        scheduleAlarms();
+      }
+    });
+  }
+}
+
+function scheduleAlarms() {
+  if (!("Notification" in window) || Notification.permission !== "granted") {
+    return;
+  }
+  clearTimeout(alarmTimeout);
+
+  const queue = JSON.parse(localStorage.getItem("srsQueue") || "[]");
+  const silenceUntil = parseInt(
+    localStorage.getItem("silenceUntil") || "0",
+    10,
+  );
+  const now = Date.now();
+
+  if (silenceUntil > now) {
+    alarmTimeout = setTimeout(scheduleAlarms, silenceUntil - now);
+    return;
+  }
+
+  const dueItem = queue.find((item) => item.due <= now);
+  if (dueItem) {
+    navigator.serviceWorker.ready.then((reg) => {
+      reg.showNotification("Review reminder", {
+        body: `Review ${dueItem.term}`,
+      });
+    });
+    const remaining = queue.filter(
+      (item) => item.term !== dueItem.term || item.due !== dueItem.due,
+    );
+    localStorage.setItem("srsQueue", JSON.stringify(remaining));
+    alarmTimeout = setTimeout(scheduleAlarms, 60 * 1000);
+  } else {
+    const nextDue = queue.reduce(
+      (min, item) => Math.min(min, item.due),
+      Infinity,
+    );
+    if (nextDue < Infinity) {
+      alarmTimeout = setTimeout(scheduleAlarms, nextDue - now);
+    }
+  }
+}
+
+function silenceForDay() {
+  const until = Date.now() + 24 * 60 * 60 * 1000;
+  localStorage.setItem("silenceUntil", until.toString());
+  clearTimeout(alarmTimeout);
+  navigator.serviceWorker.ready.then((reg) => {
+    reg.getNotifications().then((notifs) => notifs.forEach((n) => n.close()));
+  });
+  scheduleAlarms();
+}
+
+function initNotifications() {
+  requestNotificationPermission();
+  scheduleAlarms();
+}
+
+if (silenceDayBtn) {
+  silenceDayBtn.addEventListener("click", silenceForDay);
+}
+
+initNotifications();

--- a/sw.js
+++ b/sw.js
@@ -1,36 +1,59 @@
-const CACHE_NAME = 'csd-cache-v1';
+const CACHE_NAME = "csd-cache-v2";
 const URLS_TO_CACHE = [
-  '/',
-  '/index.html',
-  '/styles.css',
-  '/script.js',
-  '/data.json'
+  "/",
+  "/index.html",
+  "/styles.css",
+  "/script.js",
+  "/assets/js/app.js",
+  "/terms.json",
 ];
 
-self.addEventListener('install', event => {
+self.addEventListener("install", (event) => {
   event.waitUntil(
-    caches.open(CACHE_NAME).then(cache => cache.addAll(URLS_TO_CACHE))
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(URLS_TO_CACHE)),
   );
 });
 
-self.addEventListener('activate', event => {
+self.addEventListener("activate", (event) => {
   event.waitUntil(
-    caches.keys().then(keys =>
-      Promise.all(
-        keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key))
-      )
-    )
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(
+          keys
+            .filter((key) => key !== CACHE_NAME)
+            .map((key) => caches.delete(key)),
+        ),
+      ),
   );
 });
 
-self.addEventListener('fetch', event => {
+self.addEventListener("fetch", (event) => {
   event.respondWith(
-    caches.match(event.request).then(response =>
-      response || fetch(event.request).catch(() => {
-        if (event.request.mode === 'navigate') {
-          return caches.match('/index.html');
+    caches.match(event.request).then(
+      (response) =>
+        response ||
+        fetch(event.request).catch(() => {
+          if (event.request.mode === "navigate") {
+            return caches.match("/index.html");
+          }
+        }),
+    ),
+  );
+});
+
+self.addEventListener("notificationclick", (event) => {
+  event.notification.close();
+  event.waitUntil(
+    clients.matchAll({ type: "window" }).then((windowClients) => {
+      for (const client of windowClients) {
+        if (client.url === "/" && "focus" in client) {
+          return client.focus();
         }
-      })
-    )
+      }
+      if (clients.openWindow) {
+        return clients.openWindow("/");
+      }
+    }),
   );
 });


### PR DESCRIPTION
## Summary
- request notification permission and schedule reminders for due SRS items
- add "Silence for a Day" control to postpone alerts
- enhance service worker caching and handle notification clicks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b60845167c832891cf70887cbcc7c4