### PR TITLE
feat: add snapshot management

### DIFF
--- a/assets/js/snapshots.js
+++ b/assets/js/snapshots.js
@@ -1,0 +1,168 @@
+// Snapshot management for dictionary UI
+(function () {
+  const snapshotNameInput = document.getElementById("snapshot-name");
+  const saveSnapshotBtn = document.getElementById("save-snapshot");
+  const snapshotList = document.getElementById("snapshot-list");
+  const importInput = document.getElementById("import-snapshot");
+
+  if (!snapshotNameInput || !saveSnapshotBtn || !snapshotList) {
+    return;
+  }
+
+  // IndexedDB setup
+  const dbPromise = new Promise((resolve, reject) => {
+    const request = indexedDB.open("dictionarySnapshots", 1);
+    request.onupgradeneeded = () => {
+      request.result.createObjectStore("snapshots", {
+        keyPath: "id",
+        autoIncrement: true,
+      });
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+
+  function captureSnapshot() {
+    return {
+      searchValue: searchInput.value,
+      currentLetterFilter,
+      showFavorites: showFavoritesToggle ? showFavoritesToggle.checked : false,
+      darkMode: document.body.classList.contains("dark-mode"),
+      openTerm:
+        definitionContainer.style.display === "block"
+          ? definitionContainer.querySelector("h3")?.textContent || null
+          : null,
+    };
+  }
+
+  function applySnapshot(data) {
+    if (!data) return;
+    document.body.classList.toggle("dark-mode", !!data.darkMode);
+    searchInput.value = data.searchValue || "";
+    currentLetterFilter = data.currentLetterFilter || "All";
+    if (showFavoritesToggle) {
+      showFavoritesToggle.checked = !!data.showFavorites;
+    }
+    populateTermsList();
+    if (data.openTerm) {
+      const matched = termsData.terms.find((t) => t.term === data.openTerm);
+      if (matched) {
+        displayDefinition(matched);
+      }
+    } else {
+      clearDefinition();
+    }
+  }
+
+  async function saveSnapshotToDB(snapshot) {
+    const db = await dbPromise;
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction("snapshots", "readwrite");
+      tx.objectStore("snapshots").add(snapshot);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+  }
+
+  async function updateSnapshotInDB(snapshot) {
+    const db = await dbPromise;
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction("snapshots", "readwrite");
+      tx.objectStore("snapshots").put(snapshot);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+  }
+
+  async function deleteSnapshotFromDB(id) {
+    const db = await dbPromise;
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction("snapshots", "readwrite");
+      tx.objectStore("snapshots").delete(id);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+  }
+
+  async function getAllSnapshots() {
+    const db = await dbPromise;
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction("snapshots", "readonly");
+      const req = tx.objectStore("snapshots").getAll();
+      req.onsuccess = () => resolve(req.result || []);
+      req.onerror = () => reject(req.error);
+    });
+  }
+
+  function exportSnapshot(snapshot) {
+    const dataStr = JSON.stringify(snapshot.data);
+    const blob = new Blob([dataStr], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `${snapshot.name || "snapshot"}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  async function renderSnapshots() {
+    const snapshots = await getAllSnapshots();
+    snapshotList.innerHTML = "";
+    snapshots.forEach((snap) => {
+      const li = document.createElement("li");
+      const nameInput = document.createElement("input");
+      nameInput.value = snap.name;
+      nameInput.addEventListener("change", async () => {
+        snap.name = nameInput.value.trim();
+        await updateSnapshotInDB(snap);
+      });
+
+      const restoreBtn = document.createElement("button");
+      restoreBtn.textContent = "Restore";
+      restoreBtn.addEventListener("click", () => applySnapshot(snap.data));
+
+      const exportBtn = document.createElement("button");
+      exportBtn.textContent = "Export";
+      exportBtn.addEventListener("click", () => exportSnapshot(snap));
+
+      const deleteBtn = document.createElement("button");
+      deleteBtn.textContent = "Delete";
+      deleteBtn.addEventListener("click", async () => {
+        await deleteSnapshotFromDB(snap.id);
+        renderSnapshots();
+      });
+
+      li.append(nameInput, restoreBtn, exportBtn, deleteBtn);
+      snapshotList.appendChild(li);
+    });
+  }
+
+  saveSnapshotBtn.addEventListener("click", async () => {
+    const name = snapshotNameInput.value.trim() || "Snapshot";
+    const snapshot = { name, data: captureSnapshot() };
+    await saveSnapshotToDB(snapshot);
+    snapshotNameInput.value = "";
+    renderSnapshots();
+  });
+
+  if (importInput) {
+    importInput.addEventListener("change", async (e) => {
+      const file = e.target.files[0];
+      if (!file) return;
+      try {
+        const text = await file.text();
+        const data = JSON.parse(text);
+        applySnapshot(data);
+        const name = file.name.replace(/\.json$/, "");
+        await saveSnapshotToDB({ name, data });
+        renderSnapshots();
+      } catch (err) {
+        console.error("Failed to import snapshot", err);
+      } finally {
+        importInput.value = "";
+      }
+    });
+  }
+
+  document.addEventListener("DOMContentLoaded", renderSnapshots);
+})();

--- a/index.html
+++ b/index.html
@@ -1,41 +1,68 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Cyber Security Dictionary</title>
-  <link rel="stylesheet" href="styles.css">
-  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet">
-  <link rel="canonical" id="canonical-link" href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/">
-</head>
-<body>
-  <main class="container">
-    <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav" aria-label="Site links"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
-    <div id="definition-container" style="display: none;"></div>
-    <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
-    <input type="text" id="search" placeholder="Search...">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cyber Security Dictionary</title>
+    <link rel="stylesheet" href="styles.css">
+    <link
+      href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap"
+      rel="stylesheet"
+    >
+    <link
+      rel="canonical"
+      id="canonical-link"
+      href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/"
+    >
+  </head>
+  <body>
+    <main class="container">
+      <h1>Cyber Security Dictionary</h1>
+      <nav class="site-nav" aria-label="Site links">
+        <a href="templates/guidelines.html">Definition Guidelines</a>
+      </nav>
+      <div id="definition-container" style="display: none"></div>
+      <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
+      <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" type="button" aria-label="Show random term">Random Term</button>
+      <button id="random-term" type="button" aria-label="Show random term">
+        Random Term
+      </button>
 
-    <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">Toggle Dark Mode</button>
-    <input type="checkbox" id="show-favorites" aria-label="Show favorites">
-    <label for="show-favorites">Show Favorites</label>
+      <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">
+        Toggle Dark Mode
+      </button>
+      <input type="checkbox" id="show-favorites" aria-label="Show favorites">
+      <label for="show-favorites">Show Favorites</label>
 
-    <ul id="terms-list"></ul>
-  </main>
-  <footer class="container" aria-label="Contribute">
-    <p><a href="templates/contribute.html">Contribute</a></p>
-  </footer>
-  <button id="scrollToTopBtn" type="button" aria-label="Scroll to top">↑</button>
+      <ul id="terms-list"></ul>
 
-  <footer aria-label="Project contribution">
-    <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
-  </footer>
-  <script src="script.js"></script>
-  <script src="assets/js/app.js"></script>
-  <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
-  <script src="assets/js/metrics.js"></script>
-</body>
+      <section id="snapshot-section" aria-label="Snapshots">
+        <h2>Snapshots</h2>
+        <label for="snapshot-name">Snapshot Name</label>
+        <input id="snapshot-name" type="text">
+        <button id="save-snapshot" type="button" aria-label="Save snapshot">
+          Save Snapshot
+        </button>
+        <label for="import-snapshot">Import Snapshot</label>
+        <input id="import-snapshot" type="file" accept="application/json">
+        <ul id="snapshot-list"></ul>
+      </section>
+    </main>
+    <footer class="container" aria-label="Contribute">
+      <p><a href="templates/contribute.html">Contribute</a></p>
+    </footer>
+    <button id="scrollToTopBtn" type="button" aria-label="Scroll to top">
+      ↑
+    </button>
+
+    <footer aria-label="Project contribution">
+      <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
+    </footer>
+    <script src="script.js"></script>
+    <script src="assets/js/snapshots.js"></script>
+    <script src="assets/js/app.js"></script>
+    <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
+    <script src="assets/js/metrics.js"></script>
+  </body>
 </html>
-


### PR DESCRIPTION
## Summary
- allow users to capture and restore dictionary UI state
- persist named snapshots in IndexedDB
- add import/export controls for managing snapshot JSON

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6085c62348328ace9ef6c3bcae6d5