### PR TITLE
feat: add lightbox with themed captions and navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,9 @@
   <main class="container">
     <h1>Cyber Security Dictionary</h1>
     <nav class="site-nav" aria-label="Site links"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
+    <figure data-lightbox data-caption="Cyber security concept" data-source="https://example.com/cyber">
+      <img src="https://via.placeholder.com/600x400?text=Cybersecurity" alt="Illustration of cyber security">
+    </figure>
     <div id="definition-container" style="display: none;"></div>
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">
@@ -33,6 +36,7 @@
     <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
   </footer>
   <script src="script.js"></script>
+  <script src="lightbox.js"></script>
   <script src="assets/js/app.js"></script>
   <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
   <script src="assets/js/metrics.js"></script>

--- a/layout.html
+++ b/layout.html
@@ -34,6 +34,7 @@
   <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
 
   <script src="script.js"></script>
+  <script src="lightbox.js"></script>
   <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
   <script src="assets/js/metrics.js"></script>
 </body>

--- a/lightbox.js
+++ b/lightbox.js
@@ -1,0 +1,103 @@
+// Simple lightbox component with keyboard and swipe navigation
+(function () {
+  document.addEventListener('DOMContentLoaded', initLightbox);
+
+  function initLightbox() {
+    const figures = Array.from(document.querySelectorAll('figure[data-lightbox]'));
+    if (!figures.length) return;
+
+    const images = figures.map((fig, idx) => {
+      const img = fig.querySelector('img');
+      const captionText = fig.dataset.caption || fig.querySelector('figcaption')?.textContent || '';
+      const source = fig.dataset.source || '';
+      let figcaption = fig.querySelector('figcaption');
+      if (!figcaption) {
+        figcaption = document.createElement('figcaption');
+        fig.appendChild(figcaption);
+      }
+      figcaption.textContent = `Figure ${idx + 1}: ${captionText}${source ? ` (Source: ${source})` : ''}`;
+      fig.dataset.index = idx;
+      fig.addEventListener('click', () => openLightbox(idx));
+      const preloadImg = new Image();
+      preloadImg.src = img.src;
+      return { src: img.src, caption: figcaption.textContent };
+    });
+
+    let currentIndex = 0;
+    const overlay = buildOverlay();
+    const overlayImg = overlay.querySelector('.lightbox-image');
+    const captionEl = overlay.querySelector('.lightbox-caption');
+
+    function buildOverlay() {
+      const overlay = document.createElement('div');
+      overlay.className = 'lightbox';
+      overlay.innerHTML = `
+        <button class="lightbox-close" aria-label="Close">&times;</button>
+        <button class="lightbox-prev" aria-label="Previous">&#10094;</button>
+        <img class="lightbox-image" alt="">
+        <button class="lightbox-next" aria-label="Next">&#10095;</button>
+        <p class="lightbox-caption"></p>`;
+      document.body.appendChild(overlay);
+      overlay.querySelector('.lightbox-close').addEventListener('click', close);
+      overlay.addEventListener('click', (e) => {
+        if (e.target === overlay) close();
+      });
+      overlay.querySelector('.lightbox-prev').addEventListener('click', showPrev);
+      overlay.querySelector('.lightbox-next').addEventListener('click', showNext);
+      // Keyboard navigation
+      document.addEventListener('keydown', (e) => {
+        if (!overlay.classList.contains('visible')) return;
+        if (e.key === 'Escape') close();
+        if (e.key === 'ArrowRight') showNext();
+        if (e.key === 'ArrowLeft') showPrev();
+      });
+      // Swipe navigation
+      let startX = 0;
+      overlay.addEventListener('touchstart', (e) => {
+        startX = e.changedTouches[0].screenX;
+      });
+      overlay.addEventListener('touchend', (e) => {
+        const diff = e.changedTouches[0].screenX - startX;
+        if (diff > 50) showPrev();
+        if (diff < -50) showNext();
+      });
+      return overlay;
+    }
+
+    function openLightbox(index) {
+      currentIndex = index;
+      updateLightbox();
+      overlay.classList.add('visible');
+      preload(index - 1);
+      preload(index + 1);
+    }
+
+    function close() {
+      overlay.classList.remove('visible');
+    }
+
+    function showNext() {
+      currentIndex = (currentIndex + 1) % images.length;
+      updateLightbox();
+      preload(currentIndex + 1);
+    }
+
+    function showPrev() {
+      currentIndex = (currentIndex - 1 + images.length) % images.length;
+      updateLightbox();
+      preload(currentIndex - 1);
+    }
+
+    function updateLightbox() {
+      overlayImg.src = images[currentIndex].src;
+      captionEl.textContent = images[currentIndex].caption;
+    }
+
+    function preload(index) {
+      if (index < 0 || index >= images.length) return;
+      const img = new Image();
+      img.src = images[index].src;
+    }
+  }
+})();
+

--- a/styles.css
+++ b/styles.css
@@ -326,6 +326,73 @@ body.dark-mode #alpha-nav button.active {
   border-color: #007bff;
 }
 
+.lightbox {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  background: rgba(255, 255, 255, 0.95);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+  z-index: 1000;
+  color: #000;
+}
+
+.lightbox.visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.lightbox-image {
+  max-width: 90%;
+  max-height: 80%;
+}
+
+.lightbox-caption {
+  margin-top: 10px;
+}
+
+.lightbox-prev,
+.lightbox-next,
+.lightbox-close {
+  position: absolute;
+  background: none;
+  border: none;
+  font-size: 2rem;
+  cursor: pointer;
+  color: #000;
+}
+
+.lightbox-prev {
+  left: 10px;
+}
+
+.lightbox-next {
+  right: 10px;
+}
+
+.lightbox-close {
+  top: 10px;
+  right: 10px;
+}
+
+body.dark-mode .lightbox {
+  background: rgba(0, 0, 0, 0.9);
+  color: #fff;
+}
+
+body.dark-mode .lightbox-prev,
+body.dark-mode .lightbox-next,
+body.dark-mode .lightbox-close {
+  color: #fff;
+}
+
 @media (max-width: 480px) {
   h1 {
     font-size: 32px;


### PR DESCRIPTION
## Summary
- add swipe and keyboard navigable lightbox
- show figure numbers and sources in captions
- preload images and support dark/light themes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6085dcb4c83288151ecd412d4e8ca