### PR TITLE
Add terminal component with typewriter animation and offline support

### DIFF
--- a/assets/js/terminal.js
+++ b/assets/js/terminal.js
@@ -1,0 +1,38 @@
+// Read-only terminal with typewriter effect and theme support
+function typeWriter(text, element, index) {
+  if (index < text.length) {
+    element.textContent += text.charAt(index);
+    setTimeout(() => typeWriter(text, element, index + 1), 50);
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const output = document.getElementById('terminal-output');
+  const copyBtn = document.getElementById('terminal-copy');
+  const themeBtn = document.getElementById('terminal-theme');
+  const container = document.getElementById('terminal');
+  let content = '';
+
+  fetch('assets/terminal-content.txt')
+    .then((resp) => resp.text())
+    .then((text) => {
+      content = text;
+      typeWriter(content, output, 0);
+    })
+    .catch(() => {
+      content = 'Failed to load content.';
+      typeWriter(content, output, 0);
+    });
+
+  if (copyBtn) {
+    copyBtn.addEventListener('click', () => {
+      navigator.clipboard.writeText(content);
+    });
+  }
+
+  if (themeBtn) {
+    themeBtn.addEventListener('click', () => {
+      container.classList.toggle('dark');
+    });
+  }
+});

--- a/assets/terminal-content.txt
+++ b/assets/terminal-content.txt
@@ -1,0 +1,2 @@
+Welcome to the Cyber Security Dictionary.
+This read-only terminal demonstrates terms with a typewriter effect.

--- a/index.html
+++ b/index.html
@@ -7,11 +7,20 @@
   <link rel="stylesheet" href="styles.css">
   <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet">
   <link rel="canonical" id="canonical-link" href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/">
+  <link rel="preload" href="assets/terminal-content.txt" as="fetch" crossorigin="anonymous">
+  <link rel="preload" href="assets/js/terminal.js" as="script">
 </head>
 <body>
   <main class="container">
     <h1>Cyber Security Dictionary</h1>
     <nav class="site-nav" aria-label="Site links"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
+    <section id="terminal" class="terminal" aria-label="Read only terminal">
+      <pre id="terminal-output" aria-live="polite"></pre>
+      <div class="terminal-controls">
+        <button id="terminal-copy" type="button" aria-label="Copy terminal output">Copy</button>
+        <button id="terminal-theme" type="button" aria-label="Toggle terminal theme">Toggle Theme</button>
+      </div>
+    </section>
     <div id="definition-container" style="display: none;"></div>
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">
@@ -33,6 +42,7 @@
     <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
   </footer>
   <script src="script.js"></script>
+  <script src="assets/js/terminal.js" defer></script>
   <script src="assets/js/app.js"></script>
   <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
   <script src="assets/js/metrics.js"></script>

--- a/styles.css
+++ b/styles.css
@@ -347,3 +347,37 @@ body.dark-mode #alpha-nav button.active {
     font-size: 14px;
   }
 }
+
+/* Terminal component */
+.terminal {
+  font-family: monospace;
+  padding: 10px;
+  border-radius: 5px;
+  background-color: #f5f5f5;
+  color: #333;
+  margin-bottom: 20px;
+}
+
+.terminal.dark {
+  background-color: #000;
+  color: #0f0;
+}
+
+.terminal-controls {
+  margin-top: 10px;
+  display: flex;
+  gap: 10px;
+}
+
+.terminal-controls button {
+  padding: 5px 10px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background-color: #007bff;
+  color: #fff;
+  cursor: pointer;
+}
+
+.terminal-controls button:hover {
+  background-color: #0056b3;
+}

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,9 @@ const URLS_TO_CACHE = [
   '/index.html',
   '/styles.css',
   '/script.js',
-  '/data.json'
+  '/data.json',
+  '/assets/js/terminal.js',
+  '/assets/terminal-content.txt'
 ];
 
 self.addEventListener('install', event => {


### PR DESCRIPTION
## Summary
- Introduce read-only terminal component with typewriter animation, copy control, and theme toggle
- Preload terminal assets and cache them offline via the service worker
- Style terminal component for light/dark themes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6084e8f30832891311ff1965fb159