### PR TITLE
Add export progress indicator with cancel and toast

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,11 @@
     <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">Toggle Dark Mode</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
+    <button id="export-terms" type="button" aria-label="Export terms">Export Terms</button>
+    <div id="export-status" class="export-status" hidden>
+      <progress id="export-progress" class="progress-ring" aria-label="Exporting"></progress>
+      <button id="cancel-export" type="button" aria-label="Cancel export">Cancel</button>
+    </div>
 
     <ul id="terms-list"></ul>
   </main>
@@ -32,6 +37,7 @@
   <footer aria-label="Project contribution">
     <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
   </footer>
+  <div id="toast" class="toast" role="status" aria-live="polite" hidden></div>
   <script src="script.js"></script>
   <script src="assets/js/app.js"></script>
   <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>

--- a/script.js
+++ b/script.js
@@ -254,3 +254,78 @@ scrollBtn.addEventListener("click", () =>
 
 definitionContainer.addEventListener("click", clearDefinition);
 
+// Export logic with progress indicator and cancellation
+const exportBtn = document.getElementById("export-terms");
+const exportStatus = document.getElementById("export-status");
+const cancelExportBtn = document.getElementById("cancel-export");
+const toast = document.getElementById("toast");
+let exportController = null;
+
+function showToast(message) {
+  if (!toast) return;
+  toast.textContent = message;
+  toast.hidden = false;
+  toast.classList.add("show");
+  setTimeout(() => {
+    toast.classList.remove("show");
+    toast.hidden = true;
+  }, 3000);
+}
+
+function exportFinished(success) {
+  exportBtn.disabled = false;
+  exportStatus.hidden = true;
+  exportController = null;
+  if (success) {
+    showToast("Export complete");
+  }
+}
+
+function startExport() {
+  if (exportController) return;
+  exportController = new AbortController();
+  const { signal } = exportController;
+  exportBtn.disabled = true;
+  exportStatus.hidden = false;
+
+  const chunkSize = 20;
+  const total = termsData.terms.length;
+  const data = [];
+
+  function processChunk(index) {
+    if (signal.aborted) {
+      exportFinished(false);
+      return;
+    }
+
+    data.push(...termsData.terms.slice(index, index + chunkSize));
+
+    if (index + chunkSize < total) {
+      setTimeout(() => processChunk(index + chunkSize), 0);
+    } else {
+      const blob = new Blob(
+        [JSON.stringify({ terms: data }, null, 2)],
+        { type: "application/json" }
+      );
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = "terms-export.json";
+      a.click();
+      URL.revokeObjectURL(url);
+      exportFinished(true);
+    }
+  }
+
+  processChunk(0);
+}
+
+if (exportBtn && cancelExportBtn) {
+  exportBtn.addEventListener("click", startExport);
+  cancelExportBtn.addEventListener("click", () => {
+    if (exportController) {
+      exportController.abort();
+    }
+  });
+}
+

--- a/styles.css
+++ b/styles.css
@@ -347,3 +347,53 @@ body.dark-mode #alpha-nav button.active {
     font-size: 14px;
   }
 }
+
+/* Export progress and toast */
+.export-status {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 10px;
+}
+
+.progress-ring {
+  width: 24px;
+  height: 24px;
+  border: 4px solid #ccc;
+  border-top-color: #007bff;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  -webkit-appearance: none;
+  appearance: none;
+  background: transparent;
+}
+.progress-ring::-webkit-progress-bar,
+.progress-ring::-webkit-progress-value {
+  background: transparent;
+}
+.progress-ring::-moz-progress-bar {
+  background: transparent;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.toast {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  background-color: #333;
+  color: #fff;
+  padding: 10px 20px;
+  border-radius: 5px;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  pointer-events: none;
+}
+
+.toast.show {
+  opacity: 1;
+}


### PR DESCRIPTION
## Summary
- add export button with progress ring and cancel control
- show toast notification once export completes
- implement chunked export to keep UI responsive

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5b61f75fc832895c875c9fc30b22b