### PR TITLE
Use next/script for JSON-LD structured data

### DIFF
--- a/app/components/FAQBlock.tsx
+++ b/app/components/FAQBlock.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import Script from "next/script";
 
 interface FAQItem {
   question: string;
@@ -32,10 +33,9 @@ export function FAQBlock({ items }: FAQBlockProps) {
           <p>{item.answer}</p>
         </div>
       ))}
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
-      />
+      <Script id="faq-jsonld" type="application/ld+json">
+        {JSON.stringify(jsonLd)}
+      </Script>
     </section>
   );
 }

--- a/app/terms/[slug]/page.tsx
+++ b/app/terms/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import Script from "next/script";
 import terms from "../../../terms.json";
 import { FAQBlock } from "../../components/FAQBlock";
 
@@ -36,10 +37,9 @@ export default function TermPage({ params }: { params: { slug: string } }) {
       <h1>{term.term}</h1>
       <p>{term.definition}</p>
       <FAQBlock items={faqItems} />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(termJsonLd) }}
-      />
+      <Script id="term-jsonld" type="application/ld+json">
+        {JSON.stringify(termJsonLd)}
+      </Script>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- Use Next.js `Script` component in FAQBlock and term pages for JSON-LD
- Remove `dangerouslySetInnerHTML` in favor of safe script injection

## Testing
- `npm test`
- ⚠️ `node -e "require('ts-node').register({compilerOptions:{jsx:'react',module:'commonjs',esModuleInterop:true,allowSyntheticDefaultImports:true,resolveJsonModule:true,moduleResolution:'node',skipLibCheck:true}}); const React=require('react'); const {renderToStaticMarkup}=require('react-dom/server'); const TermPage=require('./app/terms/[slug]/page').default; const html=renderToStaticMarkup(React.createElement(TermPage,{params:{slug:'phishing'}})); console.log(html);"` (Script tag not rendered outside Next.js runtime)

------
https://chatgpt.com/codex/tasks/task_e_68b61991aacc8328925b9f47a425e6d7