### PR TITLE
Add local rating widget for term difficulty

### DIFF
--- a/script.js
+++ b/script.js
@@ -96,6 +96,29 @@ function toggleFavorite(term) {
   }
 }
 
+function getRatings() {
+  try {
+    return JSON.parse(localStorage.getItem("ratings") || "{}");
+  } catch (e) {
+    return {};
+  }
+}
+
+function getRating(term) {
+  const ratings = getRatings();
+  return ratings[term] || 0;
+}
+
+function saveRating(term, value) {
+  const ratings = getRatings();
+  ratings[term] = value;
+  try {
+    localStorage.setItem("ratings", JSON.stringify(ratings));
+  } catch (e) {
+    // Ignore storage errors
+  }
+}
+
 function highlightActiveButton(button) {
   alphaNav.querySelectorAll("button").forEach((btn) => btn.classList.remove("active"));
   button.classList.add("active");
@@ -182,7 +205,13 @@ function populateTermsList() {
 
 function displayDefinition(term) {
   definitionContainer.style.display = "block";
-  definitionContainer.innerHTML = `<h3>${term.term}</h3><p>${term.definition}</p>`;
+  const currentRating = getRating(term.term);
+  const stars = Array.from({ length: 5 }, (_, i) => {
+    const value = i + 1;
+    const rated = value <= currentRating ? "rated" : "";
+    return `<span class="rating-star ${rated}" data-value="${value}" role="radio" aria-label="${value} out of 5">★</span>`;
+  }).join("");
+  definitionContainer.innerHTML = `<h3>${term.term}</h3><p>${term.definition}</p><div class="rating-widget" role="radiogroup" aria-label="Rate difficulty">${stars}</div>`;
   window.location.hash = encodeURIComponent(term.term);
   if (canonicalLink) {
     canonicalLink.setAttribute(
@@ -190,6 +219,18 @@ function displayDefinition(term) {
       `${siteUrl}#${encodeURIComponent(term.term)}`
     );
   }
+  const starElems = definitionContainer.querySelectorAll(".rating-star");
+  starElems.forEach((star) => {
+    star.addEventListener("click", (e) => {
+      e.stopPropagation();
+      const value = parseInt(star.getAttribute("data-value"), 10);
+      saveRating(term.term, value);
+      starElems.forEach((s) => {
+        const v = parseInt(s.getAttribute("data-value"), 10);
+        s.classList.toggle("rated", v <= value);
+      });
+    });
+  });
 }
 
 function clearDefinition() {
@@ -202,7 +243,13 @@ function clearDefinition() {
 }
 
 function showRandomTerm() {
-  const randomTerm = termsData.terms[Math.floor(Math.random() * termsData.terms.length)];
+  const ratings = getRatings();
+  let pool = termsData.terms.slice();
+  const maxRating = Math.max(...pool.map((t) => ratings[t.term] || 0));
+  if (maxRating > 0) {
+    pool = pool.filter((t) => (ratings[t.term] || 0) === maxRating);
+  }
+  const randomTerm = pool[Math.floor(Math.random() * pool.length)];
   displayDefinition(randomTerm);
 
   const today = new Date().toDateString();

--- a/styles.css
+++ b/styles.css
@@ -181,6 +181,29 @@ label {
   color: #ffd700;
 }
 
+/* Rating widget styles */
+.rating-widget {
+  margin-top: 10px;
+  display: flex;
+  gap: 5px;
+}
+
+.rating-star {
+  font-size: 20px;
+  color: #ccc;
+  cursor: pointer;
+  transition: color 0.2s;
+}
+
+.rating-star:hover,
+.rating-star:focus {
+  color: #999;
+}
+
+.rating-star.rated {
+  color: #ffd700;
+}
+
 /* Category badge styles */
 .badge {
   display: inline-block;
@@ -299,6 +322,19 @@ body.dark-mode .favorite-star {
 body.dark-mode .favorite-star:hover,
 body.dark-mode .favorite-star:focus {
   color: #bbb;
+}
+
+body.dark-mode .rating-star {
+  color: #666;
+}
+
+body.dark-mode .rating-star:hover,
+body.dark-mode .rating-star:focus {
+  color: #bbb;
+}
+
+body.dark-mode .rating-star.rated {
+  color: #ffd700;
 }
 
 body.dark-mode .favorited {


### PR DESCRIPTION
## Summary
- Allow users to rate term difficulty 1–5 directly below each definition.
- Store ratings in `localStorage` and prioritize higher-rated terms for suggestions.
- Style rating stars for both light and dark themes.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b60866860c8328bbeb2c00d801871d