### PR TITLE
Add interactive standards timeline with citations

### DIFF
--- a/assets/js/timeline.js
+++ b/assets/js/timeline.js
@@ -1,0 +1,40 @@
+fetch("standards.json")
+  .then((response) => response.json())
+  .then((data) => {
+    const timeline = document.getElementById("timeline");
+    const citations = document.getElementById("citations");
+    if (!timeline || !citations) return;
+
+    data.sort((a, b) => a.year - b.year);
+
+    data.forEach((item) => {
+      const li = document.createElement("li");
+      li.id = item.id;
+      li.innerHTML = `<strong>${item.title}</strong> (${item.year}) - <a href="${item.url}">${item.citation}</a>`;
+      citations.appendChild(li);
+
+      const wrapper = document.createElement("div");
+      wrapper.className = "timeline-item";
+
+      const btn = document.createElement("button");
+      btn.className = "timeline-point";
+      btn.setAttribute(
+        "aria-label",
+        `Scroll to citation for ${item.title} (${item.year})`,
+      );
+      btn.addEventListener("click", () => {
+        document
+          .getElementById(item.id)
+          ?.scrollIntoView({ behavior: "smooth" });
+      });
+
+      const label = document.createElement("span");
+      label.className = "timeline-label";
+      label.textContent = item.year;
+
+      wrapper.appendChild(btn);
+      wrapper.appendChild(label);
+      timeline.appendChild(wrapper);
+    });
+  })
+  .catch((err) => console.error("Unable to load standards timeline", err));

--- a/index.html
+++ b/index.html
@@ -1,41 +1,54 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Cyber Security Dictionary</title>
-  <link rel="stylesheet" href="styles.css">
-  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet">
-  <link rel="canonical" id="canonical-link" href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/">
-</head>
-<body>
-  <main class="container">
-    <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav" aria-label="Site links"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
-    <div id="definition-container" style="display: none;"></div>
-    <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cyber Security Dictionary</title>
+    <link rel="stylesheet" href="styles.css">
+    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet">
+    <link rel="canonical" id="canonical-link" href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/">
+  </head>
+  <body>
+    <main class="container">
+      <h1>Cyber Security Dictionary</h1>
+      <nav class="site-nav" aria-label="Site links">
+        <a href="templates/guidelines.html">Definition Guidelines</a>
+      </nav>
+      <div id="definition-container" style="display: none"></div>
+      <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" type="button" aria-label="Show random term">Random Term</button>
+      <button id="random-term" type="button" aria-label="Show random term">
+        Random Term
+      </button>
 
-    <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+      <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">
+        Toggle Dark Mode
+      </button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
-    <label for="show-favorites">Show Favorites</label>
+      <label for="show-favorites">Show Favorites</label>
 
-    <ul id="terms-list"></ul>
-  </main>
-  <footer class="container" aria-label="Contribute">
-    <p><a href="templates/contribute.html">Contribute</a></p>
-  </footer>
-  <button id="scrollToTopBtn" type="button" aria-label="Scroll to top">↑</button>
+      <ul id="terms-list"></ul>
+      <section id="standards" aria-label="Cybersecurity standards timeline">
+        <h2>Standards Timeline</h2>
+        <div id="timeline"></div>
+        <ol id="citations"></ol>
+      </section>
+    </main>
+    <footer class="container" aria-label="Contribute">
+      <p><a href="templates/contribute.html">Contribute</a></p>
+    </footer>
+    <button id="scrollToTopBtn" type="button" aria-label="Scroll to top">
+      ↑
+    </button>
 
-  <footer aria-label="Project contribution">
-    <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
-  </footer>
-  <script src="script.js"></script>
-  <script src="assets/js/app.js"></script>
-  <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
-  <script src="assets/js/metrics.js"></script>
-</body>
+    <footer aria-label="Project contribution">
+      <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
+    </footer>
+    <script src="script.js"></script>
+    <script src="assets/js/app.js"></script>
+    <script src="assets/js/timeline.js"></script>
+    <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
+    <script src="assets/js/metrics.js"></script>
+  </body>
 </html>
-

--- a/standards.json
+++ b/standards.json
@@ -1,0 +1,30 @@
+[
+  {
+    "id": "hipaa-1996",
+    "title": "HIPAA",
+    "year": 1996,
+    "citation": "Health Insurance Portability and Accountability Act of 1996",
+    "url": "https://www.hhs.gov/hipaa/index.html"
+  },
+  {
+    "id": "gdpr-2016",
+    "title": "EU GDPR",
+    "year": 2016,
+    "citation": "Regulation (EU) 2016/679 (General Data Protection Regulation)",
+    "url": "https://eur-lex.europa.eu/eli/reg/2016/679/oj"
+  },
+  {
+    "id": "iso-27001-2013",
+    "title": "ISO/IEC 27001",
+    "year": 2013,
+    "citation": "ISO/IEC 27001:2013 Information security management systems",
+    "url": "https://www.iso.org/standard/54534.html"
+  },
+  {
+    "id": "nist-800-53r5",
+    "title": "NIST SP 800-53 Rev. 5",
+    "year": 2020,
+    "citation": "Security and Privacy Controls for Information Systems and Organizations",
+    "url": "https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final"
+  }
+]

--- a/styles.css
+++ b/styles.css
@@ -25,7 +25,7 @@ body {
 
 h1 {
   text-align: center;
-  font-family: 'Cinzel', serif;
+  font-family: "Cinzel", serif;
   font-weight: 700;
   font-size: 48px;
   margin-bottom: 20px;
@@ -110,7 +110,6 @@ body.dark-mode mark {
   box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
   min-height: 44px;
 }
-
 
 /* Controls styling */
 #random-term {
@@ -206,7 +205,9 @@ label {
   border-radius: 4px;
   padding: 10px;
   cursor: pointer;
-  transition: background-color 0.2s, color 0.2s;
+  transition:
+    background-color 0.2s,
+    color 0.2s;
   min-width: 44px;
   min-height: 44px;
 }
@@ -324,6 +325,80 @@ body.dark-mode #alpha-nav button:focus {
 body.dark-mode #alpha-nav button.active {
   background-color: #007bff;
   border-color: #007bff;
+}
+
+#standards {
+  margin-top: 40px;
+}
+
+#timeline {
+  display: flex;
+  justify-content: space-between;
+  position: relative;
+  margin: 20px 0 40px;
+}
+
+#timeline::before {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 0;
+  width: 100%;
+  height: 4px;
+  background: #ccc;
+}
+
+.timeline-item {
+  position: relative;
+  text-align: center;
+  flex: 1;
+}
+
+.timeline-point {
+  background: #007bff;
+  border: none;
+  border-radius: 50%;
+  width: 24px;
+  height: 24px;
+  cursor: pointer;
+}
+
+.timeline-point:focus {
+  outline: 2px solid #000;
+}
+
+.timeline-label {
+  display: block;
+  margin-top: 8px;
+}
+
+@media (max-width: 600px) {
+  #timeline {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  #timeline::before {
+    left: 12px;
+    top: 0;
+    width: 4px;
+    height: 100%;
+  }
+
+  .timeline-item {
+    text-align: left;
+    padding-left: 40px;
+    margin-bottom: 40px;
+  }
+
+  .timeline-point {
+    margin-left: -12px;
+  }
+
+  .timeline-label {
+    margin-top: 0;
+    margin-left: 8px;
+  }
 }
 
 @media (max-width: 480px) {


### PR DESCRIPTION
## Summary
- collect key cybersecurity standards with year metadata in `standards.json`
- render responsive client-side timeline; clicking points scrolls to corresponding citation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b60848ae4483289b28b076edb217b5