### PR TITLE
Add TLS handshake stepper

### DIFF
--- a/handshake.html
+++ b/handshake.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>TLS Handshake Steps</title>
+    <link rel="stylesheet" href="styles.css" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <main class="container">
+      <h1>TLS Handshake Steps</h1>
+      <div id="step-content"></div>
+      <div class="step-controls">
+        <button id="prevStep" type="button" aria-label="Previous step">
+          Previous
+        </button>
+        <button id="nextStep" type="button" aria-label="Next step">Next</button>
+      </div>
+    </main>
+    <script src="handshake.js"></script>
+  </body>
+</html>

--- a/handshake.js
+++ b/handshake.js
@@ -1,0 +1,78 @@
+const steps = [
+  {
+    title: "Client Hello",
+    description:
+      'The client initiates the handshake by sending supported options. Learn more about <a href="index.html#Transport%20Layer%20Security%20(TLS)">Transport Layer Security (TLS)</a>.',
+  },
+  {
+    title: "Server Hello and Certificate",
+    description:
+      'The server responds with its chosen options and sends its certificate. See <a href="index.html#Certificate%20Authority%20(CA)">Certificate Authority (CA)</a>.',
+  },
+  {
+    title: "Certificate Verification",
+    description:
+      'The client verifies the certificate using trusted authorities in a <a href="index.html#Public%20Key%20Infrastructure%20(PKI)">Public Key Infrastructure (PKI)</a>.',
+  },
+  {
+    title: "Key Exchange",
+    description:
+      'Both parties perform <a href="index.html#Key%20Exchange">Key Exchange</a> to create shared secrets.',
+  },
+  {
+    title: "Finished",
+    description:
+      'Encrypted messages finish the handshake, establishing a secure <a href="index.html#Transport%20Layer%20Security%20(TLS)">TLS</a> session.',
+  },
+];
+
+const stepContent = document.getElementById("step-content");
+const prevBtn = document.getElementById("prevStep");
+const nextBtn = document.getElementById("nextStep");
+
+const params = new URLSearchParams(window.location.search);
+let currentStep = parseInt(params.get("step"), 10);
+if (isNaN(currentStep) || currentStep < 1 || currentStep > steps.length) {
+  currentStep = 1;
+}
+
+function renderStep(push = false) {
+  const step = steps[currentStep - 1];
+  stepContent.innerHTML = `<h2>${step.title}</h2><p>${step.description}</p>`;
+  prevBtn.disabled = currentStep === 1;
+  nextBtn.disabled = currentStep === steps.length;
+  const url = new URL(window.location);
+  url.searchParams.set("step", currentStep);
+  if (push) {
+    history.pushState({ step: currentStep }, "", url);
+  } else {
+    history.replaceState({ step: currentStep }, "", url);
+  }
+}
+
+prevBtn.addEventListener("click", () => {
+  if (currentStep > 1) {
+    currentStep--;
+    renderStep(true);
+  }
+});
+
+nextBtn.addEventListener("click", () => {
+  if (currentStep < steps.length) {
+    currentStep++;
+    renderStep(true);
+  }
+});
+
+window.addEventListener("popstate", () => {
+  const stepFromUrl = parseInt(
+    new URLSearchParams(window.location.search).get("step"),
+    10,
+  );
+  if (!isNaN(stepFromUrl)) {
+    currentStep = Math.min(Math.max(stepFromUrl, 1), steps.length);
+    renderStep();
+  }
+});
+
+renderStep();

--- a/styles.css
+++ b/styles.css
@@ -25,7 +25,7 @@ body {
 
 h1 {
   text-align: center;
-  font-family: 'Cinzel', serif;
+  font-family: "Cinzel", serif;
   font-weight: 700;
   font-size: 48px;
   margin-bottom: 20px;
@@ -110,7 +110,6 @@ body.dark-mode mark {
   box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
   min-height: 44px;
 }
-
 
 /* Controls styling */
 #random-term {
@@ -206,7 +205,9 @@ label {
   border-radius: 4px;
   padding: 10px;
   cursor: pointer;
-  transition: background-color 0.2s, color 0.2s;
+  transition:
+    background-color 0.2s,
+    color 0.2s;
   min-width: 44px;
   min-height: 44px;
 }
@@ -346,4 +347,26 @@ body.dark-mode #alpha-nav button.active {
   #alpha-nav button {
     font-size: 14px;
   }
+}
+
+.step-controls {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 20px;
+}
+
+.step-controls button {
+  padding: 10px;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  background-color: #007bff;
+  color: #fff;
+  cursor: pointer;
+  min-width: 44px;
+  min-height: 44px;
+}
+
+.step-controls button:disabled {
+  background-color: #aaa;
+  cursor: not-allowed;
 }


### PR DESCRIPTION
## Summary
- Add TLS handshake page with stepper showing each phase
- Provide glossary links and next/previous navigation with URL state
- Style stepper controls

## Testing
- `npm test`
- `npx html-validate handshake.html`

------
https://chatgpt.com/codex/tasks/task_e_68b6084a1ed08328b04870333aad506b