### PR TITLE
feat: add monospace reading mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
     <button id="random-term" type="button" aria-label="Show random term">Random Term</button>
 
     <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+    <button id="monospace-toggle" type="button" aria-label="Toggle monospace mode">Toggle Monospace</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 

--- a/layout.html
+++ b/layout.html
@@ -26,6 +26,7 @@
     <button id="random-term" aria-label="Show random term">Random Term</button>
 
     <button id="dark-mode-toggle" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+    <button id="monospace-toggle" aria-label="Toggle monospace mode">Toggle Monospace</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 

--- a/script.js
+++ b/script.js
@@ -4,6 +4,7 @@ const searchInput = document.getElementById("search");
 const randomButton = document.getElementById("random-term");
 const alphaNav = document.getElementById("alpha-nav");
 const darkModeToggle = document.getElementById("dark-mode-toggle");
+const monospaceToggle = document.getElementById("monospace-toggle");
 const showFavoritesToggle = document.getElementById("show-favorites");
 const favorites = new Set(JSON.parse(localStorage.getItem("favorites") || "[]"));
 const siteUrl = "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/";
@@ -16,10 +17,24 @@ if (localStorage.getItem("darkMode") === "true") {
   document.body.classList.add("dark-mode");
 }
 
+if (localStorage.getItem("monospaceMode") === "true") {
+  document.body.classList.add("monospace-mode");
+}
+
 if (darkModeToggle) {
   darkModeToggle.addEventListener("click", () => {
     document.body.classList.toggle("dark-mode");
     localStorage.setItem("darkMode", document.body.classList.contains("dark-mode"));
+  });
+}
+
+if (monospaceToggle) {
+  monospaceToggle.addEventListener("click", () => {
+    document.body.classList.toggle("monospace-mode");
+    localStorage.setItem(
+      "monospaceMode",
+      document.body.classList.contains("monospace-mode")
+    );
   });
 }
 

--- a/styles.css
+++ b/styles.css
@@ -13,6 +13,16 @@ body {
   overflow-x: hidden;
 }
 
+body.monospace-mode {
+  font-family: "Courier New", Courier, monospace;
+  line-height: 1.5;
+  letter-spacing: 0.05em;
+}
+
+body.monospace-mode .container {
+  max-width: 60ch;
+}
+
 .container {
   max-width: 800px;
   width: 100%;
@@ -145,6 +155,22 @@ body.dark-mode mark {
   background-color: #0056b3;
 }
 
+#monospace-toggle {
+  margin-top: 10px;
+  padding: 10px;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  background-color: #007bff;
+  color: #fff;
+  cursor: pointer;
+  min-width: 44px;
+  min-height: 44px;
+}
+
+#monospace-toggle:hover {
+  background-color: #0056b3;
+}
+
 label {
   margin-left: 10px;
   margin-top: 10px;
@@ -259,6 +285,12 @@ body.dark-mode #search {
 }
 
 body.dark-mode #dark-mode-toggle {
+  background-color: #333;
+  color: #fff;
+  border-color: #555;
+}
+
+body.dark-mode #monospace-toggle {
   background-color: #333;
   color: #fff;
   border-color: #555;


### PR DESCRIPTION
## Summary
- add toggle to switch to monospace reading mode with persistent preference
- narrow container width and adjust spacing for readability in monospace mode
- style monospace toggle for both light and dark themes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6086128a48328b93172db5cb394e2