### PR TITLE
Add print stylesheet and TOC for print view

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
   <title>Cyber Security Dictionary</title>
   <script src="assets/js/preconnect.js"></script>
   <link rel="stylesheet" href="styles.css">
+  <link rel="stylesheet" href="src/styles/print.css" media="print">
   <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet">
   <link rel="canonical" id="canonical-link" href="https://alex-unnippillil.github.io/CyberSecuirtyDictionary/">
 </head>

--- a/script.js
+++ b/script.js
@@ -610,3 +610,35 @@ if (exportBtn && cancelExportBtn) {
   });
 }
 
+function buildPrintToc() {
+  if (!definitionContainer) return;
+  const headings = definitionContainer.querySelectorAll("h2, h3");
+  if (headings.length < 2) return;
+  let toc = definitionContainer.querySelector("#print-toc");
+  if (!toc) {
+    toc = document.createElement("nav");
+    toc.id = "print-toc";
+    const heading = document.createElement("h2");
+    heading.textContent = "Table of Contents";
+    toc.appendChild(heading);
+    const list = document.createElement("ol");
+    toc.appendChild(list);
+    definitionContainer.insertBefore(toc, definitionContainer.firstChild);
+  }
+  const list = toc.querySelector("ol");
+  list.innerHTML = "";
+  headings.forEach((h, i) => {
+    if (!h.id) {
+      h.id = `section-${i + 1}`;
+    }
+    const li = document.createElement("li");
+    const a = document.createElement("a");
+    a.textContent = h.textContent;
+    a.href = `#${h.id}`;
+    li.appendChild(a);
+    list.appendChild(li);
+  });
+}
+
+window.addEventListener("beforeprint", buildPrintToc);
+

--- a/src/styles/print.css
+++ b/src/styles/print.css
@@ -1,0 +1,40 @@
+#print-toc {
+  display: none;
+}
+
+@media print {
+  #print-toc {
+    display: block;
+    margin-bottom: 1em;
+  }
+
+  #print-toc ol {
+    padding-left: 1.5em;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    break-after: avoid-page;
+    break-inside: avoid;
+    page-break-after: avoid;
+    page-break-inside: avoid;
+  }
+
+  .provenance-footer {
+    font-size: 0.8rem;
+    color: #555;
+    position: running(footer);
+    break-inside: avoid;
+  }
+
+  @page {
+    margin: 1in;
+    @bottom-center {
+      content: element(footer);
+    }
+  }
+}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -21,6 +21,7 @@
   <link rel="manifest" href="{{ manifest_url }}" />
   <link rel="icon" href="{{ favicon_url }}" />
   <link rel="stylesheet" href="{{ stylesheet_url }}" />
+  <link rel="stylesheet" href="{{ base_url }}/src/styles/print.css" media="print" />
 
   <script nonce="__CSP_NONCE__">
     const BASE_URL = "{{ base_url }}";


### PR DESCRIPTION
## Summary
- add print-focused stylesheet with page break handling and running citation footers
- hook up new print stylesheet in layout and index
- generate table of contents before printing multi-section terms

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b617aa76d483288721d5a43c50a8b2