### PR TITLE
feat: add accessible on-screen keyboard

### DIFF
--- a/assets/js/keyboard.js
+++ b/assets/js/keyboard.js
@@ -1,0 +1,65 @@
+(function(){
+  function initOnScreenKeyboard(input){
+    const toggleButton = document.getElementById('toggle-keyboard');
+    const keyboard = document.getElementById('special-char-keyboard');
+    if(!toggleButton || !keyboard || !input) return;
+
+    const chars = ['á','é','í','ó','ú','ñ','ü','ç','ø','ß','æ','œ'];
+    const keys = [];
+    chars.forEach((ch, index) => {
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'key';
+      btn.textContent = ch;
+      btn.setAttribute('tabindex', index === 0 ? '0' : '-1');
+      btn.addEventListener('click', () => insertChar(ch));
+      btn.addEventListener('keydown', handleKeydown);
+      keyboard.appendChild(btn);
+      keys.push(btn);
+    });
+
+    const cols = 6;
+
+    function handleKeydown(e){
+      const idx = keys.indexOf(document.activeElement);
+      let next = idx;
+      if(e.key === 'ArrowRight') next = (idx + 1) % keys.length;
+      else if(e.key === 'ArrowLeft') next = (idx - 1 + keys.length) % keys.length;
+      else if(e.key === 'ArrowDown') next = (idx + cols) % keys.length;
+      else if(e.key === 'ArrowUp') next = (idx - cols + keys.length) % keys.length;
+      else if(e.key === 'Escape'){
+        toggle(false);
+        toggleButton.focus();
+        return;
+      } else {
+        return;
+      }
+      keys.forEach(k => k.tabIndex = -1);
+      keys[next].tabIndex = 0;
+      keys[next].focus();
+      e.preventDefault();
+    }
+
+    function insertChar(ch){
+      const start = input.selectionStart || 0;
+      const end = input.selectionEnd || 0;
+      const value = input.value;
+      input.value = value.slice(0,start) + ch + value.slice(end);
+      const pos = start + ch.length;
+      input.focus();
+      input.setSelectionRange(pos, pos);
+      input.dispatchEvent(new Event('input', {bubbles:true}));
+    }
+
+    function toggle(show){
+      keyboard.hidden = !show;
+      toggleButton.setAttribute('aria-expanded', String(show));
+    }
+
+    toggleButton.addEventListener('click', () => {
+      toggle(keyboard.hidden);
+      input.focus();
+    });
+  }
+  window.initOnScreenKeyboard = initOnScreenKeyboard;
+})();

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -23,6 +23,10 @@
     aliases = JSON.parse(localStorage.getItem('aliases') || '{}');
     renderAliasList();
 
+    if (window.initOnScreenKeyboard) {
+      window.initOnScreenKeyboard(searchInput);
+    }
+
     searchInput.addEventListener('input', handleSearch);
     aliasForm.addEventListener('submit', saveAlias);
   });

--- a/search.html
+++ b/search.html
@@ -10,7 +10,11 @@
 <body>
   <main class="container">
     <h1>Search</h1>
-    <input id="search-box" type="text" placeholder="Search terms...">
+    <div class="search-input-wrapper">
+      <input id="search-box" type="text" placeholder="Search terms...">
+      <button id="toggle-keyboard" type="button" aria-label="Toggle special character keyboard" aria-controls="special-char-keyboard" aria-expanded="false">Ω</button>
+    </div>
+    <div id="special-char-keyboard" class="keyboard" role="group" aria-label="Special characters" hidden></div>
     <section id="alias-manager">
       <h2>Aliases</h2>
       <form id="alias-form">
@@ -25,6 +29,7 @@
   <script nonce="__CSP_NONCE__">
     window.__BASE_URL__ = window.__BASE_URL__ || '';
   </script>
+  <script src="assets/js/keyboard.js"></script>
   <script src="assets/js/search.js"></script>
   <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
   <script src="assets/js/metrics.js"></script>

--- a/styles.css
+++ b/styles.css
@@ -327,6 +327,35 @@ label {
   background-color: #0056b3;
 }
 
+.search-input-wrapper {
+  display: flex;
+  gap: 5px;
+  align-items: center;
+}
+
+.search-input-wrapper input {
+  flex: 1;
+}
+
+.search-input-wrapper button {
+  min-width: 44px;
+  min-height: 44px;
+}
+
+.keyboard {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 5px;
+  margin-top: 10px;
+}
+
+.keyboard button {
+  padding: 5px;
+  font-size: 16px;
+  min-width: 44px;
+  min-height: 44px;
+}
+
 /* Skeleton styles */
 .skeleton {
   position: relative;


### PR DESCRIPTION
## Summary
- add toggleable special-character keyboard to search page
- support keyboard navigation and accessible ARIA markup
- style keyboard layout and integrate with search initialization

## Testing
- `pre-commit run --files assets/js/search.js search.html styles.css assets/js/keyboard.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6178572bc832899f724e0321579e9