### PR TITLE
feat: add accessible hovercards

### DIFF
--- a/assets/js/hovercard.js
+++ b/assets/js/hovercard.js
@@ -1,0 +1,64 @@
+(function () {
+  let hovercard;
+  let showTimer;
+
+  function ensureCard() {
+    if (hovercard) return;
+    hovercard = document.createElement('div');
+    hovercard.id = 'hovercard';
+    hovercard.className = 'hovercard';
+    hovercard.setAttribute('role', 'tooltip');
+    document.body.appendChild(hovercard);
+  }
+
+  function show(target) {
+    ensureCard();
+    clearTimeout(showTimer);
+    showTimer = setTimeout(() => {
+      const text = target.getAttribute('data-hovercard');
+      if (!text) return;
+      hovercard.textContent = text;
+      const rect = target.getBoundingClientRect();
+      hovercard.style.top = `${rect.bottom + window.scrollY}px`;
+      hovercard.style.left = `${rect.left + window.scrollX}px`;
+      hovercard.classList.add('visible');
+      target.setAttribute('aria-describedby', 'hovercard');
+    }, 50); // <100ms appearance
+  }
+
+  function hide() {
+    clearTimeout(showTimer);
+    if (hovercard) {
+      hovercard.classList.remove('visible');
+    }
+  }
+
+  document.addEventListener('mouseover', (e) => {
+    const target = e.target.closest('[data-hovercard]');
+    if (!target) return;
+    show(target);
+  });
+
+  document.addEventListener('focusin', (e) => {
+    const target = e.target.closest('[data-hovercard]');
+    if (!target) return;
+    show(target);
+  });
+
+  document.addEventListener('mouseout', (e) => {
+    if (!e.relatedTarget || !e.relatedTarget.closest('[data-hovercard]')) {
+      hide();
+    }
+  });
+
+  document.addEventListener('focusout', hide);
+
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') {
+      hide();
+      if (document.activeElement) {
+        document.activeElement.blur();
+      }
+    }
+  });
+})();

--- a/index.html
+++ b/index.html
@@ -33,6 +33,7 @@
     <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
   </footer>
   <script src="script.js"></script>
+  <script src="assets/js/hovercard.js"></script>
   <script src="assets/js/app.js"></script>
   <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
   <script src="assets/js/metrics.js"></script>

--- a/script.js
+++ b/script.js
@@ -149,6 +149,8 @@ function populateTermsList() {
         } else {
           termHeader.textContent = item.term;
         }
+        termHeader.setAttribute("tabindex", "0");
+        termHeader.setAttribute("data-hovercard", item.definition);
 
         const star = document.createElement("span");
         star.classList.add("favorite-star");
@@ -166,10 +168,6 @@ function populateTermsList() {
         });
         termHeader.appendChild(star);
         termDiv.appendChild(termHeader);
-
-        const definitionPara = document.createElement("p");
-        definitionPara.textContent = item.definition;
-        termDiv.appendChild(definitionPara);
 
         termDiv.addEventListener("click", () => {
           displayDefinition(item);

--- a/styles.css
+++ b/styles.css
@@ -242,6 +242,26 @@ label {
   background-color: #0056b3;
 }
 
+/* Hovercard styles */
+.hovercard {
+  position: absolute;
+  background-color: #fff;
+  color: #000;
+  border: 1px solid #ccc;
+  padding: 10px;
+  border-radius: 4px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 75ms ease-in;
+  z-index: 1000;
+}
+
+.hovercard.visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
 /* Dark Mode styles */
 body.dark-mode {
   background-color: #121212;
@@ -324,6 +344,12 @@ body.dark-mode #alpha-nav button:focus {
 body.dark-mode #alpha-nav button.active {
   background-color: #007bff;
   border-color: #007bff;
+}
+
+body.dark-mode .hovercard {
+  background-color: #333;
+  color: #fff;
+  border-color: #555;
 }
 
 @media (max-width: 480px) {


### PR DESCRIPTION
## Summary
- add generic hovercard component triggered by hover and keyboard focus
- populate term headings with metadata for hovercards
- style hovercards for light and dark themes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5b62067c48328beb477a5fecbebe1