### PR TITLE
feat: notify service worker updates

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,6 +1,15 @@
 if ("serviceWorker" in navigator) {
   window.addEventListener("load", () => {
     navigator.serviceWorker.register("/sw.js").then((registration) => {
+      const notifyUpdate = () =>
+        window.dispatchEvent(
+          new CustomEvent("swUpdated", { detail: registration }),
+        );
+
+      if (registration.waiting) {
+        notifyUpdate();
+      }
+
       registration.addEventListener("updatefound", () => {
         const newWorker = registration.installing;
         newWorker?.addEventListener("statechange", () => {
@@ -8,9 +17,7 @@ if ("serviceWorker" in navigator) {
             newWorker.state === "installed" &&
             navigator.serviceWorker.controller
           ) {
-            window.dispatchEvent(
-              new CustomEvent("swUpdated", { detail: registration }),
-            );
+            notifyUpdate();
           }
         });
       });

--- a/src/components/SwUpdateToast.tsx
+++ b/src/components/SwUpdateToast.tsx
@@ -36,7 +36,7 @@ const SwUpdateToast: React.FC = () => {
   if (!visible) return null;
 
   return (
-    <div className="sw-update-toast">
+    <div className="toast sw-update-toast" role="status" aria-live="polite">
       <span>Update available</span>
       <button onClick={refresh}>refresh now</button>
       <button onClick={defer}>remind later</button>


### PR DESCRIPTION
## Summary
- dispatch `swUpdated` event when service worker has an update ready
- show in-app toast offering to refresh or remind later, deferring prompt for the session

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6177fb3688328a991eda4c977291c