### PR TITLE
feat: add cloze creation with review queue

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,10 @@
     <label for="show-favorites">Show Favorites</label>
 
     <ul id="terms-list"></ul>
+    <section id="review-queue" aria-label="Review queue" style="display: none;">
+      <h2>Review Queue</h2>
+      <ul id="review-list"></ul>
+    </section>
   </main>
   <footer class="container" aria-label="Contribute">
     <p><a href="templates/contribute.html">Contribute</a></p>


### PR DESCRIPTION
## Summary
- detect text selections and prompt to create cloze cards
- store cloze cards in IndexedDB and show them in a review queue

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6084474148328a2812d2cb8796345