### PR TITLE
feat: add focus line toggle synced to caret

### DIFF
--- a/assets/js/focus-line.js
+++ b/assets/js/focus-line.js
@@ -1,0 +1,73 @@
+(function () {
+  const toggle = document.getElementById('focus-line-toggle');
+  const reduceMotionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+  if (!toggle || reduceMotionQuery.matches) {
+    if (toggle) {
+      toggle.style.display = 'none';
+    }
+    return;
+  }
+
+  const line = document.createElement('div');
+  line.id = 'focus-line';
+  document.body.appendChild(line);
+
+  function isEnabled() {
+    return line.classList.contains('visible');
+  }
+
+  function updateLine() {
+    if (!isEnabled()) return;
+    const active = document.activeElement;
+    let top;
+    if (active && (active.tagName === 'INPUT' || active.tagName === 'TEXTAREA')) {
+      const rect = active.getBoundingClientRect();
+      top = rect.top + window.scrollY + rect.height / 2;
+    } else {
+      const sel = document.getSelection();
+      if (sel && sel.rangeCount > 0) {
+        const rect = sel.getRangeAt(0).getBoundingClientRect();
+        if (rect.top || rect.bottom) {
+          top = rect.top + window.scrollY;
+        }
+      }
+    }
+    if (top === undefined) {
+      top = window.scrollY + window.innerHeight / 2;
+    }
+    line.style.top = `${top}px`;
+  }
+
+  toggle.addEventListener('click', () => {
+    line.classList.toggle('visible');
+    const visible = isEnabled();
+    localStorage.setItem('focusLine', visible);
+    if (visible) {
+      updateLine();
+    }
+  });
+
+  if (localStorage.getItem('focusLine') === 'true') {
+    line.classList.add('visible');
+    updateLine();
+  }
+
+  document.addEventListener('selectionchange', updateLine);
+  window.addEventListener('scroll', updateLine);
+  window.addEventListener('keyup', updateLine);
+  window.addEventListener('click', updateLine);
+
+  reduceMotionQuery.addEventListener('change', (e) => {
+    if (e.matches) {
+      line.classList.remove('visible');
+      toggle.style.display = 'none';
+    } else {
+      toggle.style.display = '';
+      if (localStorage.getItem('focusLine') === 'true') {
+        line.classList.add('visible');
+        updateLine();
+      }
+    }
+  });
+})();

--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
     <button id="random-term" type="button" aria-label="Show random term">Random Term</button>
 
     <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">Toggle Dark Mode</button>
+    <button id="focus-line-toggle" type="button" aria-label="Toggle focus line">Toggle Focus Line</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
 
@@ -33,6 +34,7 @@
     <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
   </footer>
   <script src="script.js"></script>
+  <script src="assets/js/focus-line.js"></script>
   <script src="assets/js/app.js"></script>
   <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
   <script src="assets/js/metrics.js"></script>

--- a/search.html
+++ b/search.html
@@ -10,12 +10,14 @@
   <main class="container">
     <h1>Search</h1>
     <input id="search-box" type="text" placeholder="Search terms...">
+    <button id="focus-line-toggle" type="button" aria-label="Toggle focus line">Toggle Focus Line</button>
     <div id="results"></div>
   </main>
   <script>
     window.__BASE_URL__ = window.__BASE_URL__ || '';
   </script>
   <script src="assets/js/search.js"></script>
+  <script src="assets/js/focus-line.js"></script>
   <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
   <script src="assets/js/metrics.js"></script>
 </body>

--- a/styles.css
+++ b/styles.css
@@ -145,6 +145,22 @@ body.dark-mode mark {
   background-color: #0056b3;
 }
 
+#focus-line-toggle {
+  margin-top: 10px;
+  padding: 10px;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  background-color: #007bff;
+  color: #fff;
+  cursor: pointer;
+  min-width: 44px;
+  min-height: 44px;
+}
+
+#focus-line-toggle:hover {
+  background-color: #0056b3;
+}
+
 label {
   margin-left: 10px;
   margin-top: 10px;
@@ -242,6 +258,21 @@ label {
   background-color: #0056b3;
 }
 
+#focus-line {
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background-color: #ff0000;
+  pointer-events: none;
+  z-index: 1000;
+  display: none;
+}
+
+#focus-line.visible {
+  display: block;
+}
+
 /* Dark Mode styles */
 body.dark-mode {
   background-color: #121212;
@@ -259,6 +290,12 @@ body.dark-mode #search {
 }
 
 body.dark-mode #dark-mode-toggle {
+  background-color: #333;
+  color: #fff;
+  border-color: #555;
+}
+
+body.dark-mode #focus-line-toggle {
   background-color: #333;
   color: #fff;
   border-color: #555;
@@ -324,6 +361,13 @@ body.dark-mode #alpha-nav button:focus {
 body.dark-mode #alpha-nav button.active {
   background-color: #007bff;
   border-color: #007bff;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  #focus-line-toggle,
+  #focus-line {
+    display: none !important;
+  }
 }
 
 @media (max-width: 480px) {


### PR DESCRIPTION
## Summary
- add movable focus line that tracks caret or scroll
- quick-action button with preference persistence
- respect reduced-motion setting by hiding line and toggle

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b608627d0083289c05d13e64fb2c2e