### PR TITLE
feat: add link preview on hover

### DIFF
--- a/src/components/LinkPreviewCard.tsx
+++ b/src/components/LinkPreviewCard.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+
+export interface LinkPreviewData {
+  /** URL for which preview is shown */
+  url: string;
+  /** Optional page title */
+  title?: string;
+  /** Optional description extracted from meta tags */
+  description?: string;
+  /** Optional preview image */
+  image?: string;
+  /** Screen coordinates where the card should be rendered */
+  position: { x: number; y: number };
+}
+
+/**
+ * Small floating card used to display metadata about a hovered link.
+ *
+ * The card is absolutely positioned near the mouse cursor and includes a
+ * minimal preview: optional image, title and description.
+ */
+const LinkPreviewCard: React.FC<LinkPreviewData> = ({
+  url,
+  title,
+  description,
+  image,
+  position,
+}) => {
+  const style: React.CSSProperties = {
+    position: "fixed",
+    top: position.y + 12,
+    left: position.x + 12,
+    zIndex: 1000,
+    width: 260,
+    maxWidth: "90vw",
+    pointerEvents: "none",
+    boxShadow: "0 2px 8px rgba(0,0,0,0.2)",
+    borderRadius: 4,
+    background: "#fff",
+    color: "#000",
+    overflow: "hidden",
+    fontSize: 14,
+  };
+
+  return (
+    <div className="link-preview-card" style={style}>
+      {image && (
+        <img
+          src={image}
+          alt=""
+          style={{ width: "100%", display: "block" }}
+        />
+      )}
+      <div style={{ padding: 8 }}>
+        <strong style={{ display: "block", marginBottom: 4 }}>
+          {title || url}
+        </strong>
+        {description && (
+          <p style={{ margin: 0, color: "#555" }}>{description}</p>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default LinkPreviewCard;

--- a/src/features/linkPreview/index.ts
+++ b/src/features/linkPreview/index.ts
@@ -1,0 +1,76 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import LinkPreviewCard, { LinkPreviewData } from "../../components/LinkPreviewCard";
+
+interface MetaData {
+  title?: string;
+  description?: string;
+  image?: string;
+}
+
+// Simple in-memory cache for the session.
+const cache = new Map<string, MetaData>();
+
+// Retrieve metadata for a URL using the Jina proxy to bypass CORS.
+async function fetchMetadata(url: string): Promise<MetaData | null> {
+  if (cache.has(url)) return cache.get(url)!;
+  try {
+    const res = await fetch(`https://r.jina.ai/${encodeURIComponent(url)}`);
+    const html = await res.text();
+    const doc = new DOMParser().parseFromString(html, "text/html");
+    const title = doc.querySelector("title")?.textContent || undefined;
+    const description =
+      doc.querySelector('meta[name="description"], meta[property="og:description"]')?.getAttribute("content") ||
+      undefined;
+    const image =
+      doc.querySelector('meta[property="og:image"], meta[name="twitter:image"]')?.getAttribute("content") ||
+      undefined;
+    const meta: MetaData = { title, description, image };
+    cache.set(url, meta);
+    return meta;
+  } catch {
+    return null;
+  }
+}
+
+export function initLinkPreview(): void {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  let currentUrl: string | null = null;
+
+  const render = (data: LinkPreviewData | null) => {
+    if (!data) {
+      ReactDOM.unmountComponentAtNode(container);
+      return;
+    }
+    ReactDOM.render(<LinkPreviewCard {...data} />, container);
+  };
+
+  const handleMouseOver = async (e: MouseEvent) => {
+    const target = (e.target as HTMLElement).closest("a");
+    if (!target) return;
+    const url = (target as HTMLAnchorElement).href;
+    currentUrl = url;
+    const meta = await fetchMetadata(url);
+    const position = { x: e.clientX, y: e.clientY };
+    render({ url, position, ...(meta || {}) });
+  };
+
+  const handleMouseMove = (e: MouseEvent) => {
+    if (!currentUrl) return;
+    const meta = cache.get(currentUrl) || {};
+    render({ url: currentUrl, position: { x: e.clientX, y: e.clientY }, ...meta });
+  };
+
+  const handleMouseOut = (e: MouseEvent) => {
+    if (!(e.target as HTMLElement).closest("a")) return;
+    currentUrl = null;
+    render(null);
+  };
+
+  document.addEventListener("mouseover", handleMouseOver);
+  document.addEventListener("mousemove", handleMouseMove);
+  document.addEventListener("mouseout", handleMouseOut);
+}
+
+export default initLinkPreview;


### PR DESCRIPTION
## Summary
- add floating LinkPreviewCard component
- fetch link metadata on hover and cache results for the session

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b617a0101c8328bac180b47830a16e