### PR TITLE
feat: harden sort toolbar persistence

### DIFF
--- a/src/components/SortToolbar.tsx
+++ b/src/components/SortToolbar.tsx
@@ -28,12 +28,23 @@ export const SortToolbar: React.FC<SortToolbarProps> = ({
 }) => {
   const storageKey = `sort-${sectionKey}`;
   const [sort, setSort] = useState<SortOption>(() => {
-    const stored = localStorage.getItem(storageKey) as SortOption | null;
-    return stored ?? "updated";
+    try {
+      const stored = window.localStorage.getItem(storageKey);
+      if (stored && OPTIONS.some((o) => o.value === stored)) {
+        return stored as SortOption;
+      }
+    } catch {
+      /* noop */
+    }
+    return "updated";
   });
 
   useEffect(() => {
-    localStorage.setItem(storageKey, sort);
+    try {
+      window.localStorage.setItem(storageKey, sort);
+    } catch {
+      /* noop */
+    }
     onSortChange?.(sort);
   }, [sort, storageKey, onSortChange]);
 


### PR DESCRIPTION
## Summary
- improve sort toolbar with validation and safe access to localStorage
- persist chosen sort order per section key

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b617a493b88328acdbe0694a2ef094