### PR TITLE
feat: add settings reset with undo

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,50 +1,86 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Cyber Security Dictionary</title>
-  <script src="assets/js/preconnect.js"></script>
-  <link rel="stylesheet" href="styles.css">
-  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet">
-  <link rel="canonical" id="canonical-link" href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/">
-</head>
-<body>
-  <main class="container">
-    <h1>Cyber Security Dictionary</h1>
-    <nav class="site-nav" aria-label="Site links"><a href="templates/guidelines.html">Definition Guidelines</a> | <a href="categories.html">Category Map</a></nav>
-    <div id="definition-container" style="display: none;"></div>
-    <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
-    <input type="text" id="search" placeholder="Search...">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cyber Security Dictionary</title>
+    <script src="assets/js/preconnect.js"></script>
+    <link rel="stylesheet" href="styles.css">
+    <link
+      href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap"
+      rel="stylesheet"
+    >
+    <link
+      rel="canonical"
+      id="canonical-link"
+      href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/"
+    >
+  </head>
+  <body>
+    <main class="container">
+      <h1>Cyber Security Dictionary</h1>
+      <nav class="site-nav" aria-label="Site links">
+        <a href="templates/guidelines.html">Definition Guidelines</a> |
+        <a href="categories.html">Category Map</a>
+      </nav>
+      <div id="definition-container" style="display: none"></div>
+      <nav id="alpha-nav" aria-label="Alphabet navigation"></nav>
+      <input type="text" id="search" placeholder="Search...">
 
-    <button id="random-term" type="button" aria-label="Show random term">Random Term</button>
+      <button id="random-term" type="button" aria-label="Show random term">
+        Random Term
+      </button>
 
-    <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">Toggle Dark Mode</button>
-    <input type="checkbox" id="show-favorites" aria-label="Show favorites">
-    <label for="show-favorites">Show Favorites</label>
-    <button id="export-terms" type="button" aria-label="Export terms">Export Terms</button>
-    <div id="export-status" class="export-status" hidden>
-      <progress id="export-progress" class="progress-ring" aria-label="Exporting"></progress>
-      <button id="cancel-export" type="button" aria-label="Cancel export">Cancel</button>
-    </div>
+      <button id="dark-mode-toggle" type="button" aria-label="Toggle dark mode">
+        Toggle Dark Mode
+      </button>
+      <input type="checkbox" id="show-favorites" aria-label="Show favorites">
+      <label for="show-favorites">Show Favorites</label>
+      <button id="export-terms" type="button" aria-label="Export terms">
+        Export Terms
+      </button>
+      <div id="export-status" class="export-status" hidden>
+        <progress
+          id="export-progress"
+          class="progress-ring"
+          aria-label="Exporting"
+        ></progress>
+        <button id="cancel-export" type="button" aria-label="Cancel export">
+          Cancel
+        </button>
+      </div>
 
-    <button id="reset-order" type="button" aria-label="Reset term order">Reset Order</button>
+      <button id="reset-order" type="button" aria-label="Reset term order">
+        Reset Order
+      </button>
 
-    <ul id="terms-list"></ul>
-  </main>
-  <footer class="container" aria-label="Contribute">
-    <p><a href="templates/contribute.html">Contribute</a></p>
-  </footer>
-  <button id="scrollToTopBtn" type="button" aria-label="Scroll to top">↑</button>
+      <button id="reset-settings" type="button" aria-label="Reset settings">
+        Reset Settings
+      </button>
 
-  <footer aria-label="Project contribution">
-    <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
-  </footer>
-  <div id="toast" class="toast" role="status" aria-live="polite" hidden></div>
-  <script src="script.js"></script>
-  <script src="assets/js/app.js"></script>
-  <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
-  <script src="assets/js/metrics.js"></script>
-</body>
+      <ul id="terms-list"></ul>
+    </main>
+    <footer class="container" aria-label="Contribute">
+      <p><a href="templates/contribute.html">Contribute</a></p>
+    </footer>
+    <button id="scrollToTopBtn" type="button" aria-label="Scroll to top">
+      ↑
+    </button>
+
+    <footer aria-label="Project contribution">
+      <p><a href="CONTRIBUTING.md">Contribute to this project</a></p>
+    </footer>
+    <div id="toast" class="toast" role="status" aria-live="polite" hidden></div>
+    <div
+      id="snackbar"
+      class="snackbar"
+      role="status"
+      aria-live="polite"
+      hidden
+    ></div>
+    <script src="script.js"></script>
+    <script src="assets/js/app.js"></script>
+    <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
+    <script src="assets/js/metrics.js"></script>
+  </body>
 </html>
-

--- a/script.js
+++ b/script.js
@@ -6,7 +6,11 @@ const alphaNav = document.getElementById("alpha-nav");
 const darkModeToggle = document.getElementById("dark-mode-toggle");
 const showFavoritesToggle = document.getElementById("show-favorites");
 const resetOrderBtn = document.getElementById("reset-order");
-const favorites = new Set(JSON.parse(localStorage.getItem("favorites") || "[]"));
+const resetSettingsBtn = document.getElementById("reset-settings");
+const snackbar = document.getElementById("snackbar");
+const favorites = new Set(
+  JSON.parse(localStorage.getItem("favorites") || "[]"),
+);
 const siteUrl = "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/";
 const canonicalLink = document.getElementById("canonical-link");
 
@@ -30,9 +34,11 @@ searchWrapper.appendChild(tokenOverlay);
 
 // copy font and padding to overlay so text lines up
 const inputStyle = window.getComputedStyle(searchInput);
-["font", "padding", "border", "boxSizing", "lineHeight", "height"].forEach((prop) => {
-  tokenOverlay.style[prop] = inputStyle[prop];
-});
+["font", "padding", "border", "boxSizing", "lineHeight", "height"].forEach(
+  (prop) => {
+    tokenOverlay.style[prop] = inputStyle[prop];
+  },
+);
 searchInput.style.background = "transparent";
 searchInput.style.color = "transparent";
 searchInput.style.caretColor = inputStyle.color;
@@ -46,13 +52,17 @@ helpPopover.style.display = "none";
 document.body.appendChild(helpPopover);
 
 function escapeHtml(str) {
-  return str.replace(/[&<>"']/g, (c) => ({
-    "&": "&amp;",
-    "<": "&lt;",
-    ">": "&gt;",
-    '"': "&quot;",
-    "'": "&#39;",
-  })[c]);
+  return str.replace(
+    /[&<>"']/g,
+    (c) =>
+      ({
+        "&": "&amp;",
+        "<": "&lt;",
+        ">": "&gt;",
+        '"': "&quot;",
+        "'": "&#39;",
+      })[c],
+  );
 }
 
 function tokenize(value) {
@@ -76,7 +86,10 @@ function tokenize(value) {
   let lastType = null;
   tokens.forEach((t, idx) => {
     if (t.type === "space") return;
-    if (t.type === "operator" && (lastType === null || lastType === "operator")) {
+    if (
+      t.type === "operator" &&
+      (lastType === null || lastType === "operator")
+    ) {
       t.error = true;
     }
     if (idx === tokens.length - 1 && t.type === "operator") {
@@ -123,7 +136,10 @@ function getCaretCoordinates(input) {
   const x = div.offsetWidth;
   document.body.removeChild(div);
   const rect = input.getBoundingClientRect();
-  return { x: rect.left + x - input.scrollLeft + window.scrollX, y: rect.top + rect.height + window.scrollY };
+  return {
+    x: rect.left + x - input.scrollLeft + window.scrollX,
+    y: rect.top + rect.height + window.scrollY,
+  };
 }
 
 function positionHelp() {
@@ -142,7 +158,7 @@ searchInput.addEventListener("focus", () => {
   searchInput.addEventListener(evt, () => {
     positionHelp();
     updateTokens();
-  })
+  }),
 );
 
 searchInput.addEventListener("blur", () => {
@@ -160,7 +176,10 @@ if (localStorage.getItem("darkMode") === "true") {
 if (darkModeToggle) {
   darkModeToggle.addEventListener("click", () => {
     document.body.classList.toggle("dark-mode");
-    localStorage.setItem("darkMode", document.body.classList.contains("dark-mode"));
+    localStorage.setItem(
+      "darkMode",
+      document.body.classList.contains("dark-mode"),
+    );
   });
 }
 
@@ -217,9 +236,11 @@ function loadTerms() {
       populateTermsList();
 
       if (window.location.hash) {
-        const termFromHash = decodeURIComponent(window.location.hash.substring(1));
+        const termFromHash = decodeURIComponent(
+          window.location.hash.substring(1),
+        );
         const matchedTerm = termsData.terms.find(
-          (t) => t.term.toLowerCase() === termFromHash.toLowerCase()
+          (t) => t.term.toLowerCase() === termFromHash.toLowerCase(),
         );
         if (matchedTerm) {
           displayDefinition(matchedTerm);
@@ -230,7 +251,7 @@ function loadTerms() {
       console.error("Detailed error fetching data:", error);
       definitionContainer.style.display = "block";
       definitionContainer.innerHTML =
-        '<p>Unable to load dictionary data. Please check your connection and try again.</p>' +
+        "<p>Unable to load dictionary data. Please check your connection and try again.</p>" +
         '<button id="retry-fetch">Retry</button>';
       const retryBtn = document.getElementById("retry-fetch");
       if (retryBtn) {
@@ -294,12 +315,16 @@ function saveRating(term, value) {
 }
 
 function highlightActiveButton(button) {
-  alphaNav.querySelectorAll("button").forEach((btn) => btn.classList.remove("active"));
+  alphaNav
+    .querySelectorAll("button")
+    .forEach((btn) => btn.classList.remove("active"));
   button.classList.add("active");
 }
 
 function buildAlphaNav() {
-  const letters = Array.from(new Set(termsData.terms.map((t) => t.term.charAt(0).toUpperCase()))).sort();
+  const letters = Array.from(
+    new Set(termsData.terms.map((t) => t.term.charAt(0).toUpperCase())),
+  ).sort();
 
   const allButton = document.createElement("button");
   allButton.textContent = "All";
@@ -328,63 +353,70 @@ function populateTermsList() {
   termsList.innerHTML = "";
   const searchValue = searchInput.value.trim().toLowerCase();
   termsData.terms.forEach((item) => {
-      const matchesSearch = item.term.toLowerCase().includes(searchValue);
-      const matchesFavorites = !showFavoritesToggle || !showFavoritesToggle.checked || favorites.has(item.term);
-      const matchesLetter =
-        currentLetterFilter === "All" || item.term.charAt(0).toUpperCase() === currentLetterFilter;
-      if (matchesSearch && matchesFavorites && matchesLetter) {
-        const termDiv = document.createElement("div");
-        termDiv.classList.add("dictionary-item");
-        termDiv.dataset.term = item.term;
-        termDiv.draggable = true;
-        termDiv.tabIndex = 0;
-        termDiv.addEventListener("dragstart", handleDragStart);
-        termDiv.addEventListener("dragover", handleDragOver);
-        termDiv.addEventListener("drop", handleDrop);
-        termDiv.addEventListener("keydown", handleKeyDown);
+    const matchesSearch = item.term.toLowerCase().includes(searchValue);
+    const matchesFavorites =
+      !showFavoritesToggle ||
+      !showFavoritesToggle.checked ||
+      favorites.has(item.term);
+    const matchesLetter =
+      currentLetterFilter === "All" ||
+      item.term.charAt(0).toUpperCase() === currentLetterFilter;
+    if (matchesSearch && matchesFavorites && matchesLetter) {
+      const termDiv = document.createElement("div");
+      termDiv.classList.add("dictionary-item");
+      termDiv.dataset.term = item.term;
+      termDiv.draggable = true;
+      termDiv.tabIndex = 0;
+      termDiv.addEventListener("dragstart", handleDragStart);
+      termDiv.addEventListener("dragover", handleDragOver);
+      termDiv.addEventListener("drop", handleDrop);
+      termDiv.addEventListener("keydown", handleKeyDown);
 
-        const termHeader = document.createElement("h3");
-        if (searchValue) {
-          const escaped = searchValue.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-          const regex = new RegExp(`(${escaped})`, "gi");
-          termHeader.innerHTML = item.term.replace(regex, "<mark>$1</mark>");
-        } else {
-          termHeader.textContent = item.term;
-        }
-
-        const star = document.createElement("span");
-        star.classList.add("favorite-star");
-        star.textContent = "★";
-        if (favorites.has(item.term)) {
-          star.classList.add("favorited");
-        }
-        star.addEventListener("click", (e) => {
-          e.stopPropagation();
-          toggleFavorite(item.term);
-          star.classList.toggle("favorited");
-          if (showFavoritesToggle && showFavoritesToggle.checked) {
-            populateTermsList();
-          }
-        });
-        termHeader.appendChild(star);
-        termDiv.appendChild(termHeader);
-
-        const definitionPara = document.createElement("p");
-        definitionPara.textContent = item.definition;
-        termDiv.appendChild(definitionPara);
-
-        termDiv.addEventListener("click", () => {
-          displayDefinition(item);
-        });
-
-        termsList.appendChild(termDiv);
+      const termHeader = document.createElement("h3");
+      if (searchValue) {
+        const escaped = searchValue.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+        const regex = new RegExp(`(${escaped})`, "gi");
+        termHeader.innerHTML = item.term.replace(regex, "<mark>$1</mark>");
+      } else {
+        termHeader.textContent = item.term;
       }
-    });
+
+      const star = document.createElement("span");
+      star.classList.add("favorite-star");
+      star.textContent = "★";
+      if (favorites.has(item.term)) {
+        star.classList.add("favorited");
+      }
+      star.addEventListener("click", (e) => {
+        e.stopPropagation();
+        toggleFavorite(item.term);
+        star.classList.toggle("favorited");
+        if (showFavoritesToggle && showFavoritesToggle.checked) {
+          populateTermsList();
+        }
+      });
+      termHeader.appendChild(star);
+      termDiv.appendChild(termHeader);
+
+      const definitionPara = document.createElement("p");
+      definitionPara.textContent = item.definition;
+      termDiv.appendChild(definitionPara);
+
+      termDiv.addEventListener("click", () => {
+        displayDefinition(item);
+      });
+
+      termsList.appendChild(termDiv);
+    }
+  });
 }
 
 function saveOrder() {
   try {
-    localStorage.setItem("termOrder", JSON.stringify(termsData.terms.map((t) => t.term)));
+    localStorage.setItem(
+      "termOrder",
+      JSON.stringify(termsData.terms.map((t) => t.term)),
+    );
   } catch (e) {
     // Ignore storage errors
   }
@@ -450,7 +482,7 @@ function displayDefinition(term) {
   if (canonicalLink) {
     canonicalLink.setAttribute(
       "href",
-      `${siteUrl}#${encodeURIComponent(term.term)}`
+      `${siteUrl}#${encodeURIComponent(term.term)}`,
     );
   }
   const starElems = definitionContainer.querySelectorAll(".rating-star");
@@ -470,7 +502,11 @@ function displayDefinition(term) {
 function clearDefinition() {
   definitionContainer.style.display = "none";
   definitionContainer.innerHTML = "";
-  history.replaceState(null, "", window.location.pathname + window.location.search);
+  history.replaceState(
+    null,
+    "",
+    window.location.pathname + window.location.search,
+  );
   if (canonicalLink) {
     canonicalLink.setAttribute("href", siteUrl);
   }
@@ -488,7 +524,10 @@ function showRandomTerm() {
 
   const today = new Date().toDateString();
   try {
-    localStorage.setItem("lastRandomTerm", JSON.stringify({ date: today, term: randomTerm }));
+    localStorage.setItem(
+      "lastRandomTerm",
+      JSON.stringify({ date: today, term: randomTerm }),
+    );
   } catch (e) {
     // Ignore storage errors
   }
@@ -530,7 +569,7 @@ window.addEventListener("scroll", () => {
   scrollBtn.style.display = window.scrollY > 200 ? "block" : "none";
 });
 scrollBtn.addEventListener("click", () =>
-  window.scrollTo({ top: 0, behavior: "smooth" })
+  window.scrollTo({ top: 0, behavior: "smooth" }),
 );
 
 definitionContainer.addEventListener("click", clearDefinition);
@@ -584,10 +623,9 @@ function startExport() {
     if (index + chunkSize < total) {
       setTimeout(() => processChunk(index + chunkSize), 0);
     } else {
-      const blob = new Blob(
-        [JSON.stringify({ terms: data }, null, 2)],
-        { type: "application/json" }
-      );
+      const blob = new Blob([JSON.stringify({ terms: data }, null, 2)], {
+        type: "application/json",
+      });
       const url = URL.createObjectURL(blob);
       const a = document.createElement("a");
       a.href = url;
@@ -610,3 +648,77 @@ if (exportBtn && cancelExportBtn) {
   });
 }
 
+function showSnackbar(message, actionLabel, action) {
+  if (!snackbar) return;
+  snackbar.innerHTML = "";
+  const span = document.createElement("span");
+  span.textContent = message;
+  const button = document.createElement("button");
+  button.textContent = actionLabel;
+  button.addEventListener("click", () => {
+    action();
+    hideSnackbar();
+  });
+  snackbar.appendChild(span);
+  snackbar.appendChild(button);
+  snackbar.hidden = false;
+  snackbar.classList.add("show");
+  setTimeout(() => hideSnackbar(), 5000);
+}
+
+function hideSnackbar() {
+  if (!snackbar) return;
+  snackbar.classList.remove("show");
+  snackbar.hidden = true;
+}
+
+function shouldClearKey(key) {
+  const CONFIG_KEYS = [
+    "darkMode",
+    "citation-style",
+    "onboarding-checklist",
+    "readingControls.fontSize",
+    "readingControls.lineHeight",
+    "readingControls.contentWidth",
+    "standardsTable",
+    "lastRandomTerm",
+  ];
+  const CONFIG_PREFIXES = ["sort-"];
+  return (
+    CONFIG_KEYS.includes(key) ||
+    CONFIG_PREFIXES.some((prefix) => key.startsWith(prefix))
+  );
+}
+
+function clearConfiguration() {
+  const snapshot = {};
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    if (key && shouldClearKey(key)) {
+      snapshot[key] = localStorage.getItem(key);
+    }
+  }
+  Object.keys(snapshot).forEach((key) => localStorage.removeItem(key));
+  document.body.classList.remove("dark-mode");
+  return snapshot;
+}
+
+function restoreConfiguration(snapshot) {
+  Object.entries(snapshot).forEach(([key, value]) => {
+    if (value !== null) {
+      localStorage.setItem(key, value);
+    }
+  });
+  if (snapshot["darkMode"] === "true") {
+    document.body.classList.add("dark-mode");
+  }
+}
+
+if (resetSettingsBtn) {
+  resetSettingsBtn.addEventListener("click", () => {
+    const snapshot = clearConfiguration();
+    showSnackbar("Settings reset", "Undo", () =>
+      restoreConfiguration(snapshot),
+    );
+  });
+}

--- a/styles.css
+++ b/styles.css
@@ -35,7 +35,7 @@ body {
 
 h1 {
   text-align: center;
-  font-family: 'Cinzel', serif;
+  font-family: "Cinzel", serif;
   font-weight: 700;
   font-size: 48px;
   margin-bottom: 20px;
@@ -169,7 +169,6 @@ body.dark-mode #search-help {
   border-color: #555;
 }
 
-
 /* Controls styling */
 #random-term {
   margin-top: 10px;
@@ -291,7 +290,9 @@ label {
   border-radius: 4px;
   padding: 10px;
   cursor: pointer;
-  transition: background-color 0.2s, color 0.2s;
+  transition:
+    background-color 0.2s,
+    color 0.2s;
   min-width: 44px;
   min-height: 44px;
 }
@@ -341,7 +342,12 @@ label {
   position: absolute;
   inset: 0;
   transform: translateX(-100%);
-  background-image: linear-gradient(90deg, transparent, var(--skeleton-fg), transparent);
+  background-image: linear-gradient(
+    90deg,
+    transparent,
+    var(--skeleton-fg),
+    transparent
+  );
   animation: skeleton-shimmer 1.5s infinite;
 }
 
@@ -472,7 +478,7 @@ body.dark-mode #alpha-nav button.active {
 }
 
 .history-fold::after {
-  content: '';
+  content: "";
   position: absolute;
   top: 0;
   right: 0;
@@ -570,4 +576,35 @@ body.dark-mode #alpha-nav button.active {
 
 .toast.show {
   opacity: 1;
+}
+
+/* Snackbar for transient messages with actions */
+.snackbar {
+  position: fixed;
+  left: 50%;
+  bottom: 20px;
+  transform: translateX(-50%);
+  background-color: #333;
+  color: #fff;
+  padding: 10px 20px;
+  border-radius: 5px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  pointer-events: none;
+}
+
+.snackbar.show {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.snackbar button {
+  background: none;
+  border: none;
+  color: #4dabf7;
+  cursor: pointer;
+  padding: 0;
 }


### PR DESCRIPTION
## Summary
- add reset settings button and snackbar container
- clear configuration keys with ability to undo
- style snackbar for visibility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6179abc6c8328a2697d051495b111