### PR TITLE
feat: add inline translations

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -89,6 +89,22 @@ body.dark-mode mark {
   color: #666;
 }
 
+.translation-toggle {
+  margin-left: 5px;
+  font-size: 0.9em;
+}
+
+.translation {
+  display: block;
+  margin-top: 4px;
+  font-size: 0.9em;
+  color: #555;
+}
+
+body.dark-mode .translation {
+  color: #ccc;
+}
+
 .dictionary-item:hover {
   transform: scale(1.02);
 }

--- a/translations.json
+++ b/translations.json
@@ -1,0 +1,15 @@
+{
+  "languagePairs": [
+    { "from": "en", "to": "es", "label": "English to Spanish" }
+  ],
+  "translations": {
+    "en-es": {
+      "Phishing": [
+        "Un intento de engañar a individuos para revelar información sensible mediante correos electrónicos, sitios web o mensajes fraudulentos."
+      ],
+      "Phishing Email": [
+        "Un correo electrónico que parece legítimo pero busca engañar a los destinatarios para revelar información sensible o realizar acciones."
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- load configurable translation pairs and data
- enable per-paragraph translation toggles in definitions
- provide sample English to Spanish translations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b608569b9c8328bba7faba7c053bc4