### PR TITLE
Add offline streak tracking and reduced-motion celebration

### DIFF
--- a/assets/js/streaks.js
+++ b/assets/js/streaks.js
@@ -1,0 +1,93 @@
+(function () {
+  const LOG_KEY = 'activityLog';
+  const STATS_KEY = 'streakStats';
+  const MS_PER_DAY = 86400000;
+
+  function read(key) {
+    try {
+      return JSON.parse(localStorage.getItem(key) || '[]');
+    } catch (e) {
+      return [];
+    }
+  }
+
+  function write(key, value) {
+    try {
+      localStorage.setItem(key, JSON.stringify(value));
+    } catch (e) {
+      // ignore storage errors
+    }
+  }
+
+  function computeStats(log) {
+    const days = Array.from(
+      new Set(
+        log.map((d) =>
+          Math.floor(new Date(d).setHours(0, 0, 0, 0) / MS_PER_DAY)
+        )
+      )
+    ).sort((a, b) => a - b);
+    if (days.length === 0) {
+      return { current: 0, best: 0 };
+    }
+    let best = 1;
+    let streak = 1;
+    for (let i = 1; i < days.length; i++) {
+      if (days[i] - days[i - 1] === 1) {
+        streak++;
+      } else {
+        streak = 1;
+      }
+      if (streak > best) {
+        best = streak;
+      }
+    }
+    const todayNum = Math.floor(Date.now() / MS_PER_DAY);
+    const lastDay = days[days.length - 1];
+    const current = lastDay === todayNum ? streak : 0;
+    return { current, best };
+  }
+
+  function updateDisplay(current, best, newRecord) {
+    const currentEl = document.getElementById('current-streak');
+    const bestEl = document.getElementById('best-streak');
+    if (!currentEl || !bestEl) return;
+    currentEl.textContent = String(current);
+    bestEl.textContent = String(best);
+    if (newRecord && !window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      bestEl.classList.add('celebrate');
+      bestEl.addEventListener(
+        'animationend',
+        () => bestEl.classList.remove('celebrate'),
+        { once: true }
+      );
+    }
+  }
+
+  function init() {
+    const today = new Date().toISOString().slice(0, 10);
+    const log = read(LOG_KEY);
+    if (!log.includes(today)) {
+      log.push(today);
+      log.sort();
+      write(LOG_KEY, log);
+    }
+    const prev = (function () {
+      try {
+        return JSON.parse(localStorage.getItem(STATS_KEY) || '{}');
+      } catch (e) {
+        return {};
+      }
+    })();
+    const stats = computeStats(log);
+    write(STATS_KEY, stats);
+    const newRecord = typeof prev.best === 'number' && stats.best > prev.best;
+    updateDisplay(stats.current, stats.best, newRecord);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/index.html
+++ b/index.html
@@ -22,6 +22,8 @@
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 
+    <div id="streaks" aria-live="polite">Current streak: <span id="current-streak">0</span> | Best streak: <span id="best-streak">0</span></div>
+
     <ul id="terms-list"></ul>
   </main>
   <footer class="container" aria-label="Contribute">
@@ -36,6 +38,7 @@
   <script src="assets/js/app.js"></script>
   <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
   <script src="assets/js/metrics.js"></script>
+  <script src="assets/js/streaks.js"></script>
 </body>
 </html>
 

--- a/styles.css
+++ b/styles.css
@@ -158,6 +158,36 @@ label {
   margin-right: 5px;
 }
 
+#streaks {
+  margin-top: 10px;
+}
+
+#streaks span {
+  font-weight: bold;
+}
+
+@keyframes pop {
+  0% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.3);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+.celebrate {
+  animation: pop 0.6s ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .celebrate {
+    animation: none;
+  }
+}
+
 /* Favorite star styles */
 .favorite-star {
   font-size: 20px;

--- a/sw.js
+++ b/sw.js
@@ -4,6 +4,7 @@ const URLS_TO_CACHE = [
   '/index.html',
   '/styles.css',
   '/script.js',
+  '/assets/js/streaks.js',
   '/data.json'
 ];
 


### PR DESCRIPTION
## Summary
- track daily activity in localStorage and compute current/best streaks
- show streak counts with optional celebratory animation and reduced-motion respect
- cache new streak script in service worker for offline use

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b60851d64483288c68fedd8d755965