### PR TITLE
Add interactive code stepper with playback controls

### DIFF
--- a/assets/js/code-stepper.js
+++ b/assets/js/code-stepper.js
@@ -1,0 +1,93 @@
+// Code stepper reveals code lines sequentially with play/pause and keyboard navigation
+
+document.addEventListener("DOMContentLoaded", () => {
+  const pre = document.querySelector(".code-stepper");
+  if (!pre) return;
+
+  const lines = pre.textContent.trimEnd().split("\n");
+  pre.textContent = "";
+  lines.forEach((line, idx) => {
+    const span = document.createElement("span");
+    span.textContent = line;
+    span.classList.add("code-line");
+    if (idx > 0) span.style.display = "none";
+    pre.appendChild(span);
+  });
+
+  const playPauseBtn = document.getElementById("play-pause");
+  const progress = document.getElementById("line-progress");
+  const progressText = document.getElementById("line-progress-text");
+
+  let current = 0;
+  let timer = null;
+
+  progress.max = lines.length;
+  updateProgress();
+
+  function updateProgress() {
+    progress.value = current + 1;
+    if (progressText) {
+      progressText.textContent = `${current + 1}/${lines.length}`;
+    }
+  }
+
+  function render() {
+    const spans = pre.querySelectorAll(".code-line");
+    spans.forEach((span, i) => {
+      span.style.display = i <= current ? "block" : "none";
+    });
+    updateProgress();
+  }
+
+  function stepForward() {
+    if (current < lines.length - 1) {
+      current += 1;
+      render();
+    } else {
+      pause();
+    }
+  }
+
+  function stepBackward() {
+    if (current > 0) {
+      current -= 1;
+      render();
+    }
+  }
+
+  function play() {
+    if (timer) return;
+    playPauseBtn.textContent = "Pause";
+    timer = setInterval(stepForward, 1000);
+  }
+
+  function pause() {
+    playPauseBtn.textContent = "Play";
+    clearInterval(timer);
+    timer = null;
+  }
+
+  playPauseBtn.addEventListener("click", () => {
+    if (timer) {
+      pause();
+    } else {
+      play();
+    }
+  });
+
+  document.addEventListener("keydown", (e) => {
+    if (["INPUT", "TEXTAREA"].includes(e.target.tagName)) return;
+    if (e.code === "ArrowRight") {
+      stepForward();
+    } else if (e.code === "ArrowLeft") {
+      stepBackward();
+    } else if (e.code === "Space") {
+      e.preventDefault();
+      if (timer) {
+        pause();
+      } else {
+        play();
+      }
+    }
+  });
+});

--- a/index.html
+++ b/index.html
@@ -11,7 +11,10 @@
 <body>
   <main class="container">
     <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav" aria-label="Site links"><a href="templates/guidelines.html">Definition Guidelines</a></nav>
+    <nav class="site-nav" aria-label="Site links">
+      <a href="templates/guidelines.html">Definition Guidelines</a>
+      <a href="templates/code-stepper.html">Code Stepper Demo</a>
+    </nav>
     <div id="definition-container" style="display: none;"></div>
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">

--- a/styles.css
+++ b/styles.css
@@ -25,7 +25,7 @@ body {
 
 h1 {
   text-align: center;
-  font-family: 'Cinzel', serif;
+  font-family: "Cinzel", serif;
   font-weight: 700;
   font-size: 48px;
   margin-bottom: 20px;
@@ -110,7 +110,6 @@ body.dark-mode mark {
   box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
   min-height: 44px;
 }
-
 
 /* Controls styling */
 #random-term {
@@ -206,7 +205,9 @@ label {
   border-radius: 4px;
   padding: 10px;
   cursor: pointer;
-  transition: background-color 0.2s, color 0.2s;
+  transition:
+    background-color 0.2s,
+    color 0.2s;
   min-width: 44px;
   min-height: 44px;
 }
@@ -346,4 +347,30 @@ body.dark-mode #alpha-nav button.active {
   #alpha-nav button {
     font-size: 14px;
   }
+}
+
+/* Code stepper styles */
+.code-stepper {
+  background-color: #1e1e1e;
+  color: #f8f8f2;
+  padding: 1em;
+  border-radius: 4px;
+  overflow-x: auto;
+  font-family: monospace;
+}
+
+.code-line {
+  display: block;
+}
+
+.stepper-controls {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 10px;
+}
+
+.stepper-controls progress {
+  flex: 1;
+  height: 20px;
 }

--- a/templates/code-stepper.html
+++ b/templates/code-stepper.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Code Stepper Demo</title>
+  <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+  <main class="container">
+    <h1>Code Stepper Demo</h1>
+    <pre class="code-stepper">
+// Example JavaScript code
+function greet(name) {
+  console.log('Hello, ' + name + '!');
+}
+
+greet('world');
+    </pre>
+    <div class="stepper-controls">
+      <button id="play-pause" type="button">Play</button>
+      <progress id="line-progress" value="1" max="1"></progress>
+      <span id="line-progress-text"></span>
+    </div>
+  </main>
+  <script src="../assets/js/code-stepper.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add reusable code stepper that reveals lines sequentially
- Provide play/pause, keyboard navigation and progress display
- Style component and link demo page from site navigation

## Testing
- `npx html-validate templates/code-stepper.html`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5b628b5d08328bc2b30c33fc2eaf7