### PR TITLE
Add interactive flashcard view with touch and keyboard controls

### DIFF
--- a/flashcards.html
+++ b/flashcards.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+      <meta charset="UTF-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <title>Flashcards - Cyber Security Dictionary</title>
+      <link rel="stylesheet" href="styles.css">
+  </head>
+  <body>
+    <main class="container flashcard-page">
+      <h1>Flashcards</h1>
+      <div
+        id="flashcard"
+        class="flashcard"
+        tabindex="0"
+        aria-label="Flashcard"
+      ></div>
+      <div class="flashcard-controls">
+        <button id="incorrect" type="button" aria-label="Mark incorrect">
+          Incorrect
+        </button>
+        <button id="correct" type="button" aria-label="Mark correct">
+          Correct
+        </button>
+      </div>
+    </main>
+    <script src="flashcards.js"></script>
+  </body>
+</html>

--- a/flashcards.js
+++ b/flashcards.js
@@ -1,0 +1,80 @@
+const flashcard = document.getElementById("flashcard");
+const correctBtn = document.getElementById("correct");
+const incorrectBtn = document.getElementById("incorrect");
+
+let terms = [];
+let currentIndex = 0;
+let revealState = "question";
+let touchStartX = 0;
+
+fetch("terms.json")
+  .then((res) => res.json())
+  .then((data) => {
+    terms = data.terms;
+    showCard();
+  });
+
+function showCard() {
+  revealState = "question";
+  const term = terms[currentIndex];
+  flashcard.textContent = term.definition;
+  flashcard.classList.remove("revealed");
+}
+
+function getHint(term) {
+  if (!term.term) return "";
+  const first = term.term.charAt(0);
+  return first + "_".repeat(term.term.length - 1);
+}
+
+function reveal() {
+  const term = terms[currentIndex];
+  if (revealState === "question") {
+    flashcard.textContent = getHint(term);
+    revealState = "hint";
+  } else if (revealState === "hint") {
+    flashcard.textContent = term.term;
+    revealState = "answer";
+    flashcard.classList.add("revealed");
+  }
+}
+
+function nextCard(correct) {
+  flashcard.classList.add(correct ? "slide-right" : "slide-left");
+  const handle = () => {
+    flashcard.removeEventListener("transitionend", handle);
+    flashcard.classList.remove("slide-right", "slide-left", "revealed");
+    currentIndex = (currentIndex + 1) % terms.length;
+    showCard();
+  };
+  flashcard.addEventListener("transitionend", handle);
+}
+
+flashcard.addEventListener("click", reveal);
+flashcard.addEventListener("touchstart", (e) => {
+  touchStartX = e.changedTouches[0].screenX;
+});
+flashcard.addEventListener("touchend", (e) => {
+  const diffX = e.changedTouches[0].screenX - touchStartX;
+  if (Math.abs(diffX) < 10) {
+    reveal();
+  } else if (diffX > 30) {
+    nextCard(true);
+  } else if (diffX < -30) {
+    nextCard(false);
+  }
+});
+
+document.addEventListener("keydown", (e) => {
+  if (e.code === "Space") {
+    e.preventDefault();
+    reveal();
+  } else if (e.code === "ArrowRight") {
+    nextCard(true);
+  } else if (e.code === "ArrowLeft") {
+    nextCard(false);
+  }
+});
+
+correctBtn.addEventListener("click", () => nextCard(true));
+incorrectBtn.addEventListener("click", () => nextCard(false));

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "script.js",
   "scripts": {
     "build": "node scripts/build.js",
-    "test": "html-validate index.html search.html diagnostics.html && node diagnostics.test.js",
+    "test": "html-validate index.html search.html diagnostics.html flashcards.html && node diagnostics.test.js",
     "watch": "chokidar \"**/*.html\" -c \"npm run build\""
   },
   "keywords": [],

--- a/styles.css
+++ b/styles.css
@@ -25,7 +25,7 @@ body {
 
 h1 {
   text-align: center;
-  font-family: 'Cinzel', serif;
+  font-family: "Cinzel", serif;
   font-weight: 700;
   font-size: 48px;
   margin-bottom: 20px;
@@ -110,7 +110,6 @@ body.dark-mode mark {
   box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
   min-height: 44px;
 }
-
 
 /* Controls styling */
 #random-term {
@@ -206,7 +205,9 @@ label {
   border-radius: 4px;
   padding: 10px;
   cursor: pointer;
-  transition: background-color 0.2s, color 0.2s;
+  transition:
+    background-color 0.2s,
+    color 0.2s;
   min-width: 44px;
   min-height: 44px;
 }
@@ -346,4 +347,44 @@ body.dark-mode #alpha-nav button.active {
   #alpha-nav button {
     font-size: 14px;
   }
+}
+
+.flashcard-page {
+  text-align: center;
+}
+
+.flashcard {
+  margin: 20px auto;
+  padding: 40px;
+  width: 80%;
+  min-height: 150px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 2px solid #333;
+  border-radius: 8px;
+  background: #fff;
+  transition:
+    transform 0.3s ease,
+    opacity 0.3s ease;
+}
+
+.flashcard.revealed {
+  background: #f0f0f0;
+}
+
+.flashcard-controls {
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+}
+
+.flashcard.slide-right {
+  transform: translateX(100%);
+  opacity: 0;
+}
+
+.flashcard.slide-left {
+  transform: translateX(-100%);
+  opacity: 0;
 }


### PR DESCRIPTION
## Summary
- create Flashcards page loading terms and showing card with hint/answer reveal
- add touch and keyboard handlers for reveal and navigation
- animate cards sliding left/right for incorrect/correct responses

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b60842f9048328b7a381f4b2c5e35d