### PR TITLE
feat: add searchable settings page

### DIFF
--- a/assets/js/settings-index.js
+++ b/assets/js/settings-index.js
@@ -1,0 +1,16 @@
+export function indexSettings(root) {
+  var items = [];
+  root.querySelectorAll("[data-setting]").forEach(function (el) {
+    var labelEl = el.querySelector("label");
+    var label = labelEl ? (labelEl.textContent || "").trim() : "";
+    var keywordsAttr = el.getAttribute("data-keywords") || "";
+    var keywords = keywordsAttr
+      .split(",")
+      .map(function (k) {
+        return k.trim().toLowerCase();
+      })
+      .filter(Boolean);
+    items.push({ id: el.id, label: label, keywords: keywords, element: el });
+  });
+  return items;
+}

--- a/assets/js/settings.js
+++ b/assets/js/settings.js
@@ -1,0 +1,70 @@
+import { indexSettings } from "./settings-index.js";
+
+const searchInput = document.getElementById("settings-search");
+const resultsList = document.getElementById("settings-search-results");
+const settingsRoot = document.getElementById("settings-root");
+const index = indexSettings(settingsRoot);
+
+function clearResults() {
+  while (resultsList.firstChild) {
+    resultsList.removeChild(resultsList.firstChild);
+  }
+}
+
+function renderResults(query) {
+  clearResults();
+  if (!query) return;
+  const q = query.toLowerCase();
+  index
+    .filter((item) => {
+      return (
+        item.label.toLowerCase().includes(q) ||
+        item.keywords.some((k) => k.includes(q))
+      );
+    })
+    .forEach((item) => {
+      const li = document.createElement("li");
+      li.textContent = item.label;
+      li.addEventListener("click", () => {
+        const details = item.element.closest("details");
+        if (details) details.open = true;
+        item.element.scrollIntoView({ behavior: "smooth", block: "center" });
+        item.element.classList.add("settings-highlight");
+        setTimeout(
+          () => item.element.classList.remove("settings-highlight"),
+          2000,
+        );
+      });
+      resultsList.appendChild(li);
+    });
+}
+
+searchInput.addEventListener("input", () => {
+  renderResults(searchInput.value);
+});
+
+const darkModeToggle = document.getElementById("dark-mode-toggle");
+if (localStorage.getItem("darkMode") === "true") {
+  document.body.classList.add("dark-mode");
+  if (darkModeToggle) darkModeToggle.checked = true;
+}
+if (darkModeToggle) {
+  darkModeToggle.addEventListener("change", () => {
+    document.body.classList.toggle("dark-mode");
+    localStorage.setItem(
+      "darkMode",
+      document.body.classList.contains("dark-mode"),
+    );
+  });
+}
+
+const showFavoritesToggle = document.getElementById("show-favorites");
+if (showFavoritesToggle) {
+  const stored = localStorage.getItem("showFavorites");
+  if (stored === "true") {
+    showFavoritesToggle.checked = true;
+  }
+  showFavoritesToggle.addEventListener("change", () => {
+    localStorage.setItem("showFavorites", String(showFavoritesToggle.checked));
+  });
+}

--- a/settings.html
+++ b/settings.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Settings</title>
+    <link rel="stylesheet" href="styles.css" />
+    <script type="module" src="assets/js/settings.js"></script>
+  </head>
+  <body>
+    <div class="container">
+      <h1>Settings</h1>
+      <input
+        id="settings-search"
+        type="search"
+        placeholder="Search settings..."
+      />
+      <ul id="settings-search-results"></ul>
+      <div id="settings-root">
+        <details>
+          <summary>Appearance</summary>
+          <div
+            id="dark-mode-setting"
+            class="setting-item"
+            data-setting
+            data-keywords="theme,night,light"
+          >
+            <label for="dark-mode-toggle">Dark Mode</label>
+            <input type="checkbox" id="dark-mode-toggle" />
+          </div>
+        </details>
+        <details>
+          <summary>Favorites</summary>
+          <div
+            id="show-favorites-setting"
+            class="setting-item"
+            data-setting
+            data-keywords="bookmarks,stars,favorites"
+          >
+            <label for="show-favorites">Show Favorites Only</label>
+            <input type="checkbox" id="show-favorites" />
+          </div>
+        </details>
+      </div>
+    </div>
+  </body>
+</html>

--- a/src/features/settings/SettingsIndex.ts
+++ b/src/features/settings/SettingsIndex.ts
@@ -1,0 +1,26 @@
+export interface SettingsEntry {
+  id: string;
+  label: string;
+  keywords: string[];
+  element: HTMLElement;
+}
+
+/**
+ * Build a search index for all settings controls inside the provided root.
+ * Each setting is expected to have the attribute `data-setting` and may
+ * optionally declare a comma separated list of keywords with `data-keywords`.
+ */
+export function indexSettings(root: HTMLElement): SettingsEntry[] {
+  const items: SettingsEntry[] = [];
+  root.querySelectorAll<HTMLElement>("[data-setting]").forEach((el) => {
+    const labelEl = el.querySelector("label");
+    const label = labelEl ? (labelEl.textContent || "").trim() : "";
+    const keywordsAttr = el.getAttribute("data-keywords") || "";
+    const keywords = keywordsAttr
+      .split(",")
+      .map((k) => k.trim().toLowerCase())
+      .filter(Boolean);
+    items.push({ id: el.id, label, keywords, element: el });
+  });
+  return items;
+}

--- a/styles.css
+++ b/styles.css
@@ -25,7 +25,7 @@ body {
 
 h1 {
   text-align: center;
-  font-family: 'Cinzel', serif;
+  font-family: "Cinzel", serif;
   font-weight: 700;
   font-size: 48px;
   margin-bottom: 20px;
@@ -110,7 +110,6 @@ body.dark-mode mark {
   box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
   min-height: 44px;
 }
-
 
 /* Controls styling */
 #random-term {
@@ -206,7 +205,9 @@ label {
   border-radius: 4px;
   padding: 10px;
   cursor: pointer;
-  transition: background-color 0.2s, color 0.2s;
+  transition:
+    background-color 0.2s,
+    color 0.2s;
   min-width: 44px;
   min-height: 44px;
 }
@@ -346,4 +347,36 @@ body.dark-mode #alpha-nav button.active {
   #alpha-nav button {
     font-size: 14px;
   }
+}
+
+.settings-highlight {
+  animation: settings-highlight 2s ease;
+}
+
+@keyframes settings-highlight {
+  from {
+    background-color: yellow;
+  }
+  to {
+    background-color: transparent;
+  }
+}
+
+#settings-search {
+  width: 100%;
+  padding: 10px;
+  font-size: 16px;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
+  min-height: 44px;
+  margin-bottom: 10px;
+}
+
+#settings-search-results {
+  margin-bottom: 20px;
+}
+
+#settings-search-results li {
+  padding: 8px 12px;
 }


### PR DESCRIPTION
## Summary
- add SettingsIndex to build search index of labels and keywords
- create settings page with search-driven navigation
- style settings search field and highlight results

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5d57b62e08328b5df074404293e76