### PR TITLE
feat: add swipe navigation for term page

### DIFF
--- a/app/terms/[slug]/page.tsx
+++ b/app/terms/[slug]/page.tsx
@@ -1,4 +1,7 @@
-import React from "react";
+"use client";
+
+import React, { useEffect, useRef } from "react";
+import { useRouter } from "next/navigation";
 import terms from "../../../terms.json";
 import { FAQBlock } from "../../components/FAQBlock";
 
@@ -10,6 +13,9 @@ function slugify(term: string) {
 }
 
 export default function TermPage({ params }: { params: { slug: string } }) {
+  const router = useRouter();
+  const mainRef = useRef<HTMLElement>(null);
+
   const term = terms.terms.find((t) => slugify(t.term) === params.slug);
 
   if (!term) {
@@ -31,8 +37,67 @@ export default function TermPage({ params }: { params: { slug: string } }) {
     },
   ];
 
+  useEffect(() => {
+    const el = mainRef.current;
+    if (!el) return;
+
+    // Determine list of slugs within the current filter context, falling back
+    // to all terms if none is stored.
+    let slugs = terms.terms.map((t) => slugify(t.term));
+    try {
+      const stored = sessionStorage.getItem("filteredTerms");
+      if (stored) {
+        const parsed = JSON.parse(stored);
+        if (Array.isArray(parsed) && parsed.length) {
+          slugs = parsed;
+        }
+      }
+    } catch {
+      // Ignore JSON/Storage errors and use default list
+    }
+
+    const currentIndex = slugs.indexOf(params.slug);
+    const prevSlug = currentIndex > 0 ? slugs[currentIndex - 1] : null;
+    const nextSlug =
+      currentIndex !== -1 && currentIndex < slugs.length - 1
+        ? slugs[currentIndex + 1]
+        : null;
+
+    const EDGE_BUFFER = 40; // px from screen edges to ignore gestures
+    const SWIPE_THRESHOLD = 50; // minimum distance for swipe
+    let startX: number | null = null;
+
+    function onTouchStart(e: TouchEvent) {
+      if (e.touches.length !== 1) return;
+      const x = e.touches[0].clientX;
+      if (x < EDGE_BUFFER || x > window.innerWidth - EDGE_BUFFER) return;
+      startX = x;
+    }
+
+    function onTouchEnd(e: TouchEvent) {
+      if (startX === null) return;
+      const deltaX = e.changedTouches[0].clientX - startX;
+      if (Math.abs(deltaX) > SWIPE_THRESHOLD) {
+        if (deltaX < 0 && nextSlug) {
+          router.push(`/terms/${nextSlug}`);
+        } else if (deltaX > 0 && prevSlug) {
+          router.push(`/terms/${prevSlug}`);
+        }
+      }
+      startX = null;
+    }
+
+    el.addEventListener("touchstart", onTouchStart);
+    el.addEventListener("touchend", onTouchEnd);
+
+    return () => {
+      el.removeEventListener("touchstart", onTouchStart);
+      el.removeEventListener("touchend", onTouchEnd);
+    };
+  }, [params.slug, router]);
+
   return (
-    <main>
+    <main ref={mainRef}>
       <h1>{term.term}</h1>
       <p>{term.definition}</p>
       <FAQBlock items={faqItems} />


### PR DESCRIPTION
## Summary
- enable touch swipe navigation on term detail pages using client-side router
- respect term filter context from sessionStorage when choosing next/previous
- ignore gestures near screen edges to avoid browser back/forward swipes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b617a783488328b1638dbe8413affa