### PR TITLE
feat: handle service worker updates

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,5 +1,19 @@
-if ('serviceWorker' in navigator) {
-  window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/sw.js');
+if ("serviceWorker" in navigator) {
+  window.addEventListener("load", () => {
+    navigator.serviceWorker.register("/sw.js").then((registration) => {
+      registration.addEventListener("updatefound", () => {
+        const newWorker = registration.installing;
+        newWorker?.addEventListener("statechange", () => {
+          if (
+            newWorker.state === "installed" &&
+            navigator.serviceWorker.controller
+          ) {
+            window.dispatchEvent(
+              new CustomEvent("swUpdated", { detail: registration }),
+            );
+          }
+        });
+      });
+    });
   });
 }

--- a/src/components/SwUpdateToast.tsx
+++ b/src/components/SwUpdateToast.tsx
@@ -1,0 +1,47 @@
+import React, { useEffect, useState } from "react";
+
+const SwUpdateToast: React.FC = () => {
+  const [waitingWorker, setWaitingWorker] = useState<ServiceWorker | null>(
+    null,
+  );
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const onUpdate = (
+      event: Event | CustomEvent<ServiceWorkerRegistration>,
+    ) => {
+      const reg = (event as CustomEvent<ServiceWorkerRegistration>).detail;
+      if (sessionStorage.getItem("sw-update-deferred")) return;
+      setWaitingWorker(reg.waiting);
+      setVisible(true);
+    };
+
+    window.addEventListener("swUpdated", onUpdate as EventListener);
+    return () => {
+      window.removeEventListener("swUpdated", onUpdate as EventListener);
+    };
+  }, []);
+
+  const refresh = () => {
+    waitingWorker?.postMessage({ type: "SKIP_WAITING" });
+    sessionStorage.removeItem("sw-update-deferred");
+    window.location.reload();
+  };
+
+  const defer = () => {
+    sessionStorage.setItem("sw-update-deferred", "true");
+    setVisible(false);
+  };
+
+  if (!visible) return null;
+
+  return (
+    <div className="sw-update-toast">
+      <span>Update available</span>
+      <button onClick={refresh}>refresh now</button>
+      <button onClick={defer}>remind later</button>
+    </div>
+  );
+};
+
+export default SwUpdateToast;

--- a/sw.js
+++ b/sw.js
@@ -1,36 +1,48 @@
-const CACHE_NAME = 'csd-cache-v1';
+const CACHE_NAME = "csd-cache-v1";
 const URLS_TO_CACHE = [
-  '/',
-  '/index.html',
-  '/styles.css',
-  '/script.js',
-  '/data.json'
+  "/",
+  "/index.html",
+  "/styles.css",
+  "/script.js",
+  "/data.json",
 ];
 
-self.addEventListener('install', event => {
+self.addEventListener("install", (event) => {
   event.waitUntil(
-    caches.open(CACHE_NAME).then(cache => cache.addAll(URLS_TO_CACHE))
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(URLS_TO_CACHE)),
   );
 });
 
-self.addEventListener('activate', event => {
+self.addEventListener("activate", (event) => {
   event.waitUntil(
-    caches.keys().then(keys =>
-      Promise.all(
-        keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key))
-      )
-    )
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(
+          keys
+            .filter((key) => key !== CACHE_NAME)
+            .map((key) => caches.delete(key)),
+        ),
+      ),
   );
 });
 
-self.addEventListener('fetch', event => {
+self.addEventListener("fetch", (event) => {
   event.respondWith(
-    caches.match(event.request).then(response =>
-      response || fetch(event.request).catch(() => {
-        if (event.request.mode === 'navigate') {
-          return caches.match('/index.html');
-        }
-      })
-    )
+    caches.match(event.request).then(
+      (response) =>
+        response ||
+        fetch(event.request).catch(() => {
+          if (event.request.mode === "navigate") {
+            return caches.match("/index.html");
+          }
+        }),
+    ),
   );
+});
+
+self.addEventListener("message", (event) => {
+  if (event.data && event.data.type === "SKIP_WAITING") {
+    self.skipWaiting();
+  }
 });


### PR DESCRIPTION
## Summary
- dispatch `swUpdated` event when an update is ready
- allow service worker to skip waiting when prompted
- add React toast to refresh now or defer once per session

## Testing
- `npm test`
- `npx prettier assets/js/app.js sw.js src/components/SwUpdateToast.tsx -w`


------
https://chatgpt.com/codex/tasks/task_e_68b5d59735d88328b4c1debc6a9a9a62