### PR TITLE
feat: add regex tester page

### DIFF
--- a/assets/js/regex.js
+++ b/assets/js/regex.js
@@ -1,0 +1,46 @@
+const patterns = [
+  { pattern: '^\\d+$', description: 'Digits only' },
+  { pattern: '^[a-zA-Z]+$', description: 'Letters only' },
+  { pattern: '^\\w+@[a-zA-Z_]+?\\.[a-zA-Z]{2,3}$', description: 'Simple email address' }
+];
+
+const list = document.getElementById('regex-list');
+const liveRegion = document.getElementById('live-region');
+
+patterns.forEach(({ pattern, description }) => {
+  const li = document.createElement('li');
+  li.innerHTML = `
+    <p>${description}</p>
+    <code>${pattern}</code>
+    <button type="button" class="copy-btn">Copy</button>
+    <input type="text" class="test-input" placeholder="Enter text to test" aria-label="Test text against pattern: ${description}">
+    <span class="result" aria-live="polite"></span>
+  `;
+  list.appendChild(li);
+
+  const regex = new RegExp(pattern);
+  const input = li.querySelector('.test-input');
+  const result = li.querySelector('.result');
+
+  input.addEventListener('input', () => {
+    if (regex.test(input.value)) {
+      input.classList.add('pass');
+      input.classList.remove('fail');
+      result.textContent = 'Match';
+    } else {
+      input.classList.add('fail');
+      input.classList.remove('pass');
+      result.textContent = 'No match';
+    }
+  });
+
+  const copyBtn = li.querySelector('.copy-btn');
+  copyBtn.addEventListener('click', async () => {
+    try {
+      await navigator.clipboard.writeText(pattern);
+      liveRegion.textContent = 'Pattern copied to clipboard';
+    } catch (err) {
+      liveRegion.textContent = 'Failed to copy pattern';
+    }
+  });
+});

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "script.js",
   "scripts": {
     "build": "node scripts/build.js",
-    "test": "html-validate index.html search.html diagnostics.html && node diagnostics.test.js",
+    "test": "html-validate index.html search.html diagnostics.html regex.html && node diagnostics.test.js",
     "watch": "chokidar \"**/*.html\" -c \"npm run build\""
   },
   "keywords": [],

--- a/regex.html
+++ b/regex.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Regex Tester</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <main class="container">
+    <h1>Regex Tester</h1>
+    <ul id="regex-list"></ul>
+    <div id="live-region" class="visually-hidden" aria-live="polite"></div>
+  </main>
+  <script src="assets/js/regex.js"></script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -347,3 +347,21 @@ body.dark-mode #alpha-nav button.active {
     font-size: 14px;
   }
 }
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  border: 0;
+}
+
+.test-input.pass {
+  border: 2px solid green;
+}
+
+.test-input.fail {
+  border: 2px solid red;
+}


### PR DESCRIPTION
## Summary
- create regex tester page listing common patterns
- add live regex validation with copy buttons and accessible feedback
- validate regex page in test script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6084c5b708328a9c8f71179817b7f