### PR TITLE
feat: remember scroll position

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,5 +1,74 @@
-if ('serviceWorker' in navigator) {
-  window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/sw.js');
-  });
-}
+(() => {
+  const SCROLL_KEY = "scroll-positions";
+  const VERSION_KEY = "content-version";
+
+  function storageKey() {
+    return `${location.pathname}${location.hash}`;
+  }
+
+  function save() {
+    try {
+      const key = storageKey();
+      const map = JSON.parse(localStorage.getItem(SCROLL_KEY) || "{}");
+      map[key] = window.scrollY;
+      localStorage.setItem(SCROLL_KEY, JSON.stringify(map));
+    } catch (e) {
+      // ignore storage errors
+    }
+  }
+
+  function restore() {
+    try {
+      const key = storageKey();
+      const map = JSON.parse(localStorage.getItem(SCROLL_KEY) || "{}");
+      const y = map[key];
+      if (typeof y === "number") {
+        window.scrollTo(0, y);
+      }
+    } catch (e) {
+      // ignore parse errors
+    }
+  }
+
+  function clear() {
+    try {
+      localStorage.removeItem(SCROLL_KEY);
+    } catch (e) {
+      // ignore storage errors
+    }
+  }
+
+  window.clearScrollPositions = clear;
+  window.checkContentVersion = function (data) {
+    try {
+      const newVersion = JSON.stringify(data).length.toString();
+      const oldVersion = localStorage.getItem(VERSION_KEY);
+      if (oldVersion !== newVersion) {
+        clear();
+        localStorage.setItem(VERSION_KEY, newVersion);
+      }
+    } catch (e) {
+      // ignore storage errors
+    }
+  };
+
+  let timeout;
+  window.addEventListener(
+    "scroll",
+    () => {
+      clearTimeout(timeout);
+      timeout = setTimeout(save, 100);
+    },
+    { passive: true },
+  );
+
+  window.addEventListener("beforeunload", save);
+  window.addEventListener("hashchange", restore);
+  document.addEventListener("DOMContentLoaded", restore);
+
+  if ("serviceWorker" in navigator) {
+    window.addEventListener("load", () => {
+      navigator.serviceWorker.register("/sw.js");
+    });
+  }
+})();

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -8,6 +8,9 @@
     fetch(`${baseUrl}/terms.json`)
       .then(r => r.ok ? r.json() : Promise.reject(r.statusText))
       .then(data => {
+        if (typeof checkContentVersion === 'function') {
+          checkContentVersion(data);
+        }
         // terms.json may either be an array or object with terms property
         terms = Array.isArray(data) ? data : (data.terms || []);
       })
@@ -19,6 +22,9 @@
   });
 
   function handleSearch(){
+    if (typeof clearScrollPositions === 'function') {
+      clearScrollPositions();
+    }
     const query = searchInput.value.trim().toLowerCase();
     resultsContainer.innerHTML = '';
     if(!query){

--- a/script.js
+++ b/script.js
@@ -36,6 +36,9 @@ function loadTerms() {
       return response.json();
     })
     .then((data) => {
+      if (typeof checkContentVersion === "function") {
+        checkContentVersion(data);
+      }
       termsData = data;
       removeDuplicateTermsAndDefinitions();
       termsData.terms.sort((a, b) => a.term.localeCompare(b.term));
@@ -128,6 +131,9 @@ function buildAlphaNav() {
 }
 
 function populateTermsList() {
+  if (typeof clearScrollPositions === "function") {
+    clearScrollPositions();
+  }
   termsList.innerHTML = "";
   const searchValue = searchInput.value.trim().toLowerCase();
   termsData.terms

--- a/search.html
+++ b/search.html
@@ -16,6 +16,7 @@
     window.__BASE_URL__ = window.__BASE_URL__ || '';
   </script>
   <script src="assets/js/search.js"></script>
+  <script src="assets/js/app.js"></script>
   <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
   <script src="assets/js/metrics.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- persist scroll positions per route and anchor in localStorage
- restore saved positions on load and hash navigation
- clear stored positions when content or search results change

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b608563f948328850cf10445417829