### PR TITLE
feat(settings): add motion level panel

### DIFF
--- a/script.js
+++ b/script.js
@@ -6,9 +6,21 @@ const alphaNav = document.getElementById("alpha-nav");
 const darkModeToggle = document.getElementById("dark-mode-toggle");
 const showFavoritesToggle = document.getElementById("show-favorites");
 const resetOrderBtn = document.getElementById("reset-order");
-const favorites = new Set(JSON.parse(localStorage.getItem("favorites") || "[]"));
+const favorites = new Set(
+  JSON.parse(localStorage.getItem("favorites") || "[]"),
+);
 const siteUrl = "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/";
 const canonicalLink = document.getElementById("canonical-link");
+
+// Apply stored motion preference
+const motionMap = { none: "0", reduced: "0.5", full: "1" };
+const storedMotion = localStorage.getItem("motion-level");
+if (storedMotion && motionMap[storedMotion]) {
+  document.documentElement.style.setProperty(
+    "--motion-scale",
+    motionMap[storedMotion],
+  );
+}
 
 // --- Search token overlay and help popover setup ---
 const searchWrapper = document.createElement("div");
@@ -30,9 +42,11 @@ searchWrapper.appendChild(tokenOverlay);
 
 // copy font and padding to overlay so text lines up
 const inputStyle = window.getComputedStyle(searchInput);
-["font", "padding", "border", "boxSizing", "lineHeight", "height"].forEach((prop) => {
-  tokenOverlay.style[prop] = inputStyle[prop];
-});
+["font", "padding", "border", "boxSizing", "lineHeight", "height"].forEach(
+  (prop) => {
+    tokenOverlay.style[prop] = inputStyle[prop];
+  },
+);
 searchInput.style.background = "transparent";
 searchInput.style.color = "transparent";
 searchInput.style.caretColor = inputStyle.color;
@@ -46,13 +60,17 @@ helpPopover.style.display = "none";
 document.body.appendChild(helpPopover);
 
 function escapeHtml(str) {
-  return str.replace(/[&<>"']/g, (c) => ({
-    "&": "&amp;",
-    "<": "&lt;",
-    ">": "&gt;",
-    '"': "&quot;",
-    "'": "&#39;",
-  })[c]);
+  return str.replace(
+    /[&<>"']/g,
+    (c) =>
+      ({
+        "&": "&amp;",
+        "<": "&lt;",
+        ">": "&gt;",
+        '"': "&quot;",
+        "'": "&#39;",
+      })[c],
+  );
 }
 
 function tokenize(value) {
@@ -76,7 +94,10 @@ function tokenize(value) {
   let lastType = null;
   tokens.forEach((t, idx) => {
     if (t.type === "space") return;
-    if (t.type === "operator" && (lastType === null || lastType === "operator")) {
+    if (
+      t.type === "operator" &&
+      (lastType === null || lastType === "operator")
+    ) {
       t.error = true;
     }
     if (idx === tokens.length - 1 && t.type === "operator") {
@@ -123,7 +144,10 @@ function getCaretCoordinates(input) {
   const x = div.offsetWidth;
   document.body.removeChild(div);
   const rect = input.getBoundingClientRect();
-  return { x: rect.left + x - input.scrollLeft + window.scrollX, y: rect.top + rect.height + window.scrollY };
+  return {
+    x: rect.left + x - input.scrollLeft + window.scrollX,
+    y: rect.top + rect.height + window.scrollY,
+  };
 }
 
 function positionHelp() {
@@ -142,7 +166,7 @@ searchInput.addEventListener("focus", () => {
   searchInput.addEventListener(evt, () => {
     positionHelp();
     updateTokens();
-  })
+  }),
 );
 
 searchInput.addEventListener("blur", () => {
@@ -160,7 +184,10 @@ if (localStorage.getItem("darkMode") === "true") {
 if (darkModeToggle) {
   darkModeToggle.addEventListener("click", () => {
     document.body.classList.toggle("dark-mode");
-    localStorage.setItem("darkMode", document.body.classList.contains("dark-mode"));
+    localStorage.setItem(
+      "darkMode",
+      document.body.classList.contains("dark-mode"),
+    );
   });
 }
 
@@ -217,9 +244,11 @@ function loadTerms() {
       populateTermsList();
 
       if (window.location.hash) {
-        const termFromHash = decodeURIComponent(window.location.hash.substring(1));
+        const termFromHash = decodeURIComponent(
+          window.location.hash.substring(1),
+        );
         const matchedTerm = termsData.terms.find(
-          (t) => t.term.toLowerCase() === termFromHash.toLowerCase()
+          (t) => t.term.toLowerCase() === termFromHash.toLowerCase(),
         );
         if (matchedTerm) {
           displayDefinition(matchedTerm);
@@ -230,7 +259,7 @@ function loadTerms() {
       console.error("Detailed error fetching data:", error);
       definitionContainer.style.display = "block";
       definitionContainer.innerHTML =
-        '<p>Unable to load dictionary data. Please check your connection and try again.</p>' +
+        "<p>Unable to load dictionary data. Please check your connection and try again.</p>" +
         '<button id="retry-fetch">Retry</button>';
       const retryBtn = document.getElementById("retry-fetch");
       if (retryBtn) {
@@ -294,12 +323,16 @@ function saveRating(term, value) {
 }
 
 function highlightActiveButton(button) {
-  alphaNav.querySelectorAll("button").forEach((btn) => btn.classList.remove("active"));
+  alphaNav
+    .querySelectorAll("button")
+    .forEach((btn) => btn.classList.remove("active"));
   button.classList.add("active");
 }
 
 function buildAlphaNav() {
-  const letters = Array.from(new Set(termsData.terms.map((t) => t.term.charAt(0).toUpperCase()))).sort();
+  const letters = Array.from(
+    new Set(termsData.terms.map((t) => t.term.charAt(0).toUpperCase())),
+  ).sort();
 
   const allButton = document.createElement("button");
   allButton.textContent = "All";
@@ -328,63 +361,70 @@ function populateTermsList() {
   termsList.innerHTML = "";
   const searchValue = searchInput.value.trim().toLowerCase();
   termsData.terms.forEach((item) => {
-      const matchesSearch = item.term.toLowerCase().includes(searchValue);
-      const matchesFavorites = !showFavoritesToggle || !showFavoritesToggle.checked || favorites.has(item.term);
-      const matchesLetter =
-        currentLetterFilter === "All" || item.term.charAt(0).toUpperCase() === currentLetterFilter;
-      if (matchesSearch && matchesFavorites && matchesLetter) {
-        const termDiv = document.createElement("div");
-        termDiv.classList.add("dictionary-item");
-        termDiv.dataset.term = item.term;
-        termDiv.draggable = true;
-        termDiv.tabIndex = 0;
-        termDiv.addEventListener("dragstart", handleDragStart);
-        termDiv.addEventListener("dragover", handleDragOver);
-        termDiv.addEventListener("drop", handleDrop);
-        termDiv.addEventListener("keydown", handleKeyDown);
+    const matchesSearch = item.term.toLowerCase().includes(searchValue);
+    const matchesFavorites =
+      !showFavoritesToggle ||
+      !showFavoritesToggle.checked ||
+      favorites.has(item.term);
+    const matchesLetter =
+      currentLetterFilter === "All" ||
+      item.term.charAt(0).toUpperCase() === currentLetterFilter;
+    if (matchesSearch && matchesFavorites && matchesLetter) {
+      const termDiv = document.createElement("div");
+      termDiv.classList.add("dictionary-item");
+      termDiv.dataset.term = item.term;
+      termDiv.draggable = true;
+      termDiv.tabIndex = 0;
+      termDiv.addEventListener("dragstart", handleDragStart);
+      termDiv.addEventListener("dragover", handleDragOver);
+      termDiv.addEventListener("drop", handleDrop);
+      termDiv.addEventListener("keydown", handleKeyDown);
 
-        const termHeader = document.createElement("h3");
-        if (searchValue) {
-          const escaped = searchValue.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-          const regex = new RegExp(`(${escaped})`, "gi");
-          termHeader.innerHTML = item.term.replace(regex, "<mark>$1</mark>");
-        } else {
-          termHeader.textContent = item.term;
-        }
-
-        const star = document.createElement("span");
-        star.classList.add("favorite-star");
-        star.textContent = "★";
-        if (favorites.has(item.term)) {
-          star.classList.add("favorited");
-        }
-        star.addEventListener("click", (e) => {
-          e.stopPropagation();
-          toggleFavorite(item.term);
-          star.classList.toggle("favorited");
-          if (showFavoritesToggle && showFavoritesToggle.checked) {
-            populateTermsList();
-          }
-        });
-        termHeader.appendChild(star);
-        termDiv.appendChild(termHeader);
-
-        const definitionPara = document.createElement("p");
-        definitionPara.textContent = item.definition;
-        termDiv.appendChild(definitionPara);
-
-        termDiv.addEventListener("click", () => {
-          displayDefinition(item);
-        });
-
-        termsList.appendChild(termDiv);
+      const termHeader = document.createElement("h3");
+      if (searchValue) {
+        const escaped = searchValue.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+        const regex = new RegExp(`(${escaped})`, "gi");
+        termHeader.innerHTML = item.term.replace(regex, "<mark>$1</mark>");
+      } else {
+        termHeader.textContent = item.term;
       }
-    });
+
+      const star = document.createElement("span");
+      star.classList.add("favorite-star");
+      star.textContent = "★";
+      if (favorites.has(item.term)) {
+        star.classList.add("favorited");
+      }
+      star.addEventListener("click", (e) => {
+        e.stopPropagation();
+        toggleFavorite(item.term);
+        star.classList.toggle("favorited");
+        if (showFavoritesToggle && showFavoritesToggle.checked) {
+          populateTermsList();
+        }
+      });
+      termHeader.appendChild(star);
+      termDiv.appendChild(termHeader);
+
+      const definitionPara = document.createElement("p");
+      definitionPara.textContent = item.definition;
+      termDiv.appendChild(definitionPara);
+
+      termDiv.addEventListener("click", () => {
+        displayDefinition(item);
+      });
+
+      termsList.appendChild(termDiv);
+    }
+  });
 }
 
 function saveOrder() {
   try {
-    localStorage.setItem("termOrder", JSON.stringify(termsData.terms.map((t) => t.term)));
+    localStorage.setItem(
+      "termOrder",
+      JSON.stringify(termsData.terms.map((t) => t.term)),
+    );
   } catch (e) {
     // Ignore storage errors
   }
@@ -450,7 +490,7 @@ function displayDefinition(term) {
   if (canonicalLink) {
     canonicalLink.setAttribute(
       "href",
-      `${siteUrl}#${encodeURIComponent(term.term)}`
+      `${siteUrl}#${encodeURIComponent(term.term)}`,
     );
   }
   const starElems = definitionContainer.querySelectorAll(".rating-star");
@@ -470,7 +510,11 @@ function displayDefinition(term) {
 function clearDefinition() {
   definitionContainer.style.display = "none";
   definitionContainer.innerHTML = "";
-  history.replaceState(null, "", window.location.pathname + window.location.search);
+  history.replaceState(
+    null,
+    "",
+    window.location.pathname + window.location.search,
+  );
   if (canonicalLink) {
     canonicalLink.setAttribute("href", siteUrl);
   }
@@ -488,7 +532,10 @@ function showRandomTerm() {
 
   const today = new Date().toDateString();
   try {
-    localStorage.setItem("lastRandomTerm", JSON.stringify({ date: today, term: randomTerm }));
+    localStorage.setItem(
+      "lastRandomTerm",
+      JSON.stringify({ date: today, term: randomTerm }),
+    );
   } catch (e) {
     // Ignore storage errors
   }
@@ -530,7 +577,7 @@ window.addEventListener("scroll", () => {
   scrollBtn.style.display = window.scrollY > 200 ? "block" : "none";
 });
 scrollBtn.addEventListener("click", () =>
-  window.scrollTo({ top: 0, behavior: "smooth" })
+  window.scrollTo({ top: 0, behavior: "smooth" }),
 );
 
 definitionContainer.addEventListener("click", clearDefinition);
@@ -584,10 +631,9 @@ function startExport() {
     if (index + chunkSize < total) {
       setTimeout(() => processChunk(index + chunkSize), 0);
     } else {
-      const blob = new Blob(
-        [JSON.stringify({ terms: data }, null, 2)],
-        { type: "application/json" }
-      );
+      const blob = new Blob([JSON.stringify({ terms: data }, null, 2)], {
+        type: "application/json",
+      });
       const url = URL.createObjectURL(blob);
       const a = document.createElement("a");
       a.href = url;
@@ -609,4 +655,3 @@ if (exportBtn && cancelExportBtn) {
     }
   });
 }
-

--- a/src/settings/MotionLevel.tsx
+++ b/src/settings/MotionLevel.tsx
@@ -1,0 +1,64 @@
+import React, { useEffect, useState } from "react";
+
+interface Level {
+  id: string;
+  label: string;
+  scale: number;
+}
+
+const levels: Level[] = [
+  { id: "none", label: "No Motion", scale: 0 },
+  { id: "reduced", label: "Reduced Motion", scale: 0.5 },
+  { id: "full", label: "Full Motion", scale: 1 },
+];
+
+const storageKey = "motion-level";
+
+export default function MotionLevel() {
+  const [current, setCurrent] = useState<Level>(() => {
+    const stored = localStorage.getItem(storageKey);
+    return levels.find((l) => l.id === stored) || levels[2];
+  });
+
+  useEffect(() => {
+    document.documentElement.style.setProperty(
+      "--motion-scale",
+      String(current.scale),
+    );
+    localStorage.setItem(storageKey, current.id);
+  }, [current]);
+
+  return (
+    <div style={{ display: "flex", gap: "0.5rem" }}>
+      {levels.map((level) => (
+        <button
+          key={level.id}
+          onClick={() => setCurrent(level)}
+          style={{
+            padding: "0.5rem",
+            border:
+              current.id === level.id ? "2px solid #000" : "1px solid #ccc",
+            cursor: "pointer",
+            textAlign: "center",
+          }}
+          aria-pressed={current.id === level.id}
+        >
+          <div
+            style={{
+              width: 20,
+              height: 20,
+              margin: "0 auto 0.25rem",
+              borderRadius: "50%",
+              background: "#007bff",
+              animation:
+                level.scale === 0
+                  ? "none"
+                  : `spin ${level.scale}s linear infinite`,
+            }}
+          />
+          <span>{level.label}</span>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/styles.css
+++ b/styles.css
@@ -7,6 +7,7 @@
 :root {
   --skeleton-bg: #e5e7eb;
   --skeleton-fg: #6b7280;
+  --motion-scale: 1;
 }
 
 body.dark-mode {
@@ -35,7 +36,7 @@ body {
 
 h1 {
   text-align: center;
-  font-family: 'Cinzel', serif;
+  font-family: "Cinzel", serif;
   font-weight: 700;
   font-size: 48px;
   margin-bottom: 20px;
@@ -169,7 +170,6 @@ body.dark-mode #search-help {
   border-color: #555;
 }
 
-
 /* Controls styling */
 #random-term {
   margin-top: 10px;
@@ -291,7 +291,9 @@ label {
   border-radius: 4px;
   padding: 10px;
   cursor: pointer;
-  transition: background-color 0.2s, color 0.2s;
+  transition:
+    background-color 0.2s,
+    color 0.2s;
   min-width: 44px;
   min-height: 44px;
 }
@@ -341,8 +343,13 @@ label {
   position: absolute;
   inset: 0;
   transform: translateX(-100%);
-  background-image: linear-gradient(90deg, transparent, var(--skeleton-fg), transparent);
-  animation: skeleton-shimmer 1.5s infinite;
+  background-image: linear-gradient(
+    90deg,
+    transparent,
+    var(--skeleton-fg),
+    transparent
+  );
+  animation: skeleton-shimmer calc(var(--motion-scale) * 1.5s) infinite;
 }
 
 @keyframes skeleton-shimmer {
@@ -455,7 +462,7 @@ body.dark-mode #alpha-nav button.active {
 
 .hidden-history.revealed {
   display: table-row;
-  animation: fade-in 0.3s ease;
+  animation: fade-in calc(var(--motion-scale) * 0.3s) ease;
 }
 
 @keyframes fade-in {
@@ -472,14 +479,14 @@ body.dark-mode #alpha-nav button.active {
 }
 
 .history-fold::after {
-  content: '';
+  content: "";
   position: absolute;
   top: 0;
   right: 0;
   width: 12px;
   height: 12px;
   background: linear-gradient(45deg, #eee 50%, transparent 50%);
-  animation: fold-pulse 3s ease-in-out infinite;
+  animation: fold-pulse calc(var(--motion-scale) * 3s) ease-in-out infinite;
 }
 
 @keyframes fold-pulse {
@@ -536,7 +543,7 @@ body.dark-mode #alpha-nav button.active {
   border: 4px solid #ccc;
   border-top-color: #007bff;
   border-radius: 50%;
-  animation: spin 1s linear infinite;
+  animation: spin calc(var(--motion-scale) * 1s) linear infinite;
   -webkit-appearance: none;
   appearance: none;
   background: transparent;


### PR DESCRIPTION
## Summary
- add motion level selector with sample animations and persistence
- tie global animation durations to --motion-scale variable
- load stored motion preference on startup

## Testing
- `npx prettier styles.css script.js src/settings/MotionLevel.tsx --write`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b61792fcc4832887f2a8f0f5fff226