### PR TITLE
feat: flip card once per day

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -347,3 +347,23 @@ body.dark-mode #alpha-nav button.active {
     font-size: 14px;
   }
 }
+
+@keyframes flip-card {
+  from {
+    transform: rotateY(-180deg);
+  }
+  to {
+    transform: rotateY(0);
+  }
+}
+
+.flip-animation {
+  animation: flip-card 0.6s ease both;
+  transform-style: preserve-3d;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .flip-animation {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary
- flip definition card once per day based on local time
- skip the flip animation for users who prefer reduced motion
- store daily random term with timezone-adjusted date

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5b622dfc883288287a58ef5ff6883