### PR TITLE
Add CSV import wizard with deduplication

### DIFF
--- a/assets/js/import.js
+++ b/assets/js/import.js
@@ -1,0 +1,92 @@
+const csvInput = document.getElementById("csvFile");
+const mappingDiv = document.getElementById("mapping");
+const previewDiv = document.getElementById("preview");
+const summaryDiv = document.getElementById("summary");
+const termSelect = document.getElementById("termColumn");
+const defSelect = document.getElementById("definitionColumn");
+const previewTable = document.getElementById("previewTable");
+const summaryText = document.getElementById("summaryText");
+
+let csvRows = [];
+let mappedRows = [];
+const collection = [];
+const slugs = new Set();
+
+function slugify(text) {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+csvInput.addEventListener("change", (e) => {
+  const file = e.target.files[0];
+  if (!file) return;
+  Papa.parse(file, {
+    complete: (results) => {
+      const isRowFilled = (row) => row.some((cell) => cell && cell.trim());
+      csvRows = results.data.filter(isRowFilled);
+      const headers = csvRows.shift();
+      populateMapping(headers);
+    },
+  });
+});
+
+function populateMapping(headers) {
+  termSelect.innerHTML = "";
+  defSelect.innerHTML = "";
+  headers.forEach((h, idx) => {
+    const opt1 = document.createElement("option");
+    opt1.value = idx;
+    opt1.textContent = h;
+    termSelect.appendChild(opt1);
+    const opt2 = document.createElement("option");
+    opt2.value = idx;
+    opt2.textContent = h;
+    defSelect.appendChild(opt2);
+  });
+  mappingDiv.style.display = "block";
+}
+
+document.getElementById("previewBtn").addEventListener("click", () => {
+  const termIdx = parseInt(termSelect.value, 10);
+  const defIdx = parseInt(defSelect.value, 10);
+  if (isNaN(termIdx) || isNaN(defIdx)) return;
+  mappedRows = csvRows.map((row) => ({
+    term: row[termIdx] ? row[termIdx].trim() : "",
+    definition: row[defIdx] ? row[defIdx].trim() : "",
+  }));
+  renderPreview();
+});
+
+function renderPreview() {
+  previewTable.innerHTML = "";
+  const thead = document.createElement("thead");
+  thead.innerHTML = "<tr><th>Term</th><th>Definition</th></tr>";
+  const tbody = document.createElement("tbody");
+  mappedRows.slice(0, 5).forEach((item) => {
+    const tr = document.createElement("tr");
+    tr.innerHTML = `<td>${item.term}</td><td>${item.definition}</td>`;
+    tbody.appendChild(tr);
+  });
+  previewTable.appendChild(thead);
+  previewTable.appendChild(tbody);
+  previewDiv.style.display = "block";
+}
+
+document.getElementById("importBtn").addEventListener("click", () => {
+  let imported = 0;
+  let skipped = 0;
+  mappedRows.forEach((item) => {
+    const slug = slugify(item.term);
+    if (!slugs.has(slug)) {
+      slugs.add(slug);
+      collection.push({ ...item, slug });
+      imported++;
+    } else {
+      skipped++;
+    }
+  });
+  summaryText.textContent = `${imported} items imported, ${skipped} items skipped.`;
+  summaryDiv.style.display = "block";
+});

--- a/import.html
+++ b/import.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Import Terms</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <main class="container">
+    <h1>Import Terms from CSV</h1>
+    <div id="step1">
+      <input type="file" id="csvFile" accept=".csv" aria-label="CSV file">
+    </div>
+    <div id="mapping" style="display: none">
+      <h2>Map Columns</h2>
+      <label>Term Column:
+        <select id="termColumn"></select>
+      </label>
+      <label>Definition Column:
+        <select id="definitionColumn"></select>
+      </label>
+      <button id="previewBtn" type="button">Preview</button>
+    </div>
+    <div id="preview" style="display: none">
+      <h2>Preview</h2>
+      <table id="previewTable"></table>
+      <button id="importBtn" type="button">Import</button>
+    </div>
+    <div id="summary" style="display: none">
+      <h2>Summary</h2>
+      <p id="summaryText"></p>
+    </div>
+  </main>
+  <script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js"></script>
+  <script src="assets/js/import.js"></script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "script.js",
   "scripts": {
     "build": "node scripts/build.js",
-    "test": "html-validate index.html search.html diagnostics.html && node diagnostics.test.js",
+    "test": "html-validate index.html search.html diagnostics.html import.html && node diagnostics.test.js",
     "watch": "chokidar \"**/*.html\" -c \"npm run build\""
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
- add `import.html` with step-by-step CSV import wizard
- allow mapping CSV columns to term fields and previewing data
- deduplicate terms by slug when importing and report import vs skip counts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b60866dab08328a0d54715051eb858