### PR TITLE
Add CIDR network calculator with copyable results

### DIFF
--- a/assets/js/cidr.js
+++ b/assets/js/cidr.js
@@ -1,0 +1,84 @@
+function ipToInt(ip) {
+  return ip.split(".").reduce((acc, oct) => (acc << 8) + Number(oct), 0) >>> 0;
+}
+
+function intToIp(int) {
+  return [int >>> 24, (int >>> 16) & 255, (int >>> 8) & 255, int & 255].join(
+    ".",
+  );
+}
+
+function prefixToMask(prefix) {
+  return prefix === 0 ? 0 : (0xffffffff << (32 - prefix)) >>> 0;
+}
+
+function copyToClipboard(id) {
+  const text = document.getElementById(id).textContent;
+  navigator.clipboard.writeText(text);
+}
+
+function calculate() {
+  const input = document.getElementById("cidr-input").value.trim();
+  const match = input.match(/^(\d{1,3}(?:\.\d{1,3}){3})\/(\d{1,2})$/);
+  if (!match) {
+    alert("Invalid CIDR notation");
+    return;
+  }
+  const ip = match[1];
+  const prefix = parseInt(match[2], 10);
+  if (prefix < 0 || prefix > 32) {
+    alert("Invalid CIDR notation");
+    return;
+  }
+  const octets = ip.split(".").map(Number);
+  if (octets.some((o) => o > 255)) {
+    alert("Invalid IP address");
+    return;
+  }
+  const ipInt = ipToInt(ip);
+  const maskInt = prefixToMask(prefix);
+  const networkInt = ipInt & maskInt;
+  const broadcastInt = networkInt | (~maskInt >>> 0);
+  let hostCount;
+  if (prefix === 32) hostCount = 1;
+  else if (prefix === 31) hostCount = 2;
+  else hostCount = Math.pow(2, 32 - prefix) - 2;
+  const firstHostInt = hostCount > 1 ? networkInt + 1 : networkInt;
+  const lastHostInt = hostCount > 1 ? broadcastInt - 1 : broadcastInt;
+
+  const results = {
+    "IP Address": ip,
+    "Subnet Mask": intToIp(maskInt),
+    "Network Address": intToIp(networkInt),
+    "Network Range": `${intToIp(networkInt)} - ${intToIp(broadcastInt)}`,
+    "Host Count": hostCount.toString(),
+    "First Host": intToIp(firstHostInt),
+    "Last Host": intToIp(lastHostInt),
+    "Broadcast Address": intToIp(broadcastInt),
+  };
+
+  const resultsDiv = document.getElementById("results");
+  resultsDiv.innerHTML = "";
+  Object.entries(results).forEach(([label, value]) => {
+    const wrapper = document.createElement("div");
+    wrapper.style.marginBottom = "10px";
+
+    const span = document.createElement("span");
+    span.id = label.replace(/\s+/g, "-").toLowerCase();
+    span.textContent = value;
+
+    const btn = document.createElement("button");
+    btn.textContent = "Copy";
+    btn.className = "copy-btn";
+    btn.addEventListener("click", () => copyToClipboard(span.id));
+
+    wrapper.appendChild(document.createTextNode(label + ": "));
+    wrapper.appendChild(span);
+    wrapper.appendChild(btn);
+    resultsDiv.appendChild(wrapper);
+  });
+}
+
+if (document.getElementById("calculate")) {
+  document.getElementById("calculate").addEventListener("click", calculate);
+}

--- a/cidr.html
+++ b/cidr.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+      <meta charset="UTF-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <title>CIDR Calculator</title>
+      <link rel="stylesheet" href="styles.css">
+    </head>
+    <body>
+      <main class="container">
+        <h1>CIDR Calculator</h1>
+        <input id="cidr-input" type="text" placeholder="e.g., 192.168.1.0/24">
+        <button id="calculate" type="button">Calculate</button>
+        <div id="results"></div>
+      </main>
+      <script src="assets/js/cidr.js"></script>
+    </body>
+  </html>

--- a/styles.css
+++ b/styles.css
@@ -145,6 +145,10 @@ body.dark-mode mark {
   background-color: #0056b3;
 }
 
+#results {
+  margin-top: 20px;
+}
+
 label {
   margin-left: 10px;
   margin-top: 10px;


### PR DESCRIPTION
## Summary
- Add standalone CIDR calculator page
- Parse CIDR input to compute network range, host count, and address details
- Include copy buttons for each calculated value and style results section

## Testing
- `npx html-validate cidr.html`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6084b59cc832897f877b315fa2a8a