### PR TITLE
feat: add metadata update workflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,8 +19,11 @@
     <button id="random-term" type="button" aria-label="Show random term">Random Term</button>
 
     <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+    <button id="check-updates" type="button" aria-label="Check for updates">Check Updates</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
+
+    <div id="update-container" style="display: none;"></div>
 
     <ul id="terms-list"></ul>
   </main>

--- a/sw.js
+++ b/sw.js
@@ -1,10 +1,10 @@
-const CACHE_NAME = 'csd-cache-v1';
+const CACHE_NAME = 'csd-cache-v2';
 const URLS_TO_CACHE = [
   '/',
   '/index.html',
   '/styles.css',
   '/script.js',
-  '/data.json'
+  '/terms.json'
 ];
 
 self.addEventListener('install', event => {
@@ -24,6 +24,18 @@ self.addEventListener('activate', event => {
 });
 
 self.addEventListener('fetch', event => {
+  if (event.request.url.endsWith('/terms.json')) {
+    event.respondWith(
+      fetch(event.request)
+        .then(response => {
+          const clone = response.clone();
+          caches.open(CACHE_NAME).then(cache => cache.put(event.request, clone));
+          return response;
+        })
+        .catch(() => caches.match(event.request))
+    );
+    return;
+  }
   event.respondWith(
     caches.match(event.request).then(response =>
       response || fetch(event.request).catch(() => {


### PR DESCRIPTION
## Summary
- add UI button to check for dictionary term updates
- compare local terms with remote metadata and allow selective refresh
- cache terms and updates for offline usage via localStorage and service worker

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6085a4eac8328be965c64cea5da63