### PR TITLE
feat: add accessibility checker tool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "axe-core": "^4.10.3",
         "hammerjs": "^2.0.8"
       },
       "devDependencies": {
@@ -309,6 +310,15 @@
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/axe-core": {
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.3.tgz",
+      "integrity": "sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==",
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/basic-auth": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "prettier": "^3.6.2"
   },
   "dependencies": {
+    "axe-core": "^4.10.3",
     "hammerjs": "^2.0.8"
   }
 }

--- a/src/tools/AccessibilityChecker.tsx
+++ b/src/tools/AccessibilityChecker.tsx
@@ -1,0 +1,60 @@
+import React, { useState } from "react";
+import axe from "axe-core";
+
+interface Issue {
+  id: string;
+  impact: axe.ImpactValue | null;
+  description: string;
+  target: string[];
+}
+
+const AccessibilityChecker: React.FC = () => {
+  const [issues, setIssues] = useState<Issue[]>([]);
+
+  const runScan = async () => {
+    const { violations } = await axe.run(document);
+    const flattened: Issue[] = violations.flatMap((v) =>
+      v.nodes.map((n) => ({
+        id: v.id,
+        impact: v.impact ?? null,
+        description: v.help,
+        target: n.target,
+      }))
+    );
+    setIssues(flattened);
+  };
+
+  const focusNode = (target: string[]) => {
+    const selector = target[0];
+    const el = document.querySelector<HTMLElement>(selector);
+    if (!el) return;
+    if (!el.hasAttribute("tabindex")) {
+      el.setAttribute("tabindex", "-1");
+    }
+    el.focus();
+    el.scrollIntoView({ behavior: "smooth", block: "center" });
+  };
+
+  return (
+    <div>
+      <button onClick={runScan}>Run Accessibility Scan</button>
+      {issues.length > 0 && (
+        <ul>
+          {issues.map((issue, i) => (
+            <li key={`${issue.id}-${i}`}>
+              <button
+                onClick={() => focusNode(issue.target)}
+                style={{ display: "block", width: "100%", textAlign: "left" }}
+              >
+                <strong>{issue.impact ?? "unknown"}:</strong> {issue.description}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default AccessibilityChecker;
+


### PR DESCRIPTION
## Summary
- add AccessibilityChecker tool to run axe-core scans and focus failing elements
- add axe-core dependency

## Testing
- `pre-commit run --files package.json package-lock.json src/tools/AccessibilityChecker.tsx`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6177de9288328adc14f24dd6ec985