### PR TITLE
feat: add reading queue for terms

### DIFF
--- a/app/terms/[slug]/page.tsx
+++ b/app/terms/[slug]/page.tsx
@@ -1,6 +1,9 @@
-import React from "react";
+"use client";
+
+import React, { useEffect, useState } from "react";
 import terms from "../../../terms.json";
 import { FAQBlock } from "../../components/FAQBlock";
+import { readingQueue } from "../../../src/features/queue/ReadingQueue";
 
 function slugify(term: string) {
   return term
@@ -31,10 +34,28 @@ export default function TermPage({ params }: { params: { slug: string } }) {
     },
   ];
 
+  const [counts, setCounts] = useState(readingQueue.counts());
+
+  useEffect(() => {
+    return readingQueue.subscribe(() => setCounts(readingQueue.counts()));
+  }, []);
+
+  const queueNext = () => readingQueue.add("nextUp", term.term);
+  const queueLater = () => readingQueue.add("later", term.term);
+
   return (
     <main>
+      <header style={{ display: "flex", justifyContent: "flex-end" }}>
+        <span aria-label="Reading queue" title="Reading queue">
+          📚 {counts.nextUp + counts.later}
+        </span>
+      </header>
       <h1>{term.term}</h1>
       <p>{term.definition}</p>
+      <div style={{ display: "flex", gap: "0.5rem" }}>
+        <button onClick={queueNext}>Queue Next</button>
+        <button onClick={queueLater}>Queue Later</button>
+      </div>
       <FAQBlock items={faqItems} />
       <script
         type="application/ld+json"

--- a/src/features/queue/ReadingQueue.ts
+++ b/src/features/queue/ReadingQueue.ts
@@ -1,0 +1,92 @@
+export type QueueList = "nextUp" | "later";
+
+export interface QueueState {
+  nextUp: string[];
+  later: string[];
+}
+
+/**
+ * Simple reading queue supporting two lists: `nextUp` and `later`.
+ * State is persisted to localStorage and components can subscribe to changes.
+ */
+export class ReadingQueue {
+  private static STORAGE_KEY = "readingQueue";
+
+  private state: QueueState;
+  private listeners = new Set<() => void>();
+
+  constructor() {
+    this.state = { nextUp: [], later: [] };
+    if (typeof window !== "undefined") {
+      try {
+        const stored = window.localStorage.getItem(ReadingQueue.STORAGE_KEY);
+        if (stored) {
+          const parsed = JSON.parse(stored);
+          if (parsed.nextUp && parsed.later) {
+            this.state = {
+              nextUp: Array.isArray(parsed.nextUp) ? parsed.nextUp : [],
+              later: Array.isArray(parsed.later) ? parsed.later : [],
+            };
+          }
+        }
+      } catch {
+        // ignore parse errors
+      }
+    }
+  }
+
+  private save() {
+    try {
+      window.localStorage.setItem(
+        ReadingQueue.STORAGE_KEY,
+        JSON.stringify(this.state),
+      );
+    } catch {
+      // ignore storage errors
+    }
+  }
+
+  private notify() {
+    for (const l of this.listeners) l();
+  }
+
+  subscribe(listener: () => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  getState(): QueueState {
+    return {
+      nextUp: [...this.state.nextUp],
+      later: [...this.state.later],
+    };
+  }
+
+  counts(): { nextUp: number; later: number } {
+    return {
+      nextUp: this.state.nextUp.length,
+      later: this.state.later.length,
+    };
+  }
+
+  add(list: QueueList, term: string) {
+    const arr = this.state[list];
+    if (!arr.includes(term)) {
+      arr.push(term);
+      this.save();
+      this.notify();
+    }
+  }
+
+  remove(list: QueueList, term: string) {
+    const arr = this.state[list];
+    const idx = arr.indexOf(term);
+    if (idx !== -1) {
+      arr.splice(idx, 1);
+      this.save();
+      this.notify();
+    }
+  }
+}
+
+export const readingQueue = new ReadingQueue();


### PR DESCRIPTION
## Summary
- add ReadingQueue store with nextUp and later lists
- show queue counts and actions on term page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b61796d7ac832881d26bab47cc8c16