### PR TITLE
feat: linkable text selections

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -571,3 +571,13 @@ body.dark-mode #alpha-nav button.active {
 .toast.show {
   opacity: 1;
 }
+
+#selection-link-btn {
+  z-index: 1000;
+  font-size: 12px;
+  padding: 4px 8px;
+}
+
+.selection-highlight {
+  background-color: yellow;
+}


### PR DESCRIPTION
## Summary
- allow highlighting terms via URL range parameters and scroll selected text into view
- add floating "Link to this selection" button to copy a range-based URL
- enable text selection by only clearing definitions on outside click

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b617900e788328a3f0e1e14c0358df