### PR TITLE
fix: reset alphabet grid focus on term updates

### DIFF
--- a/src/components/AlphabetGrid.tsx
+++ b/src/components/AlphabetGrid.tsx
@@ -44,6 +44,12 @@ const AlphabetGrid: React.FC<AlphabetGridProps> = ({ terms }) => {
   }, [letterToTerm]);
 
   const [activeIndex, setActiveIndex] = useState(initialIndex);
+  // Whenever the underlying terms list changes we recompute the first
+  // available letter and reset focus to it. This keeps the keyboard
+  // navigation stable if the set of terms is filtered dynamically.
+  useEffect(() => {
+    setActiveIndex(initialIndex);
+  }, [initialIndex]);
   const refs = useRef<(HTMLAnchorElement | HTMLSpanElement | null)[]>([]);
 
   // Focus the active element when activeIndex changes


### PR DESCRIPTION
## Summary
- ensure the alphabet grid resets focus when the list of terms changes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b617a927ec83288c0caa107be8086f