### PR TITLE
Enable paragraph highlighting with double-tap and drawer

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,41 +1,66 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Cyber Security Dictionary</title>
-  <link rel="stylesheet" href="styles.css">
-  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet">
-  <link rel="canonical" id="canonical-link" href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/">
-</head>
-<body>
-  <main class="container">
-    <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav" aria-label="Site links"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
-    <div id="definition-container" style="display: none;"></div>
-    <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
-    <input type="text" id="search" placeholder="Search...">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Cyber Security Dictionary</title>
+    <link rel="stylesheet" href="styles.css" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      rel="canonical"
+      id="canonical-link"
+      href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/"
+    />
+  </head>
+  <body>
+    <main class="container">
+      <h1>Cyber Security Dictionary</h1>
+      <nav class="site-nav" aria-label="Site links">
+        <a href="templates/guidelines.html">Definition Guidelines</a>
+      </nav>
+      <div id="definition-container" style="display: none"></div>
+      <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
+      <input type="text" id="search" placeholder="Search..." />
 
-    <button id="random-term" type="button" aria-label="Show random term">Random Term</button>
+      <button id="random-term" type="button" aria-label="Show random term">
+        Random Term
+      </button>
 
-    <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">Toggle Dark Mode</button>
-    <input type="checkbox" id="show-favorites" aria-label="Show favorites">
-    <label for="show-favorites">Show Favorites</label>
+      <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">
+        Toggle Dark Mode
+      </button>
+      <input type="checkbox" id="show-favorites" aria-label="Show favorites" />
+      <label for="show-favorites">Show Favorites</label>
 
-    <ul id="terms-list"></ul>
-  </main>
-  <footer class="container" aria-label="Contribute">
-    <p><a href="templates/contribute.html">Contribute</a></p>
-  </footer>
-  <button id="scrollToTopBtn" type="button" aria-label="Scroll to top">↑</button>
+      <ul id="terms-list"></ul>
+    </main>
+    <footer class="container" aria-label="Contribute">
+      <p><a href="templates/contribute.html">Contribute</a></p>
+    </footer>
+    <button id="scrollToTopBtn" type="button" aria-label="Scroll to top">
+      ↑
+    </button>
 
-  <footer aria-label="Project contribution">
-    <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
-  </footer>
-  <script src="script.js"></script>
-  <script src="assets/js/app.js"></script>
-  <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
-  <script src="assets/js/metrics.js"></script>
-</body>
+    <footer aria-label="Project contribution">
+      <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
+    </footer>
+    <button
+      id="highlights-toggle"
+      type="button"
+      aria-label="Toggle highlights drawer"
+    >
+      Highlights
+    </button>
+    <aside id="highlights-drawer" aria-label="Highlights drawer">
+      <h2>Highlights</h2>
+      <ul id="highlights-list"></ul>
+    </aside>
+    <script src="script.js"></script>
+    <script src="assets/js/app.js"></script>
+    <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
+    <script src="assets/js/metrics.js"></script>
+  </body>
 </html>
-

--- a/layout.html
+++ b/layout.html
@@ -1,40 +1,74 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Cyber Security Dictionary</title>
-  <link rel="stylesheet" href="styles.css">
-  <meta property="og:title" content="Cyber Security Dictionary">
-  <meta property="og:description" content="An interactive dictionary for cyber security terms.">
-  <meta property="og:type" content="website">
-  <meta property="og:url" content="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/">
-  <meta property="og:image" content="https://github.com/Alex-Unnippillil/CyberSecuirtyDictionary/assets/24538548/c5a54c56-babb-485d-b01c-4fdfb186325b">
-  <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Cyber Security Dictionary">
-  <meta name="twitter:description" content="An interactive dictionary for cyber security terms.">
-  <meta name="twitter:url" content="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/">
-  <meta name="twitter:image" content="https://github.com/Alex-Unnippillil/CyberSecuirtyDictionary/assets/24538548/c5a54c56-babb-485d-b01c-4fdfb186325b">
-</head>
-<body>
-  <main class="container">
-    <h1>Cyber Security Dictionary</h1>
-    <div id="definition-container" style="display: none;"></div>
-    <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
-    <input type="text" id="search" placeholder="Search...">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Cyber Security Dictionary</title>
+    <link rel="stylesheet" href="styles.css" />
+    <meta property="og:title" content="Cyber Security Dictionary" />
+    <meta
+      property="og:description"
+      content="An interactive dictionary for cyber security terms."
+    />
+    <meta property="og:type" content="website" />
+    <meta
+      property="og:url"
+      content="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/"
+    />
+    <meta
+      property="og:image"
+      content="https://github.com/Alex-Unnippillil/CyberSecuirtyDictionary/assets/24538548/c5a54c56-babb-485d-b01c-4fdfb186325b"
+    />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Cyber Security Dictionary" />
+    <meta
+      name="twitter:description"
+      content="An interactive dictionary for cyber security terms."
+    />
+    <meta
+      name="twitter:url"
+      content="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/"
+    />
+    <meta
+      name="twitter:image"
+      content="https://github.com/Alex-Unnippillil/CyberSecuirtyDictionary/assets/24538548/c5a54c56-babb-485d-b01c-4fdfb186325b"
+    />
+  </head>
+  <body>
+    <main class="container">
+      <h1>Cyber Security Dictionary</h1>
+      <div id="definition-container" style="display: none"></div>
+      <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
+      <input type="text" id="search" placeholder="Search..." />
 
-    <button id="random-term" aria-label="Show random term">Random Term</button>
+      <button id="random-term" aria-label="Show random term">
+        Random Term
+      </button>
 
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
-    <input type="checkbox" id="show-favorites" aria-label="Show favorites">
-    <label for="show-favorites">Show Favorites</label>
+      <button id="dark-mode-toggle" aria-label="Toggle dark mode">
+        Toggle Dark Mode
+      </button>
+      <input type="checkbox" id="show-favorites" aria-label="Show favorites" />
+      <label for="show-favorites">Show Favorites</label>
 
-    <ul id="terms-list"></ul>
-  </main>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+      <ul id="terms-list"></ul>
+    </main>
+    <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
 
-  <script src="script.js"></script>
-  <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
-  <script src="assets/js/metrics.js"></script>
-</body>
+    <button
+      id="highlights-toggle"
+      type="button"
+      aria-label="Toggle highlights drawer"
+    >
+      Highlights
+    </button>
+    <aside id="highlights-drawer" aria-label="Highlights drawer">
+      <h2>Highlights</h2>
+      <ul id="highlights-list"></ul>
+    </aside>
+
+    <script src="script.js"></script>
+    <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
+    <script src="assets/js/metrics.js"></script>
+  </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -5,9 +5,17 @@ const randomButton = document.getElementById("random-term");
 const alphaNav = document.getElementById("alpha-nav");
 const darkModeToggle = document.getElementById("dark-mode-toggle");
 const showFavoritesToggle = document.getElementById("show-favorites");
-const favorites = new Set(JSON.parse(localStorage.getItem("favorites") || "[]"));
+const favorites = new Set(
+  JSON.parse(localStorage.getItem("favorites") || "[]"),
+);
 const siteUrl = "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/";
 const canonicalLink = document.getElementById("canonical-link");
+const highlightsToggle = document.getElementById("highlights-toggle");
+const highlightsDrawer = document.getElementById("highlights-drawer");
+const highlightsList = document.getElementById("highlights-list");
+const highlights = new Map(
+  JSON.parse(localStorage.getItem("highlights") || "[]"),
+);
 
 let currentLetterFilter = "All";
 let termsData = { terms: [] };
@@ -19,7 +27,16 @@ if (localStorage.getItem("darkMode") === "true") {
 if (darkModeToggle) {
   darkModeToggle.addEventListener("click", () => {
     document.body.classList.toggle("dark-mode");
-    localStorage.setItem("darkMode", document.body.classList.contains("dark-mode"));
+    localStorage.setItem(
+      "darkMode",
+      document.body.classList.contains("dark-mode"),
+    );
+  });
+}
+
+if (highlightsToggle && highlightsDrawer) {
+  highlightsToggle.addEventListener("click", () => {
+    highlightsDrawer.classList.toggle("open");
   });
 }
 
@@ -43,9 +60,11 @@ function loadTerms() {
       populateTermsList();
 
       if (window.location.hash) {
-        const termFromHash = decodeURIComponent(window.location.hash.substring(1));
+        const termFromHash = decodeURIComponent(
+          window.location.hash.substring(1),
+        );
         const matchedTerm = termsData.terms.find(
-          (t) => t.term.toLowerCase() === termFromHash.toLowerCase()
+          (t) => t.term.toLowerCase() === termFromHash.toLowerCase(),
         );
         if (matchedTerm) {
           displayDefinition(matchedTerm);
@@ -56,7 +75,7 @@ function loadTerms() {
       console.error("Detailed error fetching data:", error);
       definitionContainer.style.display = "block";
       definitionContainer.innerHTML =
-        '<p>Unable to load dictionary data. Please check your connection and try again.</p>' +
+        "<p>Unable to load dictionary data. Please check your connection and try again.</p>" +
         '<button id="retry-fetch">Retry</button>';
       const retryBtn = document.getElementById("retry-fetch");
       if (retryBtn) {
@@ -96,13 +115,75 @@ function toggleFavorite(term) {
   }
 }
 
+function addDoubleTapListener(element, callback) {
+  let lastTap = 0;
+  element.addEventListener("touchend", (e) => {
+    const currentTime = new Date().getTime();
+    const tapLength = currentTime - lastTap;
+    if (tapLength > 0 && tapLength < 300) {
+      e.preventDefault();
+      callback(e);
+    }
+    lastTap = currentTime;
+  });
+  element.addEventListener("dblclick", callback);
+}
+
+function attachHighlightHandlers(paragraph, term, text) {
+  addDoubleTapListener(paragraph, () => toggleHighlight(term, text));
+}
+
+function toggleHighlight(term, text) {
+  if (highlights.has(term)) {
+    highlights.delete(term);
+  } else {
+    highlights.set(term, text);
+  }
+  try {
+    localStorage.setItem(
+      "highlights",
+      JSON.stringify(Array.from(highlights.entries())),
+    );
+  } catch (e) {
+    // Ignore storage errors
+  }
+  applyHighlightToTerm(term);
+  updateHighlightsDrawer();
+}
+
+function applyHighlightToTerm(term) {
+  const escaped = CSS && CSS.escape ? CSS.escape(term) : term;
+  document.querySelectorAll(`p[data-term="${escaped}"]`).forEach((p) => {
+    p.classList.toggle("highlight", highlights.has(term));
+  });
+}
+
+function updateHighlightsDrawer() {
+  if (!highlightsList) return;
+  highlightsList.innerHTML = "";
+  highlights.forEach((text, term) => {
+    const li = document.createElement("li");
+    li.textContent = `${term}: ${text}`;
+    highlightsList.appendChild(li);
+  });
+}
+
+function applyStoredHighlights() {
+  highlights.forEach((_, term) => applyHighlightToTerm(term));
+  updateHighlightsDrawer();
+}
+
 function highlightActiveButton(button) {
-  alphaNav.querySelectorAll("button").forEach((btn) => btn.classList.remove("active"));
+  alphaNav
+    .querySelectorAll("button")
+    .forEach((btn) => btn.classList.remove("active"));
   button.classList.add("active");
 }
 
 function buildAlphaNav() {
-  const letters = Array.from(new Set(termsData.terms.map((t) => t.term.charAt(0).toUpperCase()))).sort();
+  const letters = Array.from(
+    new Set(termsData.terms.map((t) => t.term.charAt(0).toUpperCase())),
+  ).sort();
 
   const allButton = document.createElement("button");
   allButton.textContent = "All";
@@ -134,9 +215,13 @@ function populateTermsList() {
     .sort((a, b) => a.term.localeCompare(b.term))
     .forEach((item) => {
       const matchesSearch = item.term.toLowerCase().includes(searchValue);
-      const matchesFavorites = !showFavoritesToggle || !showFavoritesToggle.checked || favorites.has(item.term);
+      const matchesFavorites =
+        !showFavoritesToggle ||
+        !showFavoritesToggle.checked ||
+        favorites.has(item.term);
       const matchesLetter =
-        currentLetterFilter === "All" || item.term.charAt(0).toUpperCase() === currentLetterFilter;
+        currentLetterFilter === "All" ||
+        item.term.charAt(0).toUpperCase() === currentLetterFilter;
       if (matchesSearch && matchesFavorites && matchesLetter) {
         const termDiv = document.createElement("div");
         termDiv.classList.add("dictionary-item");
@@ -169,6 +254,8 @@ function populateTermsList() {
 
         const definitionPara = document.createElement("p");
         definitionPara.textContent = item.definition;
+        definitionPara.dataset.term = item.term;
+        attachHighlightHandlers(definitionPara, item.term, item.definition);
         termDiv.appendChild(definitionPara);
 
         termDiv.addEventListener("click", () => {
@@ -178,16 +265,20 @@ function populateTermsList() {
         termsList.appendChild(termDiv);
       }
     });
+  applyStoredHighlights();
 }
 
 function displayDefinition(term) {
   definitionContainer.style.display = "block";
-  definitionContainer.innerHTML = `<h3>${term.term}</h3><p>${term.definition}</p>`;
+  definitionContainer.innerHTML = `<h3>${term.term}</h3><p data-term="${term.term}">${term.definition}</p>`;
+  const definitionPara = definitionContainer.querySelector("p");
+  attachHighlightHandlers(definitionPara, term.term, term.definition);
+  applyHighlightToTerm(term.term);
   window.location.hash = encodeURIComponent(term.term);
   if (canonicalLink) {
     canonicalLink.setAttribute(
       "href",
-      `${siteUrl}#${encodeURIComponent(term.term)}`
+      `${siteUrl}#${encodeURIComponent(term.term)}`,
     );
   }
 }
@@ -195,19 +286,27 @@ function displayDefinition(term) {
 function clearDefinition() {
   definitionContainer.style.display = "none";
   definitionContainer.innerHTML = "";
-  history.replaceState(null, "", window.location.pathname + window.location.search);
+  history.replaceState(
+    null,
+    "",
+    window.location.pathname + window.location.search,
+  );
   if (canonicalLink) {
     canonicalLink.setAttribute("href", siteUrl);
   }
 }
 
 function showRandomTerm() {
-  const randomTerm = termsData.terms[Math.floor(Math.random() * termsData.terms.length)];
+  const randomTerm =
+    termsData.terms[Math.floor(Math.random() * termsData.terms.length)];
   displayDefinition(randomTerm);
 
   const today = new Date().toDateString();
   try {
-    localStorage.setItem("lastRandomTerm", JSON.stringify({ date: today, term: randomTerm }));
+    localStorage.setItem(
+      "lastRandomTerm",
+      JSON.stringify({ date: today, term: randomTerm }),
+    );
   } catch (e) {
     // Ignore storage errors
   }
@@ -249,8 +348,7 @@ window.addEventListener("scroll", () => {
   scrollBtn.style.display = window.scrollY > 200 ? "block" : "none";
 });
 scrollBtn.addEventListener("click", () =>
-  window.scrollTo({ top: 0, behavior: "smooth" })
+  window.scrollTo({ top: 0, behavior: "smooth" }),
 );
 
 definitionContainer.addEventListener("click", clearDefinition);
-

--- a/styles.css
+++ b/styles.css
@@ -25,7 +25,7 @@ body {
 
 h1 {
   text-align: center;
-  font-family: 'Cinzel', serif;
+  font-family: "Cinzel", serif;
   font-weight: 700;
   font-size: 48px;
   margin-bottom: 20px;
@@ -64,6 +64,68 @@ mark {
 body.dark-mode mark {
   background-color: #ffeb3b;
   color: #000;
+}
+
+.highlight {
+  background-color: yellow;
+}
+
+body.dark-mode .highlight {
+  background-color: #ffeb3b;
+  color: #000;
+}
+
+#highlights-drawer {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: 250px;
+  height: 100%;
+  background-color: #f2f2f2;
+  box-shadow: -2px 0 5px rgba(0, 0, 0, 0.1);
+  transform: translateX(100%);
+  transition: transform 0.3s ease;
+  overflow-y: auto;
+  z-index: 1000;
+}
+
+#highlights-drawer.open {
+  transform: translateX(0);
+}
+
+#highlights-drawer h2 {
+  margin: 0;
+  padding: 10px;
+}
+
+#highlights-list {
+  list-style: none;
+  margin: 0;
+  padding: 0 10px 10px;
+}
+
+#highlights-toggle {
+  position: fixed;
+  top: 50%;
+  right: 0;
+  transform: translateY(-50%);
+  background-color: #007bff;
+  color: #fff;
+  border: none;
+  border-radius: 4px 0 0 4px;
+  padding: 10px;
+  cursor: pointer;
+  z-index: 1001;
+}
+
+body.dark-mode #highlights-drawer {
+  background-color: #1e1e1e;
+  box-shadow: -2px 0 5px rgba(255, 255, 255, 0.1);
+}
+
+body.dark-mode #highlights-toggle {
+  background-color: #333;
+  color: #fff;
 }
 
 .dictionary-item {
@@ -110,7 +172,6 @@ body.dark-mode mark {
   box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
   min-height: 44px;
 }
-
 
 /* Controls styling */
 #random-term {
@@ -206,7 +267,9 @@ label {
   border-radius: 4px;
   padding: 10px;
   cursor: pointer;
-  transition: background-color 0.2s, color 0.2s;
+  transition:
+    background-color 0.2s,
+    color 0.2s;
   min-width: 44px;
   min-height: 44px;
 }


### PR DESCRIPTION
## Summary
- Allow double-tap or double-click on definition paragraphs to toggle highlight
- Add a highlights drawer that lists all highlighted definitions
- Persist highlights in localStorage and sync across dictionary views

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6085801588328969f9920126fd475