### PR TITLE
feat: add share builder modal and highlight

### DIFF
--- a/script.js
+++ b/script.js
@@ -41,15 +41,16 @@ function loadTerms() {
       termsData.terms.sort((a, b) => a.term.localeCompare(b.term));
       buildAlphaNav();
       populateTermsList();
-
       if (window.location.hash) {
-        const termFromHash = decodeURIComponent(window.location.hash.substring(1));
+        const rawHash = window.location.hash.substring(1);
+        const termFromHash = decodeURIComponent(rawHash);
         const matchedTerm = termsData.terms.find(
           (t) => t.term.toLowerCase() === termFromHash.toLowerCase()
         );
         if (matchedTerm) {
           displayDefinition(matchedTerm);
         }
+        scrollToHashAndHighlight(rawHash);
       }
     })
     .catch((error) => {
@@ -140,6 +141,7 @@ function populateTermsList() {
       if (matchesSearch && matchesFavorites && matchesLetter) {
         const termDiv = document.createElement("div");
         termDiv.classList.add("dictionary-item");
+        termDiv.id = encodeURIComponent(item.term);
 
         const termHeader = document.createElement("h3");
         if (searchValue) {
@@ -178,6 +180,28 @@ function populateTermsList() {
         termsList.appendChild(termDiv);
       }
     });
+}
+
+function scrollToHashAndHighlight(id) {
+  const targetEl = document.getElementById(id);
+  if (!targetEl) return;
+  targetEl.scrollIntoView({ behavior: "smooth", block: "center" });
+  targetEl.classList.add("pulse-highlight");
+  const params = new URLSearchParams(window.location.search);
+  const sel = params.get("sel");
+  if (sel) {
+    highlightText(targetEl, decodeURIComponent(sel));
+  }
+}
+
+function highlightText(element, text) {
+  if (!text) return;
+  const escaped = text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const regex = new RegExp(escaped, "i");
+  element.innerHTML = element.innerHTML.replace(
+    regex,
+    (match) => `<mark class="pulse-highlight">${match}</mark>`
+  );
 }
 
 function displayDefinition(term) {

--- a/src/components/ShareBuilder.tsx
+++ b/src/components/ShareBuilder.tsx
@@ -1,0 +1,77 @@
+import React, { useMemo, useState } from "react";
+
+interface ShareBuilderProps {
+  /** Base URL of the site, e.g., https://example.com */
+  baseUrl: string;
+  /** ID of the element or term to link to */
+  targetId: string;
+  /** Optional default selection text */
+  defaultSelection?: string;
+}
+
+/**
+ * ShareBuilder renders a simple modal that allows a user to compose a
+ * shareable URL for the current page.  UTM parameters can be supplied and any
+ * selected text may be highlighted when the link is opened.
+ */
+const ShareBuilder: React.FC<ShareBuilderProps> = ({
+  baseUrl,
+  targetId,
+  defaultSelection = "",
+}) => {
+  const [utmSource, setUtmSource] = useState("");
+  const [utmMedium, setUtmMedium] = useState("");
+  const [utmCampaign, setUtmCampaign] = useState("");
+  const [selection, setSelection] = useState(defaultSelection);
+
+  const shareUrl = useMemo(() => {
+    const url = new URL(baseUrl);
+    if (utmSource) url.searchParams.set("utm_source", utmSource);
+    if (utmMedium) url.searchParams.set("utm_medium", utmMedium);
+    if (utmCampaign) url.searchParams.set("utm_campaign", utmCampaign);
+    if (selection) url.searchParams.set("sel", encodeURIComponent(selection));
+    url.hash = targetId;
+    return url.toString();
+  }, [baseUrl, targetId, utmSource, utmMedium, utmCampaign, selection]);
+
+  return (
+    <div className="share-modal">
+      <h2>Share Link</h2>
+      <label>
+        UTM Source
+        <input
+          type="text"
+          value={utmSource}
+          onChange={(e) => setUtmSource(e.target.value)}
+        />
+      </label>
+      <label>
+        UTM Medium
+        <input
+          type="text"
+          value={utmMedium}
+          onChange={(e) => setUtmMedium(e.target.value)}
+        />
+      </label>
+      <label>
+        UTM Campaign
+        <input
+          type="text"
+          value={utmCampaign}
+          onChange={(e) => setUtmCampaign(e.target.value)}
+        />
+      </label>
+      <label>
+        Text to highlight (optional)
+        <input
+          type="text"
+          value={selection}
+          onChange={(e) => setSelection(e.target.value)}
+        />
+      </label>
+      <input type="text" readOnly value={shareUrl} />
+    </div>
+  );
+};
+
+export default ShareBuilder;

--- a/styles.css
+++ b/styles.css
@@ -347,3 +347,19 @@ body.dark-mode #alpha-nav button.active {
     font-size: 14px;
   }
 }
+
+@keyframes pulse-highlight {
+  0% {
+    background-color: yellow;
+  }
+  50% {
+    background-color: transparent;
+  }
+  100% {
+    background-color: yellow;
+  }
+}
+
+.pulse-highlight {
+  animation: pulse-highlight 2s ease-in-out 2;
+}


### PR DESCRIPTION
## Summary
- add ShareBuilder modal to compose share links with UTM parameters and optional text selection
- scroll to shared term and pulse-highlight matching selection on page load
- support pulse animation styling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5d55c2c708328ae3261c8f615349f