### PR TITLE
feat: add custom in-page search overlay

### DIFF
--- a/assets/js/find.js
+++ b/assets/js/find.js
@@ -1,0 +1,124 @@
+(function(){
+  let overlay;
+  let input;
+  let matches = [];
+  let currentIndex = -1;
+
+  function createOverlay(){
+    overlay = document.createElement('div');
+    overlay.id = 'find-overlay';
+    overlay.innerHTML = '<input type="text" id="find-input" aria-label="Find in page" />';
+    document.body.appendChild(overlay);
+    input = overlay.querySelector('#find-input');
+    input.addEventListener('input', handleInput);
+    input.addEventListener('keydown', handleKeyDown);
+  }
+
+  function handleKeyDown(e){
+    if(e.key === 'Enter'){
+      e.preventDefault();
+      if(e.shiftKey){
+        focusPrev();
+      } else {
+        focusNext();
+      }
+    } else if(e.key === 'Escape'){
+      hideOverlay();
+    }
+  }
+
+  function handleInput(){
+    const query = input.value.trim();
+    clearHighlights();
+    if(!query){
+      matches = [];
+      currentIndex = -1;
+      return;
+    }
+    const accs = Array.from(document.querySelectorAll('details, .accordion'));
+    const regex = new RegExp(query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'gi');
+    accs.forEach(acc => {
+      const text = acc.textContent.toLowerCase();
+      if(text.includes(query.toLowerCase())){
+        if(acc.tagName.toLowerCase() === 'details'){
+          acc.open = true;
+        } else {
+          acc.classList.add('open');
+        }
+        highlight(acc, regex);
+      }
+    });
+    matches = Array.from(document.querySelectorAll('mark.find-match'));
+    if(matches.length){
+      focusMatch(0);
+    }
+  }
+
+  function highlight(node, regex){
+    const walker = document.createTreeWalker(node, NodeFilter.SHOW_TEXT, null);
+    const nodes = [];
+    while(walker.nextNode()){
+      nodes.push(walker.currentNode);
+    }
+    nodes.forEach(textNode => {
+      if(regex.test(textNode.textContent)){
+        const span = document.createElement('span');
+        span.innerHTML = textNode.textContent.replace(regex, match => `<mark class="find-match">${match}</mark>`);
+        textNode.parentNode.replaceChild(span, textNode);
+      }
+    });
+  }
+
+  function clearHighlights(){
+    document.querySelectorAll('mark.find-match').forEach(m => {
+      const text = document.createTextNode(m.textContent);
+      m.parentNode.replaceChild(text, m);
+    });
+    matches = [];
+    currentIndex = -1;
+  }
+
+  function focusMatch(index){
+    if(matches[currentIndex]){
+      matches[currentIndex].classList.remove('find-focus');
+    }
+    currentIndex = index;
+    const m = matches[currentIndex];
+    if(m){
+      m.classList.add('find-focus');
+      m.scrollIntoView({behavior:'smooth', block:'center'});
+    }
+  }
+
+  function focusNext(){
+    if(!matches.length) return;
+    const next = (currentIndex + 1) % matches.length;
+    focusMatch(next);
+  }
+
+  function focusPrev(){
+    if(!matches.length) return;
+    const prev = (currentIndex - 1 + matches.length) % matches.length;
+    focusMatch(prev);
+  }
+
+  function hideOverlay(){
+    overlay.style.display = 'none';
+    clearHighlights();
+  }
+
+  document.addEventListener('keydown', e => {
+    const isFind = (e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'f';
+    if(isFind){
+      e.preventDefault();
+      if(!overlay){
+        createOverlay();
+      }
+      overlay.style.display = 'block';
+      input.focus();
+      input.select();
+    } else if(e.key === 'Escape' && overlay && overlay.style.display !== 'none'){
+      hideOverlay();
+    }
+  });
+})();

--- a/diagnostics.html
+++ b/diagnostics.html
@@ -17,5 +17,6 @@
     </table>
   </main>
   <script src="assets/js/diagnostics.js"></script>
+  <script src="assets/js/find.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -34,6 +34,7 @@
   </footer>
   <script src="script.js"></script>
   <script src="assets/js/app.js"></script>
+  <script src="assets/js/find.js"></script>
   <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
   <script src="assets/js/metrics.js"></script>
 </body>

--- a/search.html
+++ b/search.html
@@ -16,6 +16,7 @@
     window.__BASE_URL__ = window.__BASE_URL__ || '';
   </script>
   <script src="assets/js/search.js"></script>
+  <script src="assets/js/find.js"></script>
   <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
   <script src="assets/js/metrics.js"></script>
 </body>

--- a/styles.css
+++ b/styles.css
@@ -347,3 +347,20 @@ body.dark-mode #alpha-nav button.active {
     font-size: 14px;
   }
 }
+#find-overlay {
+  position: fixed;
+  top: 10px;
+  right: 10px;
+  background: #fff;
+  border: 1px solid #ccc;
+  padding: 5px;
+  z-index: 1000;
+  display: none;
+}
+#find-overlay input {
+  width: 200px;
+}
+mark.find-focus {
+  background-color: orange;
+  color: #000;
+}


### PR DESCRIPTION
## Summary
- add script to intercept browser find shortcuts
- highlight matches across accordion sections and auto-expand
- include in-page search overlay styles across site

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b60854ec948328b563674793e9982c