### PR TITLE
feat: add pro mode toggle

### DIFF
--- a/assets/js/pro.js
+++ b/assets/js/pro.js
@@ -1,0 +1,53 @@
+(function(){
+  const STORAGE_KEY = 'proMode';
+  const PARAM = 'pro';
+
+  function updateUrl(enabled){
+    const url = new URL(window.location.href);
+    if(enabled){
+      url.searchParams.set(PARAM,'1');
+    } else {
+      url.searchParams.delete(PARAM);
+    }
+    window.history.replaceState({}, '', url);
+  }
+
+  function isEnabled(){
+    const params = new URLSearchParams(window.location.search);
+    if(params.get(PARAM) === '1'){
+      localStorage.setItem(STORAGE_KEY, '1');
+      return true;
+    }
+    return localStorage.getItem(STORAGE_KEY) === '1';
+  }
+
+  function applyVisibility(){
+    const enabled = isEnabled();
+    updateUrl(enabled);
+    document.querySelectorAll('[data-pro-only]').forEach(el => {
+      el.style.display = enabled ? '' : 'none';
+    });
+    const toggle = document.getElementById('pro-toggle');
+    if(toggle){
+      toggle.checked = enabled;
+    }
+  }
+
+  function setupToggle(){
+    const toggle = document.getElementById('pro-toggle');
+    if(!toggle) return;
+    toggle.addEventListener('change', () => {
+      const enabled = toggle.checked;
+      if(enabled){
+        localStorage.setItem(STORAGE_KEY, '1');
+      }else{
+        localStorage.removeItem(STORAGE_KEY);
+      }
+      updateUrl(enabled);
+      applyVisibility();
+    });
+  }
+
+  applyVisibility();
+  setupToggle();
+})();

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
 <body>
   <main class="container">
     <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav" aria-label="Site links"><a href="templates/guidelines.html">Definition Guidelines</a> | <a href="categories.html">Category Map</a></nav>
+    <nav class="site-nav" aria-label="Site links"><a href="templates/guidelines.html">Definition Guidelines</a> | <a href="categories.html">Category Map</a> | <a href="settings.html">Settings</a></nav>
     <div id="definition-container" style="display: none;"></div>
     <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
     <input type="text" id="search" placeholder="Search...">
@@ -22,13 +22,13 @@
     <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">Toggle Dark Mode</button>
     <input type="checkbox" id="show-favorites" aria-label="Show favorites">
     <label for="show-favorites">Show Favorites</label>
-    <button id="export-terms" type="button" aria-label="Export terms">Export Terms</button>
-    <div id="export-status" class="export-status" hidden>
+    <button id="export-terms" type="button" aria-label="Export terms" data-pro-only>Export Terms</button>
+    <div id="export-status" class="export-status" hidden data-pro-only>
       <progress id="export-progress" class="progress-ring" aria-label="Exporting"></progress>
       <button id="cancel-export" type="button" aria-label="Cancel export">Cancel</button>
     </div>
 
-    <button id="reset-order" type="button" aria-label="Reset term order">Reset Order</button>
+    <button id="reset-order" type="button" aria-label="Reset term order" data-pro-only>Reset Order</button>
 
     <ul id="terms-list"></ul>
   </main>
@@ -41,6 +41,7 @@
     <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
   </footer>
   <div id="toast" class="toast" role="status" aria-live="polite" hidden></div>
+  <script src="assets/js/pro.js"></script>
   <script src="script.js"></script>
   <script src="assets/js/app.js"></script>
   <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>

--- a/search.html
+++ b/search.html
@@ -11,7 +11,7 @@
   <main class="container">
     <h1>Search</h1>
     <input id="search-box" type="text" placeholder="Search terms...">
-    <section id="alias-manager">
+    <section id="alias-manager" data-pro-only>
       <h2>Aliases</h2>
       <form id="alias-form">
         <input id="alias-name" type="text" placeholder="Alias">
@@ -25,6 +25,7 @@
   <script nonce="__CSP_NONCE__">
     window.__BASE_URL__ = window.__BASE_URL__ || '';
   </script>
+  <script src="assets/js/pro.js"></script>
   <script src="assets/js/search.js"></script>
   <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
   <script src="assets/js/metrics.js"></script>

--- a/settings.html
+++ b/settings.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Settings</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <main class="container">
+    <h1>Settings</h1>
+    <label for="pro-toggle"><input id="pro-toggle" type="checkbox"> Enable Pro Mode</label>
+  </main>
+  <script src="assets/js/pro.js"></script>
+  <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
+  <script src="assets/js/metrics.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add standalone settings page with pro-mode switch
- persist pro state in localStorage and `?pro=1` URL param
- hide advanced controls unless pro mode enabled

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6179daf6083289031bae9ba79c3d0