### PR TITLE
feat: add image annotation tool

### DIFF
--- a/annotator.html
+++ b/annotator.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Image Annotator</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <h1>Image Annotator</h1>
+  <div>
+    <input type="file" id="imageLoader" accept="image/*">
+    <button id="arrowTool" type="button">Arrow</button>
+    <button id="rectTool" type="button">Box</button>
+    <button id="textTool" type="button">Text</button>
+    <button id="saveCanvas" type="button">Save</button>
+    <button id="loadCanvas" type="button">Load</button>
+    <button id="exportPng" type="button">Export PNG</button>
+  </div>
+  <canvas id="annotator-canvas" class="canvas-border" width="800" height="600"></canvas>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/fabric.js/5.3.0/fabric.min.js" integrity="sha512-AUt0jH0TADaBrZEcD3xKhsR4HIX66vepQP9enZ5bY3bT5iAG2wE8xmPKzW0fvkYlEYwH14r2raXIiQunlslqCQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script src="annotator.js"></script>
+</body>
+</html>

--- a/annotator.js
+++ b/annotator.js
@@ -1,0 +1,146 @@
+const canvas = new fabric.Canvas("annotator-canvas");
+let currentTool = null;
+let drawingObject = null;
+let startX, startY;
+
+// Image loading
+const imageLoader = document.getElementById("imageLoader");
+imageLoader.addEventListener("change", handleImage, false);
+function handleImage(e) {
+  const reader = new FileReader();
+  reader.onload = function (evt) {
+    fabric.Image.fromURL(evt.target.result, function (img) {
+      canvas.setWidth(img.width);
+      canvas.setHeight(img.height);
+      canvas.setBackgroundImage(img, canvas.renderAll.bind(canvas));
+    });
+  };
+  reader.readAsDataURL(e.target.files[0]);
+}
+
+// Tool buttons
+const arrowBtn = document.getElementById("arrowTool");
+const rectBtn = document.getElementById("rectTool");
+const textBtn = document.getElementById("textTool");
+arrowBtn.onclick = () => (currentTool = "arrow");
+rectBtn.onclick = () => (currentTool = "rect");
+textBtn.onclick = () => (currentTool = "text");
+
+canvas.on("mouse:down", function (opt) {
+  const pointer = canvas.getPointer(opt.e);
+  startX = pointer.x;
+  startY = pointer.y;
+  if (currentTool === "rect") {
+    drawingObject = new fabric.Rect({
+      left: startX,
+      top: startY,
+      width: 0,
+      height: 0,
+      fill: "rgba(0,0,0,0)",
+      stroke: "red",
+      strokeWidth: 2,
+    });
+    canvas.add(drawingObject);
+  } else if (currentTool === "arrow") {
+    const points = [startX, startY, startX, startY];
+    drawingObject = new fabric.Line(points, {
+      strokeWidth: 2,
+      stroke: "blue",
+    });
+    canvas.add(drawingObject);
+  } else if (currentTool === "text") {
+    const text = new fabric.IText("Text", {
+      left: startX,
+      top: startY,
+      fill: "green",
+    });
+    canvas.add(text).setActiveObject(text);
+    currentTool = null;
+  }
+});
+
+canvas.on("mouse:move", function (opt) {
+  if (!drawingObject) return;
+  const pointer = canvas.getPointer(opt.e);
+  if (currentTool === "rect") {
+    const width = pointer.x - startX;
+    const height = pointer.y - startY;
+    drawingObject.set({
+      width: width,
+      height: height,
+    });
+    drawingObject.setCoords();
+    canvas.renderAll();
+  } else if (currentTool === "arrow") {
+    drawingObject.set({ x2: pointer.x, y2: pointer.y });
+    canvas.renderAll();
+  }
+});
+
+canvas.on("mouse:up", function (opt) {
+  if (currentTool === "arrow" && drawingObject) {
+    const x1 = drawingObject.x1;
+    const y1 = drawingObject.y1;
+    const x2 = drawingObject.x2;
+    const y2 = drawingObject.y2;
+    const angle = (Math.atan2(y2 - y1, x2 - x1) * 180) / Math.PI;
+    const triangle = new fabric.Triangle({
+      left: x2,
+      top: y2,
+      originX: "center",
+      originY: "center",
+      width: 10,
+      height: 15,
+      angle: angle + 90,
+      fill: "blue",
+    });
+    const group = new fabric.Group([drawingObject, triangle], {
+      selectable: true,
+    });
+    canvas.remove(drawingObject);
+    canvas.add(group);
+  }
+  drawingObject = null;
+  currentTool = null;
+});
+
+// IndexedDB helper
+function openDb(callback) {
+  const request = indexedDB.open("annotation-db", 1);
+  request.onupgradeneeded = function (e) {
+    const db = e.target.result;
+    db.createObjectStore("canvases");
+  };
+  request.onsuccess = function (e) {
+    callback(e.target.result);
+  };
+}
+
+document.getElementById("saveCanvas").onclick = function () {
+  openDb(function (db) {
+    const tx = db.transaction("canvases", "readwrite");
+    tx.objectStore("canvases").put(canvas.toJSON(), "last");
+  });
+};
+
+document.getElementById("loadCanvas").onclick = function () {
+  openDb(function (db) {
+    const tx = db.transaction("canvases");
+    const req = tx.objectStore("canvases").get("last");
+    req.onsuccess = function () {
+      if (req.result) {
+        canvas.loadFromJSON(req.result, canvas.renderAll.bind(canvas));
+      }
+    };
+  });
+};
+
+document.getElementById("exportPng").onclick = function () {
+  const dataURL = canvas.toDataURL({ format: "png" });
+  const link = document.createElement("a");
+  link.href = dataURL;
+  link.download = "annotation.png";
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+};

--- a/styles.css
+++ b/styles.css
@@ -25,7 +25,7 @@ body {
 
 h1 {
   text-align: center;
-  font-family: 'Cinzel', serif;
+  font-family: "Cinzel", serif;
   font-weight: 700;
   font-size: 48px;
   margin-bottom: 20px;
@@ -110,7 +110,6 @@ body.dark-mode mark {
   box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
   min-height: 44px;
 }
-
 
 /* Controls styling */
 #random-term {
@@ -206,7 +205,9 @@ label {
   border-radius: 4px;
   padding: 10px;
   cursor: pointer;
-  transition: background-color 0.2s, color 0.2s;
+  transition:
+    background-color 0.2s,
+    color 0.2s;
   min-width: 44px;
   min-height: 44px;
 }
@@ -346,4 +347,8 @@ body.dark-mode #alpha-nav button.active {
   #alpha-nav button {
     font-size: 14px;
   }
+}
+
+.canvas-border {
+  border: 1px solid #ccc;
 }


### PR DESCRIPTION
## Summary
- add standalone image annotator using Fabric.js
- allow drawing arrows, boxes, and text with editing support
- persist annotations in IndexedDB and export annotated images to PNG

## Testing
- `npx html-validate annotator.html`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b60858b1dc8328baa2bf464ff2ceb9