### PR TITLE
Add sharing via Web Share Target with WebRTC fallback

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="styles.css">
   <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet">
   <link rel="canonical" id="canonical-link" href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/">
+  <link rel="manifest" href="manifest.json">
 </head>
 <body>
   <main class="container">
@@ -17,6 +18,8 @@
     <input type="text" id="search" placeholder="Search...">
 
     <button id="random-term" type="button" aria-label="Show random term">Random Term</button>
+
+    <button id="receive-webrtc" type="button" aria-label="Receive shared content">Receive via WebRTC</button>
 
     <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">Toggle Dark Mode</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,15 @@
+{
+  "name": "Cyber Security Dictionary",
+  "short_name": "SecDict",
+  "start_url": "/index.html",
+  "display": "standalone",
+  "share_target": {
+    "action": "/index.html?share-target",
+    "method": "GET",
+    "params": {
+      "title": "title",
+      "text": "text",
+      "url": "url"
+    }
+  }
+}

--- a/sw.js
+++ b/sw.js
@@ -1,10 +1,11 @@
-const CACHE_NAME = 'csd-cache-v1';
+const CACHE_NAME = 'csd-cache-v2';
 const URLS_TO_CACHE = [
   '/',
   '/index.html',
   '/styles.css',
   '/script.js',
-  '/data.json'
+  '/data.json',
+  '/manifest.json'
 ];
 
 self.addEventListener('install', event => {


### PR DESCRIPTION
## Summary
- enable PWA share target through new manifest and service worker caching
- allow sharing definitions via Web Share API with WebRTC peer-to-peer fallback
- add receiver interface and safer definition dismissal logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b60863def883288d3f29ef647d9a50