### PR TITLE
feat: add selection manager with persistence

### DIFF
--- a/src/features/selection/SelectionContext.tsx
+++ b/src/features/selection/SelectionContext.tsx
@@ -1,0 +1,101 @@
+import React, { createContext, useContext, useEffect, useRef, useState } from 'react';
+
+type SelectionEntry = { id: string; timestamp: number };
+
+interface SelectionContextValue {
+  selected: SelectionEntry[];
+  isSelected(id: string): boolean;
+  toggle(id: string, opts?: { range?: string[] }): void;
+  clear(): void;
+  marqueeSelect(ids: string[]): void;
+}
+
+const SelectionContext = createContext<SelectionContextValue | undefined>(undefined);
+
+const STORAGE_KEY = 'selection';
+const EXPIRY_MS = 5 * 60 * 1000; // 5 minutes
+
+function loadFromStorage(): SelectionEntry[] {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const data = JSON.parse(raw);
+    if (data.expires && Date.now() > data.expires) {
+      sessionStorage.removeItem(STORAGE_KEY);
+      return [];
+    }
+    return data.items ?? [];
+  } catch {
+    return [];
+  }
+}
+
+export const SelectionProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [selected, setSelected] = useState<SelectionEntry[]>(() => loadFromStorage());
+  const lastIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const payload = { items: selected, expires: Date.now() + EXPIRY_MS };
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+  }, [selected]);
+
+  const toggle = (id: string, opts?: { range?: string[] }) => {
+    setSelected(prev => {
+      let next = prev;
+      if (opts?.range && lastIdRef.current) {
+        const ids = opts.range;
+        const start = ids.indexOf(lastIdRef.current);
+        const end = ids.indexOf(id);
+        if (start !== -1 && end !== -1) {
+          const [from, to] = start < end ? [start, end] : [end, start];
+          const rangeIds = ids.slice(from, to + 1);
+          const idSet = new Set(prev.map(p => p.id));
+          const timestamp = Date.now();
+          rangeIds.forEach(rid => {
+            if (!idSet.has(rid)) {
+              idSet.add(rid);
+              next = [...next, { id: rid, timestamp }];
+            }
+          });
+          lastIdRef.current = id;
+          return next;
+        }
+      }
+      const existing = prev.find(p => p.id === id);
+      if (existing) {
+        return prev.filter(p => p.id !== id);
+      }
+      lastIdRef.current = id;
+      return [...prev, { id, timestamp: Date.now() }];
+    });
+  };
+
+  const clear = () => setSelected([]);
+
+  const marqueeSelect = (ids: string[]) => {
+    const timestamp = Date.now();
+    setSelected(prev => {
+      const idSet = new Set(prev.map(p => p.id));
+      const additions = ids.filter(id => !idSet.has(id)).map(id => ({ id, timestamp }));
+      return [...prev, ...additions];
+    });
+  };
+
+  const value: SelectionContextValue = {
+    selected,
+    isSelected: id => selected.some(s => s.id === id),
+    toggle,
+    clear,
+    marqueeSelect,
+  };
+
+  return <SelectionContext.Provider value={value}>{children}</SelectionContext.Provider>;
+};
+
+export function useSelection() {
+  const ctx = useContext(SelectionContext);
+  if (!ctx) throw new Error('useSelection must be used within SelectionProvider');
+  return ctx;
+}
+
+export default SelectionContext;

--- a/src/features/selection/SelectionToolbar.tsx
+++ b/src/features/selection/SelectionToolbar.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { useSelection } from './SelectionContext';
+
+interface Props {
+  onCompare(ids: string[]): void;
+  onExport(ids: string[]): void;
+}
+
+export const SelectionToolbar: React.FC<Props> = ({ onCompare, onExport }) => {
+  const { selected, clear } = useSelection();
+  if (selected.length === 0) return null;
+  const ids = selected.map(s => s.id);
+  return (
+    <div className="selection-toolbar">
+      <span>{selected.length} selected</span>
+      <button onClick={() => onCompare(ids)}>Compare</button>
+      <button onClick={() => onExport(ids)}>Export</button>
+      <button onClick={clear}>Clear</button>
+    </div>
+  );
+};

--- a/src/features/selection/index.ts
+++ b/src/features/selection/index.ts
@@ -1,0 +1,3 @@
+export * from './SelectionContext';
+export * from './useMarquee';
+export * from './SelectionToolbar';

--- a/src/features/selection/useMarquee.ts
+++ b/src/features/selection/useMarquee.ts
@@ -1,0 +1,49 @@
+import { useEffect, useRef } from 'react';
+import { useSelection } from './SelectionContext';
+
+interface Item { id: string; rect: DOMRect }
+
+export function useMarquee(
+  container: HTMLElement | null,
+  getItems: () => Item[]
+): void {
+  const { marqueeSelect } = useSelection();
+  const startRef = useRef<{ x: number; y: number } | null>(null);
+
+  useEffect(() => {
+    if (!container) return;
+
+    function onMouseDown(e: MouseEvent) {
+      if (e.button !== 0) return;
+      startRef.current = { x: e.clientX, y: e.clientY };
+      window.addEventListener('mousemove', onMouseMove);
+      window.addEventListener('mouseup', onMouseUp);
+    }
+
+    function onMouseMove(e: MouseEvent) {
+      const start = startRef.current;
+      if (!start) return;
+      const x1 = Math.min(start.x, e.clientX);
+      const y1 = Math.min(start.y, e.clientY);
+      const x2 = Math.max(start.x, e.clientX);
+      const y2 = Math.max(start.y, e.clientY);
+      const hits = getItems()
+        .filter(({ rect }) => rect.left < x2 && rect.right > x1 && rect.top < y2 && rect.bottom > y1)
+        .map(i => i.id);
+      marqueeSelect(hits);
+    }
+
+    function onMouseUp() {
+      startRef.current = null;
+      window.removeEventListener('mousemove', onMouseMove);
+      window.removeEventListener('mouseup', onMouseUp);
+    }
+
+    container.addEventListener('mousedown', onMouseDown);
+    return () => {
+      container.removeEventListener('mousedown', onMouseDown);
+      window.removeEventListener('mousemove', onMouseMove);
+      window.removeEventListener('mouseup', onMouseUp);
+    };
+  }, [container, marqueeSelect, getItems]);
+}


### PR DESCRIPTION
## Summary
- add SelectionContext with sessionStorage persistence and shift-click selection
- support marquee selection via useMarquee hook
- add bulk action toolbar for compare and export

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5d53d25e88328990e2063d536872c