### PR TITLE
Add category sunburst visualization

### DIFF
--- a/assets/js/sunburst.js
+++ b/assets/js/sunburst.js
@@ -1,0 +1,155 @@
+// Sunburst visualization of term categories
+
+document.addEventListener('DOMContentLoaded', initSunburst);
+
+async function initSunburst(){
+  try {
+    const res = await fetch('terms.json');
+    const data = await res.json();
+    const hierarchy = buildHierarchy(data.terms || []);
+    drawSunburst(hierarchy);
+  } catch(err){
+    console.error('Failed to load terms.json', err);
+  }
+}
+
+function buildHierarchy(terms){
+  const root = { name: 'Terms', children: [] };
+  const categories = {};
+  terms.forEach(term => {
+    const category = term.category || 'Uncategorized';
+    if(!categories[category]){
+      categories[category] = { name: category, children: [] };
+    }
+    categories[category].children.push({ name: term.term || term.name, value: 1 });
+  });
+  root.children = Object.values(categories);
+  return root;
+}
+
+function drawSunburst(data){
+  const width = 600;
+  const radius = width / 6;
+
+  const partition = (data) => {
+    const root = d3.hierarchy(data)
+      .sum(d => d.value || 0)
+      .sort((a, b) => b.value - a.value);
+    return d3.partition()
+      .size([2 * Math.PI, root.height + 1])(root);
+  };
+
+  const root = partition(data);
+  root.each(d => d.current = d);
+
+  const svg = d3.select('#sunburst')
+    .attr('viewBox', [0, 0, width, width])
+    .style('font', '10px sans-serif');
+
+  const g = svg.append('g')
+    .attr('transform', `translate(${width / 2},${width / 2})`);
+
+  const color = d3.scaleOrdinal()
+    .domain(root.children.map(d => d.data.name))
+    .range(d3.quantize(d3.interpolateRainbow, root.children.length + 1));
+
+  const arc = d3.arc()
+    .startAngle(d => d.x0)
+    .endAngle(d => d.x1)
+    .padAngle(d => Math.min((d.x1 - d.x0) / 2, 0.005))
+    .padRadius(radius * 1.5)
+    .innerRadius(d => d.y0 * radius)
+    .outerRadius(d => Math.max(d.y0 * radius, d.y1 * radius - 1));
+
+  const path = g.append('g')
+    .selectAll('path')
+    .data(root.descendants().slice(1))
+    .join('path')
+      .attr('fill', d => { while (d.depth > 1) d = d.parent; return color(d.data.name); })
+      .attr('fill-opacity', d => arcVisible(d.current) ? (d.children ? 0.6 : 0.4) : 0)
+      .attr('d', d => arc(d.current));
+
+  path.filter(d => d.children)
+    .style('cursor', 'pointer')
+    .on('click', clicked);
+
+  path.append('title')
+    .text(d => d.ancestors().map(d => d.data.name).reverse().join(' / '));
+
+  const label = g.append('g')
+    .attr('pointer-events', 'none')
+    .attr('text-anchor', 'middle')
+    .style('user-select', 'none')
+    .selectAll('text')
+    .data(root.descendants().slice(1))
+    .join('text')
+      .attr('dy', '0.35em')
+      .attr('fill-opacity', d => +labelVisible(d.current))
+      .attr('transform', d => labelTransform(d.current))
+      .text(d => d.data.name);
+
+  const parent = g.append('circle')
+    .datum(root)
+    .attr('r', radius)
+    .attr('fill', 'none')
+    .attr('pointer-events', 'all')
+    .on('click', clicked);
+
+  const breadcrumbs = d3.select('#breadcrumbs');
+  const backBtn = d3.select('#back-btn')
+    .style('display', 'none')
+    .on('click', () => clicked(null, root));
+
+  function clicked(event, p) {
+    updateBreadcrumbs(p);
+    parent.datum(p.parent || root);
+
+    root.each(d => d.target = {
+      x0: Math.max(0, Math.min(1, (d.x0 - p.x0) / (p.x1 - p.x0))) * 2 * Math.PI,
+      x1: Math.max(0, Math.min(1, (d.x1 - p.x0) / (p.x1 - p.x0))) * 2 * Math.PI,
+      y0: Math.max(0, d.y0 - p.depth),
+      y1: Math.max(0, d.y1 - p.depth)
+    });
+
+    const t = g.transition().duration(750);
+
+    path.transition(t)
+      .tween('data', d => {
+        const i = d3.interpolate(d.current, d.target);
+        return t => d.current = i(t);
+      })
+      .filter(function(d) {
+        return +this.getAttribute('fill-opacity') || arcVisible(d.target);
+      })
+        .attr('fill-opacity', d => arcVisible(d.target) ? (d.children ? 0.6 : 0.4) : 0)
+        .attr('pointer-events', d => arcVisible(d.target) ? 'auto' : 'none')
+        .attrTween('d', d => () => arc(d.current));
+
+    label.filter(function(d) {
+        return +this.getAttribute('fill-opacity') || labelVisible(d.target);
+      }).transition(t)
+        .attr('fill-opacity', d => +labelVisible(d.target))
+        .attrTween('transform', d => () => labelTransform(d.current));
+  }
+
+  function updateBreadcrumbs(node){
+    breadcrumbs.text(node.ancestors().reverse().map(d => d.data.name).join(' > '));
+    backBtn.style('display', node === root ? 'none' : 'inline-block');
+  }
+
+  function arcVisible(d) {
+    return d.y1 <= 3 && d.y0 >= 1 && d.x1 > d.x0;
+  }
+
+  function labelVisible(d) {
+    return d.y1 <= 3 && d.y0 >= 1 && (d.x1 - d.x0) > 0.03;
+  }
+
+  function labelTransform(d) {
+    const x = (d.x0 + d.x1) / 2 * 180 / Math.PI;
+    const y = (d.y0 + d.y1) / 2 * radius;
+    return `rotate(${x - 90}) translate(${y},0) rotate(${x < 180 ? 0 : 180})`;
+  }
+
+  updateBreadcrumbs(root);
+}

--- a/categories.html
+++ b/categories.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Category Sunburst</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <main class="container">
+    <h1>Category Map</h1>
+    <nav id="breadcrumbs" aria-label="Breadcrumb"></nav>
+    <button id="back-btn" type="button" aria-label="Return to root">Back</button>
+    <svg id="sunburst" width="600" height="600"></svg>
+  </main>
+  <script src="https://d3js.org/d3.v7.min.js"></script>
+  <script src="assets/js/sunburst.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 <body>
   <main class="container">
     <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav" aria-label="Site links"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
+    <nav class="site-nav" aria-label="Site links"><a href="templates/guidelines.html">Definition Guidelines</a> | <a href="categories.html">Category Map</a></nav>
     <div id="definition-container" style="display: none;"></div>
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">


### PR DESCRIPTION
## Summary
- build hierarchical category data from term metadata
- draw zoomable sunburst with breadcrumb navigation and back button
- add standalone Category Map page and link from home page

## Testing
- `npm test`
- `npx html-validate categories.html && echo "HTML validated"`


------
https://chatgpt.com/codex/tasks/task_e_68b608477bd4832894008de5e78f26aa