### PR TITLE
Refactor compare page to server component with metadata

### DIFF
--- a/app/compare/[a]-vs-[b]/CompareClient.tsx
+++ b/app/compare/[a]-vs-[b]/CompareClient.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useState, useEffect } from "react";
+import styles from "./page.module.css";
+
+export type Term = { term: string; definition: string };
+
+function highlight(
+  def: string,
+  other: string,
+  showDiff: boolean,
+  showSame: boolean,
+) {
+  const words = def.split(/(\s+)/);
+  const otherSet = new Set(other.toLowerCase().split(/\s+/));
+  return words.map((w, i) => {
+    const lw = w.toLowerCase();
+    const isWord = /\w/.test(w);
+    const isDiff = showDiff && isWord && !otherSet.has(lw);
+    const isSame = showSame && isWord && otherSet.has(lw);
+    const className = isDiff
+      ? `${styles.callout} ${styles.diff}`
+      : isSame
+        ? `${styles.callout} ${styles.same}`
+        : undefined;
+    return (
+      <span key={i} className={className}>
+        {w}
+      </span>
+    );
+  });
+}
+
+export default function CompareClient({
+  termA,
+  termB,
+}: {
+  termA: Term;
+  termB: Term;
+}) {
+  const search = useSearchParams();
+  const router = useRouter();
+
+  const [showDiff, setShowDiff] = useState(search.get("diff") === "1");
+  const [showSame, setShowSame] = useState(search.get("same") === "1");
+
+  useEffect(() => {
+    const sp = new URLSearchParams(Array.from(search.entries()));
+    showDiff ? sp.set("diff", "1") : sp.delete("diff");
+    showSame ? sp.set("same", "1") : sp.delete("same");
+    router.replace(`?${sp.toString()}`, { scroll: false });
+  }, [showDiff, showSame, router, search]);
+
+  return (
+    <div>
+      <h1>
+        Compare {termA.term} vs {termB.term}
+      </h1>
+      <div className={styles.controls}>
+        <label>
+          <input
+            type="checkbox"
+            checked={showDiff}
+            onChange={() => setShowDiff((d) => !d)}
+          />
+          Highlight differences
+        </label>
+        <label>
+          <input
+            type="checkbox"
+            checked={showSame}
+            onChange={() => setShowSame((s) => !s)}
+          />
+          Highlight similarities
+        </label>
+      </div>
+      <div className={styles.compareGrid}>
+        <div>
+          <h2>{termA.term}</h2>
+          <p>
+            {highlight(termA.definition, termB.definition, showDiff, showSame)}
+          </p>
+        </div>
+        <div>
+          <h2>{termB.term}</h2>
+          <p>
+            {highlight(termB.definition, termA.definition, showDiff, showSame)}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/compare/[a]-vs-[b]/page.tsx
+++ b/app/compare/[a]-vs-[b]/page.tsx
@@ -1,11 +1,7 @@
-"use client";
-
-import { useRouter, useSearchParams } from "next/navigation";
-import { useState, useEffect, useMemo } from "react";
-import styles from "./page.module.css";
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
 import termsData from "../../../terms.json";
-
-type Term = { term: string; definition: string };
+import CompareClient, { Term } from "./CompareClient";
 
 type Params = { a: string; b: string };
 
@@ -14,86 +10,18 @@ function findTerm(slug: string): Term | undefined {
   return termsData.terms.find((t: Term) => t.term.toLowerCase() === normalized);
 }
 
-function highlight(
-  def: string,
-  other: string,
-  showDiff: boolean,
-  showSame: boolean,
-) {
-  const words = def.split(/(\s+)/);
-  const otherSet = new Set(other.toLowerCase().split(/\s+/));
-  return words.map((w, i) => {
-    const lw = w.toLowerCase();
-    const isWord = /\w/.test(w);
-    const isDiff = showDiff && isWord && !otherSet.has(lw);
-    const isSame = showSame && isWord && otherSet.has(lw);
-    const className = isDiff
-      ? `${styles.callout} ${styles.diff}`
-      : isSame
-        ? `${styles.callout} ${styles.same}`
-        : undefined;
-    return (
-      <span key={i} className={className}>
-        {w}
-      </span>
-    );
-  });
+export function generateMetadata({ params }: { params: Params }): Metadata {
+  const termA = findTerm(params.a);
+  const termB = findTerm(params.b);
+  if (!termA || !termB) notFound();
+  return {
+    title: `${termA.term} vs ${termB.term} \u2013 Cyber Security Dictionary`,
+  };
 }
 
 export default function ComparePage({ params }: { params: Params }) {
-  const { a, b } = params;
-  const search = useSearchParams();
-  const router = useRouter();
-
-  const [showDiff, setShowDiff] = useState(search.get("diff") === "1");
-  const [showSame, setShowSame] = useState(search.get("same") === "1");
-
-  useEffect(() => {
-    const sp = new URLSearchParams(Array.from(search.entries()));
-    showDiff ? sp.set("diff", "1") : sp.delete("diff");
-    showSame ? sp.set("same", "1") : sp.delete("same");
-    router.replace(`?${sp.toString()}`, { scroll: false });
-  }, [showDiff, showSame, router]);
-
-  const termA = useMemo(() => findTerm(a), [a]);
-  const termB = useMemo(() => findTerm(b), [b]);
-
-  const defA = termA?.definition || "Term not found.";
-  const defB = termB?.definition || "Term not found.";
-
-  return (
-    <div>
-      <h1>
-        Compare {termA?.term || a} vs {termB?.term || b}
-      </h1>
-      <div className={styles.controls}>
-        <label>
-          <input
-            type="checkbox"
-            checked={showDiff}
-            onChange={() => setShowDiff((d) => !d)}
-          />
-          Highlight differences
-        </label>
-        <label>
-          <input
-            type="checkbox"
-            checked={showSame}
-            onChange={() => setShowSame((s) => !s)}
-          />
-          Highlight similarities
-        </label>
-      </div>
-      <div className={styles.compareGrid}>
-        <div>
-          <h2>{termA?.term || a}</h2>
-          <p>{highlight(defA, defB, showDiff, showSame)}</p>
-        </div>
-        <div>
-          <h2>{termB?.term || b}</h2>
-          <p>{highlight(defB, defA, showDiff, showSame)}</p>
-        </div>
-      </div>
-    </div>
-  );
+  const termA = findTerm(params.a);
+  const termB = findTerm(params.b);
+  if (!termA || !termB) notFound();
+  return <CompareClient termA={termA} termB={termB} />;
 }


### PR DESCRIPTION
## Summary
- Generate metadata for compare pages with descriptive titles
- Validate comparison terms and return 404 for unknown terms
- Split interactive highlighting into a client component for better SEO

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6199213448328b73f7c3b6a379164