### PR TITLE
Add tabbed encoding tools with streaming processing

### DIFF
--- a/assets/js/tools.js
+++ b/assets/js/tools.js
@@ -1,0 +1,115 @@
+function switchTab(selected) {
+  document.querySelectorAll('.tab-buttons [role="tab"]').forEach((btn) => {
+    const active = btn.dataset.tab === selected;
+    btn.classList.toggle("active", active);
+    btn.setAttribute("aria-selected", active);
+  });
+  document.querySelectorAll(".tab-content").forEach((panel) => {
+    const show = panel.id === selected;
+    panel.classList.toggle("active", show);
+    panel.hidden = !show;
+  });
+}
+
+document.querySelectorAll('.tab-buttons [role="tab"]').forEach((btn) => {
+  btn.addEventListener("click", () => switchTab(btn.dataset.tab));
+});
+
+async function processInChunks(str, size, fn) {
+  let result = "";
+  for (let i = 0; i < str.length; i += size) {
+    result += fn(str.slice(i, i + size));
+    await new Promise((r) => setTimeout(r));
+  }
+  return result;
+}
+
+async function base64Encode(str) {
+  return processInChunks(str, 3072, (chunk) => {
+    const binary = unescape(encodeURIComponent(chunk));
+    return btoa(binary);
+  });
+}
+
+async function base64Decode(str) {
+  return processInChunks(str, 4096, (chunk) => {
+    const decoded = atob(chunk);
+    return decodeURIComponent(escape(decoded));
+  });
+}
+
+async function urlEncode(str) {
+  return processInChunks(str, 5000, encodeURIComponent);
+}
+
+async function urlDecode(str) {
+  return processInChunks(str, 5000, decodeURIComponent);
+}
+
+async function hexEncode(str) {
+  const bytes = new TextEncoder().encode(str);
+  let out = "";
+  for (let i = 0; i < bytes.length; i++) {
+    out += bytes[i].toString(16).padStart(2, "0");
+    if (i % 1024 === 1023) {
+      await new Promise((r) => setTimeout(r));
+    }
+  }
+  return out;
+}
+
+async function hexDecode(str) {
+  if (str.length % 2 !== 0 || /[^0-9a-f]/i.test(str)) {
+    throw new Error("Invalid hex string");
+  }
+  const bytes = new Uint8Array(str.length / 2);
+  for (let i = 0; i < str.length; i += 2) {
+    bytes[i / 2] = parseInt(str.substr(i, 2), 16);
+    if (i % 2048 === 0) {
+      await new Promise((r) => setTimeout(r));
+    }
+  }
+  return new TextDecoder().decode(bytes);
+}
+
+function setupTab(prefix, encodeFn, decodeFn) {
+  const input = document.getElementById(`${prefix}-input`);
+  const output = document.getElementById(`${prefix}-output`);
+  const error = document.getElementById(`${prefix}-error`);
+  document
+    .getElementById(`${prefix}-encode`)
+    .addEventListener("click", async () => {
+      error.textContent = "";
+      output.textContent = "";
+      try {
+        output.textContent = await encodeFn(input.value);
+      } catch (e) {
+        error.textContent = e.message;
+      }
+    });
+  document
+    .getElementById(`${prefix}-decode`)
+    .addEventListener("click", async () => {
+      error.textContent = "";
+      output.textContent = "";
+      try {
+        output.textContent = await decodeFn(input.value);
+      } catch (e) {
+        error.textContent = e.message;
+      }
+    });
+  document.getElementById(`${prefix}-copy`).addEventListener("click", () => {
+    navigator.clipboard.writeText(output.textContent);
+  });
+  document.getElementById(`${prefix}-clear`).addEventListener("click", () => {
+    input.value = "";
+    output.textContent = "";
+    error.textContent = "";
+  });
+}
+
+setupTab("base64", base64Encode, base64Decode);
+setupTab("url", urlEncode, urlDecode);
+setupTab("hex", hexEncode, hexDecode);
+
+switchTab("base64");

--- a/styles.css
+++ b/styles.css
@@ -25,7 +25,7 @@ body {
 
 h1 {
   text-align: center;
-  font-family: 'Cinzel', serif;
+  font-family: "Cinzel", serif;
   font-weight: 700;
   font-size: 48px;
   margin-bottom: 20px;
@@ -110,7 +110,6 @@ body.dark-mode mark {
   box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
   min-height: 44px;
 }
-
 
 /* Controls styling */
 #random-term {
@@ -206,7 +205,9 @@ label {
   border-radius: 4px;
   padding: 10px;
   cursor: pointer;
-  transition: background-color 0.2s, color 0.2s;
+  transition:
+    background-color 0.2s,
+    color 0.2s;
   min-width: 44px;
   min-height: 44px;
 }
@@ -346,4 +347,58 @@ body.dark-mode #alpha-nav button.active {
   #alpha-nav button {
     font-size: 14px;
   }
+}
+
+/* Tools page tabbed interface */
+.tab-buttons {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.tab-buttons button {
+  flex: 1;
+  padding: 10px;
+  border: 1px solid #ccc;
+  background-color: #f2f2f2;
+  cursor: pointer;
+}
+
+.tab-buttons button.active {
+  background-color: #007bff;
+  color: #fff;
+}
+
+.tab-content {
+  display: none;
+}
+
+.tab-content.active {
+  display: block;
+}
+
+textarea {
+  width: 100%;
+  min-height: 100px;
+}
+
+.controls button,
+.copy-btn {
+  margin-top: 10px;
+  padding: 10px;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  background-color: #007bff;
+  color: #fff;
+  cursor: pointer;
+}
+
+.controls button:hover,
+.copy-btn:hover {
+  background-color: #0056b3;
+}
+
+.error {
+  color: red;
+  margin-top: 10px;
 }

--- a/tools.html
+++ b/tools.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Encoding Tools</title>
+    <link rel="stylesheet" href="styles.css">
+  </head>
+  <body>
+    <main class="container">
+      <h1>Encoding Tools</h1>
+      <div class="tab-container">
+        <div class="tab-buttons" role="tablist">
+          <button
+            type="button"
+            role="tab"
+            aria-selected="true"
+            data-tab="base64"
+          >
+            Base64
+          </button>
+          <button type="button" role="tab" aria-selected="false" data-tab="url">
+            URL
+          </button>
+          <button type="button" role="tab" aria-selected="false" data-tab="hex">
+            Hex
+          </button>
+        </div>
+        <div id="base64" class="tab-content" role="tabpanel">
+          <textarea
+            id="base64-input"
+            placeholder="Enter text or Base64"
+          ></textarea>
+          <div class="controls">
+            <button id="base64-encode" type="button">Encode</button>
+            <button id="base64-decode" type="button">Decode</button>
+            <button id="base64-clear" type="button">Clear</button>
+          </div>
+          <pre id="base64-output" aria-live="polite"></pre>
+          <button id="base64-copy" type="button" class="copy-btn">Copy</button>
+          <p id="base64-error" class="error" aria-live="assertive"></p>
+        </div>
+        <div id="url" class="tab-content" role="tabpanel" hidden>
+          <textarea id="url-input" placeholder="Enter text or URL"></textarea>
+          <div class="controls">
+            <button id="url-encode" type="button">Encode</button>
+            <button id="url-decode" type="button">Decode</button>
+            <button id="url-clear" type="button">Clear</button>
+          </div>
+          <pre id="url-output" aria-live="polite"></pre>
+          <button id="url-copy" type="button" class="copy-btn">Copy</button>
+          <p id="url-error" class="error" aria-live="assertive"></p>
+        </div>
+        <div id="hex" class="tab-content" role="tabpanel" hidden>
+          <textarea id="hex-input" placeholder="Enter text or hex"></textarea>
+          <div class="controls">
+            <button id="hex-encode" type="button">Encode</button>
+            <button id="hex-decode" type="button">Decode</button>
+            <button id="hex-clear" type="button">Clear</button>
+          </div>
+          <pre id="hex-output" aria-live="polite"></pre>
+          <button id="hex-copy" type="button" class="copy-btn">Copy</button>
+          <p id="hex-error" class="error" aria-live="assertive"></p>
+        </div>
+      </div>
+    </main>
+    <script src="assets/js/tools.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Add `tools.html` with a tabbed interface for Base64, URL and Hex operations
- Implement async chunked encoding/decoding logic with copy and clear controls
- Style new tools page

## Testing
- `npx html-validate tools.html`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6084bda6c8328b0939271d5061026