### PR TITLE
feat: add paste sanitizer tool

### DIFF
--- a/assets/js/sanitize.js
+++ b/assets/js/sanitize.js
@@ -1,0 +1,40 @@
+const textarea = document.getElementById('paste-input');
+const originalPre = document.getElementById('original');
+const sanitizedPre = document.getElementById('sanitized');
+const copyBtn = document.getElementById('copy-clean');
+
+function stripHidden(text) {
+  // Remove control characters except tab, newline, and carriage return
+  return text.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, '');
+}
+
+function diffView(original, cleaned) {
+  let result = '';
+  let j = 0;
+  for (let i = 0; i < original.length; i++) {
+    const o = original[i];
+    const c = cleaned[j];
+    if (o === c) {
+      result += o;
+      j++;
+    } else {
+      const code = o.charCodeAt(0).toString(16).padStart(2, '0');
+      result += `<span class="removed" title="0x${code}">\\x${code}</span>`;
+    }
+  }
+  return result;
+}
+
+textarea.addEventListener('paste', (e) => {
+  e.preventDefault();
+  const text = (e.clipboardData || window.clipboardData).getData('text');
+  const cleaned = stripHidden(text);
+  textarea.value = cleaned;
+  originalPre.innerHTML = diffView(text, cleaned);
+  sanitizedPre.textContent = cleaned;
+  copyBtn.disabled = cleaned.length === 0;
+});
+
+copyBtn.addEventListener('click', () => {
+  navigator.clipboard.writeText(sanitizedPre.textContent);
+});

--- a/sanitize.html
+++ b/sanitize.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Paste Sanitizer</title>
+  <link rel="stylesheet" href="styles.css">
+  <style>
+    .diff {
+      display: flex;
+      gap: 1rem;
+      flex-wrap: wrap;
+    }
+    .diff > div {
+      flex: 1 1 45%;
+    }
+    textarea {
+      width: 100%;
+      height: 150px;
+    }
+    pre {
+      white-space: pre-wrap;
+      word-break: break-all;
+      border: 1px solid #ccc;
+      padding: 0.5rem;
+    }
+    .removed {
+      background: #ffdddd;
+    }
+  </style>
+</head>
+<body>
+  <main class="container">
+    <h1>Paste Sanitizer</h1>
+    <textarea id="paste-input" placeholder="Paste text here"></textarea>
+    <div class="diff">
+      <div>
+        <h2>Original</h2>
+        <pre id="original"></pre>
+      </div>
+      <div>
+        <h2>Sanitized</h2>
+        <pre id="sanitized"></pre>
+      </div>
+    </div>
+    <button id="copy-clean" type="button" disabled>Copy Cleaned Text</button>
+  </main>
+  <script src="assets/js/sanitize.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add standalone page to remove hidden control characters from pasted text
- highlight differences between original and sanitized content
- let users copy the cleaned text back to the clipboard

## Testing
- `npx html-validate sanitize.html`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6084e21208328834a4706cc03491c