### PR TITLE
feat: add settings backup import/export

### DIFF
--- a/src/settings/DiffPreview.tsx
+++ b/src/settings/DiffPreview.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { BackupData } from "../utils/exportImport";
+
+interface DiffPreviewProps {
+  current: BackupData;
+  incoming: BackupData;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+function buildDiff(
+  current: Record<string, string>,
+  incoming: Record<string, string>,
+) {
+  const keys = new Set([...Object.keys(current), ...Object.keys(incoming)]);
+  const changes: Array<{ key: string; before?: string; after?: string }> = [];
+  keys.forEach((key) => {
+    if (current[key] !== incoming[key]) {
+      changes.push({ key, before: current[key], after: incoming[key] });
+    }
+  });
+  return changes;
+}
+
+export default function DiffPreview({
+  current,
+  incoming,
+  onConfirm,
+  onCancel,
+}: DiffPreviewProps) {
+  const settingsDiff = buildDiff(current.settings, incoming.settings);
+  const notesDiff = buildDiff(current.notes, incoming.notes);
+
+  return (
+    <div style={{ border: "1px solid #ccc", padding: "1rem", marginTop: "1rem" }}>
+      <h2>Preview Changes</h2>
+      <section>
+        <h3>Settings</h3>
+        {settingsDiff.length === 0 ? (
+          <p>No changes</p>
+        ) : (
+          <ul>
+            {settingsDiff.map((d) => (
+              <li key={d.key}>
+                <strong>{d.key}</strong>: {d.before ?? "∅"} → {d.after ?? "∅"}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+      <section>
+        <h3>Notes</h3>
+        {notesDiff.length === 0 ? (
+          <p>No changes</p>
+        ) : (
+          <ul>
+            {notesDiff.map((d) => (
+              <li key={d.key}>
+                <strong>{d.key}</strong>: {d.before ?? "∅"} → {d.after ?? "∅"}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+      <button onClick={onConfirm}>Apply</button>
+      <button onClick={onCancel} style={{ marginLeft: "0.5rem" }}>
+        Cancel
+      </button>
+    </div>
+  );
+}

--- a/src/settings/ExportImport.tsx
+++ b/src/settings/ExportImport.tsx
@@ -1,0 +1,68 @@
+import React, { useState } from "react";
+import {
+  BackupData,
+  exportData,
+  getCurrentData,
+  importData,
+  parseBackup,
+} from "../utils/exportImport";
+import DiffPreview from "./DiffPreview";
+
+export default function ExportImport() {
+  const [preview, setPreview] = useState<BackupData | null>(null);
+
+  function handleExport() {
+    const data = exportData();
+    const blob = new Blob([data], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "backup.json";
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  function handleFile(event: React.ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      try {
+        const data = parseBackup(String(reader.result));
+        setPreview(data);
+      } catch {
+        alert("Invalid backup file");
+      }
+    };
+    reader.readAsText(file);
+  }
+
+  function applyImport(data: BackupData) {
+    importData(data);
+    setPreview(null);
+  }
+
+  return (
+    <div style={{ marginTop: "1rem" }}>
+      <h2>Backup</h2>
+      <button onClick={handleExport}>Export</button>
+      <label style={{ marginLeft: "0.5rem" }}>
+        Import
+        <input
+          type="file"
+          accept="application/json"
+          onChange={handleFile}
+          style={{ display: "none" }}
+        />
+      </label>
+      {preview && (
+        <DiffPreview
+          current={getCurrentData()}
+          incoming={preview}
+          onConfirm={() => applyImport(preview)}
+          onCancel={() => setPreview(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/settings/index.tsx
+++ b/src/settings/index.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import ColorBlindPalette from "./ColorBlindPalette";
+import ExportImport from "./ExportImport";
+
+export default function SettingsPage() {
+  return (
+    <div>
+      <h1>Settings</h1>
+      <ColorBlindPalette />
+      <ExportImport />
+    </div>
+  );
+}

--- a/src/utils/exportImport.ts
+++ b/src/utils/exportImport.ts
@@ -1,0 +1,40 @@
+export interface BackupData {
+  settings: Record<string, string>;
+  notes: Record<string, string>;
+}
+
+const NOTES_PREFIX = "note-";
+
+export function getCurrentData(): BackupData {
+  const settings: Record<string, string> = {};
+  const notes: Record<string, string> = {};
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    if (!key) continue;
+    const value = localStorage.getItem(key);
+    if (value === null) continue;
+    if (key.startsWith(NOTES_PREFIX)) {
+      notes[key] = value;
+    } else {
+      settings[key] = value;
+    }
+  }
+  return { settings, notes };
+}
+
+export function exportData(): string {
+  return JSON.stringify(getCurrentData(), null, 2);
+}
+
+export function importData(data: BackupData): void {
+  Object.entries(data.settings || {}).forEach(([key, value]) => {
+    localStorage.setItem(key, value);
+  });
+  Object.entries(data.notes || {}).forEach(([key, value]) => {
+    localStorage.setItem(key, value);
+  });
+}
+
+export function parseBackup(json: string): BackupData {
+  return JSON.parse(json) as BackupData;
+}


### PR DESCRIPTION
## Summary
- add utility to serialize/deserialize settings and notes as JSON
- add settings backup controls with export and import (with diff preview)
- expose new Settings page combining palette selector and backup controls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b617ae5a048328ad8c51a3ae70d5db