### PR TITLE
feat: add settings search index

### DIFF
--- a/src/features/settings/SettingsIndex.ts
+++ b/src/features/settings/SettingsIndex.ts
@@ -1,0 +1,53 @@
+export interface SettingEntry {
+  /** Unique DOM id of the control */
+  id: string;
+  /** Visible label for the setting */
+  label: string;
+  /** Keywords associated with the setting */
+  keywords: string[];
+  /** Id of the section containing the setting */
+  sectionId: string;
+}
+
+/**
+ * Build an index of all settings controls within the given root element.
+ * Controls must declare `data-setting-label` and optionally `data-setting-keywords`.
+ * The closest ancestor with `data-setting-section` is used as the section id.
+ */
+export function buildSettingsIndex(root: HTMLElement): SettingEntry[] {
+  const elements = Array.from(
+    root.querySelectorAll<HTMLElement>('[data-setting-label]')
+  );
+
+  return elements
+    .filter((el) => el.id)
+    .map((el) => {
+      const label = el.dataset.settingLabel || '';
+      const keywords = (el.dataset.settingKeywords || '')
+        .split(',')
+        .map((k) => k.trim())
+        .filter(Boolean);
+      const section = el.closest<HTMLElement>('[data-setting-section]');
+      return {
+        id: el.id,
+        label,
+        keywords,
+        sectionId: section ? section.id : '',
+      };
+    });
+}
+
+/**
+ * Search the settings index using a case-insensitive substring match.
+ */
+export function searchSettings(
+  entries: SettingEntry[],
+  query: string
+): SettingEntry[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return [];
+  return entries.filter((e) => {
+    if (e.label.toLowerCase().includes(q)) return true;
+    return e.keywords.some((k) => k.toLowerCase().includes(q));
+  });
+}

--- a/src/settings/SettingsPage.tsx
+++ b/src/settings/SettingsPage.tsx
@@ -1,0 +1,80 @@
+import React, { useEffect, useRef, useState } from 'react';
+import ColorBlindPalette from './ColorBlindPalette';
+import {
+  buildSettingsIndex,
+  searchSettings,
+  SettingEntry,
+} from '../features/settings/SettingsIndex';
+
+/**
+ * Settings page with client side search. Results update as the user types and
+ * selecting a result expands the relevant section and highlights the control.
+ */
+export default function SettingsPage() {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const indexRef = useRef<SettingEntry[]>([]);
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<SettingEntry[]>([]);
+
+  useEffect(() => {
+    if (rootRef.current) {
+      indexRef.current = buildSettingsIndex(rootRef.current);
+    }
+  }, []);
+
+  useEffect(() => {
+    setResults(searchSettings(indexRef.current, query));
+  }, [query]);
+
+  const handleResultClick = (entry: SettingEntry): void => {
+    const section = document.getElementById(entry.sectionId) as HTMLDetailsElement | null;
+    if (section && section.tagName.toLowerCase() === 'details') {
+      section.open = true;
+    }
+    const el = document.getElementById(entry.id);
+    el?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    if (el) {
+      el.classList.add('setting-highlight');
+      setTimeout(() => el.classList.remove('setting-highlight'), 2000);
+    }
+  };
+
+  return (
+    <div ref={rootRef} className="settings-page">
+      <style>{`.setting-highlight{outline:2px solid #0d6efd;}`}</style>
+      <div className="settings-search">
+        <input
+          type="search"
+          placeholder="Search settings"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+        />
+        {results.length > 0 && (
+          <ul className="settings-search__results">
+            {results.map((r) => (
+              <li key={r.id}>
+                <button type="button" onClick={() => handleResultClick(r)}>
+                  {r.label}
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <details id="appearance" data-setting-section>
+        <summary>Appearance</summary>
+        <div>
+          <label htmlFor="palette">Color palette</label>
+          <div
+            id="palette"
+            data-setting-label="Color palette"
+            data-setting-keywords="color,theme,palette"
+          >
+            <ColorBlindPalette />
+          </div>
+        </div>
+      </details>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- index settings controls by label and keywords
- provide SettingsPage with search that highlights and scrolls to results

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6179503a483289f12e2a001134dab