### PR TITLE
Add lite mode toggle to disable heavy media

### DIFF
--- a/assets/js/performance.js
+++ b/assets/js/performance.js
@@ -1,0 +1,32 @@
+(function () {
+  const STORAGE_KEY = 'liteMode';
+  const toggle = document.getElementById('lite-mode-toggle');
+  const badge = document.getElementById('lite-mode-badge');
+
+  function apply(on) {
+    document.body.classList.toggle('lite-mode', on);
+    if (badge) {
+      badge.style.display = on ? 'block' : 'none';
+    }
+    try {
+      localStorage.setItem(STORAGE_KEY, on);
+    } catch (e) {
+      /* ignore storage errors */
+    }
+  }
+
+  let enabled = false;
+  try {
+    enabled = localStorage.getItem(STORAGE_KEY) === 'true';
+  } catch (e) {
+    enabled = false;
+  }
+  apply(enabled);
+
+  if (toggle) {
+    toggle.addEventListener('click', () => {
+      enabled = !document.body.classList.contains('lite-mode');
+      apply(enabled);
+    });
+  }
+})();

--- a/diagnostics.html
+++ b/diagnostics.html
@@ -15,7 +15,10 @@
       </thead>
       <tbody id="metrics-body"></tbody>
     </table>
+    <button id="lite-mode-toggle" type="button" aria-label="Toggle lite mode">Toggle Lite Mode</button>
   </main>
+  <div id="lite-mode-badge" class="badge" aria-live="polite">Lite Mode</div>
+  <script src="assets/js/performance.js"></script>
   <script src="assets/js/diagnostics.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
     <button id="random-term" type="button" aria-label="Show random term">Random Term</button>
 
     <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+    <button id="lite-mode-toggle" type="button" aria-label="Toggle lite mode">Toggle Lite Mode</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 
@@ -29,9 +30,12 @@
   </footer>
   <button id="scrollToTopBtn" type="button" aria-label="Scroll to top">↑</button>
 
+  <div id="lite-mode-badge" class="badge" aria-live="polite">Lite Mode</div>
+
   <footer aria-label="Project contribution">
     <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
   </footer>
+  <script src="assets/js/performance.js"></script>
   <script src="script.js"></script>
   <script src="assets/js/app.js"></script>
   <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>

--- a/search.html
+++ b/search.html
@@ -11,10 +11,13 @@
     <h1>Search</h1>
     <input id="search-box" type="text" placeholder="Search terms...">
     <div id="results"></div>
+    <button id="lite-mode-toggle" type="button" aria-label="Toggle lite mode">Toggle Lite Mode</button>
   </main>
+  <div id="lite-mode-badge" class="badge" aria-live="polite">Lite Mode</div>
   <script>
     window.__BASE_URL__ = window.__BASE_URL__ || '';
   </script>
+  <script src="assets/js/performance.js"></script>
   <script src="assets/js/search.js"></script>
   <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
   <script src="assets/js/metrics.js"></script>

--- a/styles.css
+++ b/styles.css
@@ -326,6 +326,32 @@ body.dark-mode #alpha-nav button.active {
   border-color: #007bff;
 }
 
+/* Lite mode styles */
+body.lite-mode *,
+body.lite-mode *::before,
+body.lite-mode *::after {
+  animation: none !important;
+  transition: none !important;
+}
+
+body.lite-mode img,
+body.lite-mode iframe,
+body.lite-mode .playground-preview {
+  display: none !important;
+}
+
+#lite-mode-badge {
+  position: fixed;
+  top: 10px;
+  right: 10px;
+  z-index: 1000;
+  display: none;
+}
+
+body.lite-mode #lite-mode-badge {
+  display: block;
+}
+
 @media (max-width: 480px) {
   h1 {
     font-size: 32px;


### PR DESCRIPTION
## Summary
- add Lite Mode toggle with persistent state and visible badge
- hide images, animations, and playground previews when Lite Mode is active
- include shared script across pages to toggle heavy features without reload

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6085be17c8328b13e0ce8a980e4ac