### PR TITLE
Add Pomodoro timer with reading queue integration

### DIFF
--- a/assets/js/pomodoro.js
+++ b/assets/js/pomodoro.js
@@ -1,0 +1,123 @@
+// Simple Pomodoro timer with short/long breaks and persistent state
+(function () {
+  const defaultDurations = {
+    work: 25 * 60,
+    shortBreak: 5 * 60,
+    longBreak: 15 * 60,
+  };
+
+  const state = JSON.parse(localStorage.getItem("pomodoroState") || "{}");
+
+  let mode = state.mode || "work";
+  let endTime = state.endTime || null;
+  let timerInterval = null;
+  let pinned = state.pinned !== false; // default pinned
+  let currentItem = state.currentItem || null;
+
+  const container = document.createElement("div");
+  container.id = "pomodoro-timer";
+  container.innerHTML = `
+    <select id="pomodoro-mode">
+      <option value="work">Work</option>
+      <option value="shortBreak">Short Break</option>
+      <option value="longBreak">Long Break</option>
+    </select>
+    <span id="pomodoro-time"></span>
+    <button id="pomodoro-start" type="button">Start</button>
+    <button id="pomodoro-reset" type="button">Reset</button>
+    <button id="pomodoro-pin" type="button">Pin</button>
+    <div id="pomodoro-current"></div>
+  `;
+  document.body.appendChild(container);
+
+  const modeSelect = container.querySelector("#pomodoro-mode");
+  const timeDisplay = container.querySelector("#pomodoro-time");
+  const startBtn = container.querySelector("#pomodoro-start");
+  const resetBtn = container.querySelector("#pomodoro-reset");
+  const pinBtn = container.querySelector("#pomodoro-pin");
+  const currentDiv = container.querySelector("#pomodoro-current");
+
+  function persist() {
+    localStorage.setItem(
+      "pomodoroState",
+      JSON.stringify({ mode, endTime, pinned, currentItem }),
+    );
+  }
+
+  function updateDisplay() {
+    if (!endTime) {
+      timeDisplay.textContent = formatTime(defaultDurations[mode]);
+      return;
+    }
+    const remaining = Math.max(0, Math.floor((endTime - Date.now()) / 1000));
+    timeDisplay.textContent = formatTime(remaining);
+    if (remaining <= 0) {
+      clearInterval(timerInterval);
+      timerInterval = null;
+      endTime = null;
+      persist();
+    }
+  }
+
+  function formatTime(sec) {
+    const m = String(Math.floor(sec / 60)).padStart(2, "0");
+    const s = String(sec % 60).padStart(2, "0");
+    return `${m}:${s}`;
+  }
+
+  function start() {
+    if (!endTime) {
+      endTime = Date.now() + defaultDurations[mode] * 1000;
+      if (mode === "work" && typeof window.startReadingSession === "function") {
+        currentItem = window.startReadingSession();
+        currentDiv.textContent = currentItem ? `Reading: ${currentItem}` : "";
+      }
+      persist();
+    }
+    if (!timerInterval) {
+      timerInterval = setInterval(updateDisplay, 1000);
+    }
+  }
+
+  function reset() {
+    clearInterval(timerInterval);
+    timerInterval = null;
+    endTime = null;
+    currentItem = null;
+    currentDiv.textContent = "";
+    persist();
+    updateDisplay();
+  }
+
+  startBtn.addEventListener("click", start);
+  resetBtn.addEventListener("click", reset);
+
+  modeSelect.value = mode;
+  modeSelect.addEventListener("change", () => {
+    mode = modeSelect.value;
+    reset();
+    persist();
+  });
+
+  pinBtn.addEventListener("click", () => {
+    pinned = !pinned;
+    applyPin();
+    persist();
+  });
+
+  function applyPin() {
+    if (pinned) {
+      container.classList.add("pinned");
+    } else {
+      container.classList.remove("pinned");
+    }
+  }
+
+  applyPin();
+  updateDisplay();
+  if (endTime) {
+    start();
+  }
+
+  currentDiv.textContent = currentItem ? `Reading: ${currentItem}` : "";
+})();

--- a/diagnostics.html
+++ b/diagnostics.html
@@ -1,21 +1,27 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Diagnostics</title>
-  <link rel="stylesheet" href="styles.css">
-</head>
-<body>
-  <main class="container">
-    <h1>Performance Diagnostics</h1>
-    <table>
-      <thead>
-        <tr><th>Timestamp</th><th>LCP</th><th>CLS</th><th>TBT</th></tr>
-      </thead>
-      <tbody id="metrics-body"></tbody>
-    </table>
-  </main>
-  <script src="assets/js/diagnostics.js"></script>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Diagnostics</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="container">
+      <h1>Performance Diagnostics</h1>
+      <table>
+        <thead>
+          <tr>
+            <th>Timestamp</th>
+            <th>LCP</th>
+            <th>CLS</th>
+            <th>TBT</th>
+          </tr>
+        </thead>
+        <tbody id="metrics-body"></tbody>
+      </table>
+    </main>
+    <script src="assets/js/diagnostics.js"></script>
+    <script src="assets/js/pomodoro.js"></script>
+  </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,41 +1,56 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Cyber Security Dictionary</title>
-  <link rel="stylesheet" href="styles.css">
-  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet">
-  <link rel="canonical" id="canonical-link" href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/">
-</head>
-<body>
-  <main class="container">
-    <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav" aria-label="Site links"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
-    <div id="definition-container" style="display: none;"></div>
-    <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
-    <input type="text" id="search" placeholder="Search...">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Cyber Security Dictionary</title>
+    <link rel="stylesheet" href="styles.css" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      rel="canonical"
+      id="canonical-link"
+      href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/"
+    />
+  </head>
+  <body>
+    <main class="container">
+      <h1>Cyber Security Dictionary</h1>
+      <nav class="site-nav" aria-label="Site links">
+        <a href="templates/guidelines.html">Definition Guidelines</a>
+      </nav>
+      <div id="definition-container" style="display: none"></div>
+      <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
+      <input type="text" id="search" placeholder="Search..." />
 
-    <button id="random-term" type="button" aria-label="Show random term">Random Term</button>
+      <button id="random-term" type="button" aria-label="Show random term">
+        Random Term
+      </button>
 
-    <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">Toggle Dark Mode</button>
-    <input type="checkbox" id="show-favorites" aria-label="Show favorites">
-    <label for="show-favorites">Show Favorites</label>
+      <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">
+        Toggle Dark Mode
+      </button>
+      <input type="checkbox" id="show-favorites" aria-label="Show favorites" />
+      <label for="show-favorites">Show Favorites</label>
 
-    <ul id="terms-list"></ul>
-  </main>
-  <footer class="container" aria-label="Contribute">
-    <p><a href="templates/contribute.html">Contribute</a></p>
-  </footer>
-  <button id="scrollToTopBtn" type="button" aria-label="Scroll to top">↑</button>
+      <ul id="terms-list"></ul>
+    </main>
+    <footer class="container" aria-label="Contribute">
+      <p><a href="templates/contribute.html">Contribute</a></p>
+    </footer>
+    <button id="scrollToTopBtn" type="button" aria-label="Scroll to top">
+      ↑
+    </button>
 
-  <footer aria-label="Project contribution">
-    <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
-  </footer>
-  <script src="script.js"></script>
-  <script src="assets/js/app.js"></script>
-  <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
-  <script src="assets/js/metrics.js"></script>
-</body>
+    <footer aria-label="Project contribution">
+      <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
+    </footer>
+    <script src="script.js"></script>
+    <script src="assets/js/pomodoro.js"></script>
+    <script src="assets/js/app.js"></script>
+    <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
+    <script src="assets/js/metrics.js"></script>
+  </body>
 </html>
-

--- a/script.js
+++ b/script.js
@@ -5,7 +5,10 @@ const randomButton = document.getElementById("random-term");
 const alphaNav = document.getElementById("alpha-nav");
 const darkModeToggle = document.getElementById("dark-mode-toggle");
 const showFavoritesToggle = document.getElementById("show-favorites");
-const favorites = new Set(JSON.parse(localStorage.getItem("favorites") || "[]"));
+const favorites = new Set(
+  JSON.parse(localStorage.getItem("favorites") || "[]"),
+);
+const readingQueue = JSON.parse(localStorage.getItem("readingQueue") || "[]");
 const siteUrl = "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/";
 const canonicalLink = document.getElementById("canonical-link");
 
@@ -19,7 +22,10 @@ if (localStorage.getItem("darkMode") === "true") {
 if (darkModeToggle) {
   darkModeToggle.addEventListener("click", () => {
     document.body.classList.toggle("dark-mode");
-    localStorage.setItem("darkMode", document.body.classList.contains("dark-mode"));
+    localStorage.setItem(
+      "darkMode",
+      document.body.classList.contains("dark-mode"),
+    );
   });
 }
 
@@ -43,9 +49,11 @@ function loadTerms() {
       populateTermsList();
 
       if (window.location.hash) {
-        const termFromHash = decodeURIComponent(window.location.hash.substring(1));
+        const termFromHash = decodeURIComponent(
+          window.location.hash.substring(1),
+        );
         const matchedTerm = termsData.terms.find(
-          (t) => t.term.toLowerCase() === termFromHash.toLowerCase()
+          (t) => t.term.toLowerCase() === termFromHash.toLowerCase(),
         );
         if (matchedTerm) {
           displayDefinition(matchedTerm);
@@ -56,7 +64,7 @@ function loadTerms() {
       console.error("Detailed error fetching data:", error);
       definitionContainer.style.display = "block";
       definitionContainer.innerHTML =
-        '<p>Unable to load dictionary data. Please check your connection and try again.</p>' +
+        "<p>Unable to load dictionary data. Please check your connection and try again.</p>" +
         '<button id="retry-fetch">Retry</button>';
       const retryBtn = document.getElementById("retry-fetch");
       if (retryBtn) {
@@ -97,12 +105,16 @@ function toggleFavorite(term) {
 }
 
 function highlightActiveButton(button) {
-  alphaNav.querySelectorAll("button").forEach((btn) => btn.classList.remove("active"));
+  alphaNav
+    .querySelectorAll("button")
+    .forEach((btn) => btn.classList.remove("active"));
   button.classList.add("active");
 }
 
 function buildAlphaNav() {
-  const letters = Array.from(new Set(termsData.terms.map((t) => t.term.charAt(0).toUpperCase()))).sort();
+  const letters = Array.from(
+    new Set(termsData.terms.map((t) => t.term.charAt(0).toUpperCase())),
+  ).sort();
 
   const allButton = document.createElement("button");
   allButton.textContent = "All";
@@ -134,9 +146,13 @@ function populateTermsList() {
     .sort((a, b) => a.term.localeCompare(b.term))
     .forEach((item) => {
       const matchesSearch = item.term.toLowerCase().includes(searchValue);
-      const matchesFavorites = !showFavoritesToggle || !showFavoritesToggle.checked || favorites.has(item.term);
+      const matchesFavorites =
+        !showFavoritesToggle ||
+        !showFavoritesToggle.checked ||
+        favorites.has(item.term);
       const matchesLetter =
-        currentLetterFilter === "All" || item.term.charAt(0).toUpperCase() === currentLetterFilter;
+        currentLetterFilter === "All" ||
+        item.term.charAt(0).toUpperCase() === currentLetterFilter;
       if (matchesSearch && matchesFavorites && matchesLetter) {
         const termDiv = document.createElement("div");
         termDiv.classList.add("dictionary-item");
@@ -182,32 +198,73 @@ function populateTermsList() {
 
 function displayDefinition(term) {
   definitionContainer.style.display = "block";
-  definitionContainer.innerHTML = `<h3>${term.term}</h3><p>${term.definition}</p>`;
+  definitionContainer.innerHTML = `<h3>${term.term}</h3><p>${term.definition}</p><button id="add-to-queue" type="button">Add to Reading Queue</button>`;
   window.location.hash = encodeURIComponent(term.term);
   if (canonicalLink) {
     canonicalLink.setAttribute(
       "href",
-      `${siteUrl}#${encodeURIComponent(term.term)}`
+      `${siteUrl}#${encodeURIComponent(term.term)}`,
     );
+  }
+
+  const addBtn = document.getElementById("add-to-queue");
+  if (addBtn) {
+    addBtn.addEventListener("click", () => {
+      if (!readingQueue.includes(term.term)) {
+        readingQueue.push(term.term);
+        try {
+          localStorage.setItem("readingQueue", JSON.stringify(readingQueue));
+        } catch (e) {
+          // Ignore storage errors
+        }
+      }
+    });
   }
 }
 
 function clearDefinition() {
   definitionContainer.style.display = "none";
   definitionContainer.innerHTML = "";
-  history.replaceState(null, "", window.location.pathname + window.location.search);
+  history.replaceState(
+    null,
+    "",
+    window.location.pathname + window.location.search,
+  );
   if (canonicalLink) {
     canonicalLink.setAttribute("href", siteUrl);
   }
 }
 
+window.startReadingSession = function () {
+  if (readingQueue.length === 0) {
+    return null;
+  }
+  const nextTerm = readingQueue.shift();
+  try {
+    localStorage.setItem("readingQueue", JSON.stringify(readingQueue));
+  } catch (e) {
+    // Ignore storage errors
+  }
+  const termObj = termsData.terms.find(
+    (t) => t.term.toLowerCase() === nextTerm.toLowerCase(),
+  );
+  if (termObj) {
+    displayDefinition(termObj);
+  }
+  return nextTerm;
+};
+
 function showRandomTerm() {
-  const randomTerm = termsData.terms[Math.floor(Math.random() * termsData.terms.length)];
+  const randomTerm =
+    termsData.terms[Math.floor(Math.random() * termsData.terms.length)];
   displayDefinition(randomTerm);
 
   const today = new Date().toDateString();
   try {
-    localStorage.setItem("lastRandomTerm", JSON.stringify({ date: today, term: randomTerm }));
+    localStorage.setItem(
+      "lastRandomTerm",
+      JSON.stringify({ date: today, term: randomTerm }),
+    );
   } catch (e) {
     // Ignore storage errors
   }
@@ -249,8 +306,7 @@ window.addEventListener("scroll", () => {
   scrollBtn.style.display = window.scrollY > 200 ? "block" : "none";
 });
 scrollBtn.addEventListener("click", () =>
-  window.scrollTo({ top: 0, behavior: "smooth" })
+  window.scrollTo({ top: 0, behavior: "smooth" }),
 );
 
 definitionContainer.addEventListener("click", clearDefinition);
-

--- a/search.html
+++ b/search.html
@@ -1,22 +1,23 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Search</title>
-  <link rel="stylesheet" href="styles.css">
-</head>
-<body>
-  <main class="container">
-    <h1>Search</h1>
-    <input id="search-box" type="text" placeholder="Search terms...">
-    <div id="results"></div>
-  </main>
-  <script>
-    window.__BASE_URL__ = window.__BASE_URL__ || '';
-  </script>
-  <script src="assets/js/search.js"></script>
-  <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
-  <script src="assets/js/metrics.js"></script>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Search</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="container">
+      <h1>Search</h1>
+      <input id="search-box" type="text" placeholder="Search terms..." />
+      <div id="results"></div>
+    </main>
+    <script>
+      window.__BASE_URL__ = window.__BASE_URL__ || "";
+    </script>
+    <script src="assets/js/search.js"></script>
+    <script src="assets/js/pomodoro.js"></script>
+    <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
+    <script src="assets/js/metrics.js"></script>
+  </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -25,7 +25,7 @@ body {
 
 h1 {
   text-align: center;
-  font-family: 'Cinzel', serif;
+  font-family: "Cinzel", serif;
   font-weight: 700;
   font-size: 48px;
   margin-bottom: 20px;
@@ -110,7 +110,6 @@ body.dark-mode mark {
   box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
   min-height: 44px;
 }
-
 
 /* Controls styling */
 #random-term {
@@ -206,7 +205,9 @@ label {
   border-radius: 4px;
   padding: 10px;
   cursor: pointer;
-  transition: background-color 0.2s, color 0.2s;
+  transition:
+    background-color 0.2s,
+    color 0.2s;
   min-width: 44px;
   min-height: 44px;
 }
@@ -236,6 +237,25 @@ label {
   width: 44px;
   height: 44px;
   border-radius: 50%;
+}
+
+#pomodoro-timer {
+  background-color: #fff;
+  border: 1px solid #ccc;
+  padding: 10px;
+  border-radius: 5px;
+  z-index: 1000;
+}
+
+#pomodoro-timer.pinned {
+  position: fixed;
+  bottom: 10px;
+  right: 10px;
+}
+
+#pomodoro-timer button,
+#pomodoro-timer select {
+  margin-left: 5px;
 }
 
 #scrollToTopBtn:hover {


### PR DESCRIPTION
## Summary
- Add persistent Pomodoro timer supporting work, short break, and long break sessions.
- Allow pinning the timer to the page corner and retaining state across navigation.
- Integrate timer with a reading queue, enabling sessions to start with queued terms.

## Testing
- `npm test`
- `npx prettier --write index.html search.html diagnostics.html script.js styles.css assets/js/pomodoro.js`

------
https://chatgpt.com/codex/tasks/task_e_68b608525ff4832884a39b7674b3f79b