### PR TITLE
feat: add g-based navigation shortcuts

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -17,3 +17,29 @@ if ("serviceWorker" in navigator) {
     });
   });
 }
+
+// --- Global key sequence handler ---
+const KEY_SEQ_TIMEOUT = 1000;
+let pendingG = false;
+let gTimer;
+
+window.addEventListener("keydown", (e) => {
+  const key = e.key.toLowerCase();
+  if (pendingG) {
+    pendingG = false;
+    clearTimeout(gTimer);
+    if (key === "t") {
+      window.location.href = "/";
+    } else if (key === "c") {
+      window.location.href = "/collections";
+    }
+    return;
+  }
+
+  if (key === "g") {
+    pendingG = true;
+    gTimer = setTimeout(() => {
+      pendingG = false;
+    }, KEY_SEQ_TIMEOUT);
+  }
+});

--- a/src/components/ShortcutCheatsheet.tsx
+++ b/src/components/ShortcutCheatsheet.tsx
@@ -9,6 +9,8 @@ const SHORTCUTS: Shortcut[] = [
   { keys: "Shift+/", description: "Open shortcut help" },
   { keys: "Ctrl+F", description: "Search" },
   { keys: "Esc", description: "Close overlay" },
+  { keys: "g then t", description: "Go to term list" },
+  { keys: "g then c", description: "Go to collections" },
 ];
 
 export default function ShortcutCheatsheet() {


### PR DESCRIPTION
## Summary
- add global handler for `g` key sequences
- document `g then t` and `g then c` in shortcut cheat sheet

## Testing
- `npm test`
- `pre-commit run --files assets/js/app.js src/components/ShortcutCheatsheet.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68b617912ef8832885bb2e1e9e8b5970