### PR TITLE
feat: add search API and component

### DIFF
--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server";
+import data from "../../../terms.json";
+
+interface Term {
+  term: string;
+  definition: string;
+}
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const query = searchParams.get("q")?.toLowerCase() ?? "";
+
+  const terms: Term[] = (data as any).terms || [];
+  const results = terms.filter(
+    (t) =>
+      t.term.toLowerCase().includes(query) ||
+      t.definition.toLowerCase().includes(query)
+  );
+
+  return NextResponse.json(results);
+}

--- a/app/components/SearchInput.tsx
+++ b/app/components/SearchInput.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useState } from "react";
+
+interface Term {
+  term: string;
+  definition: string;
+}
+
+export default function SearchInput() {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<Term[]>([]);
+
+  const handleChange = async (
+    e: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const value = e.target.value;
+    setQuery(value);
+
+    const res = await fetch(`/api/search?q=${encodeURIComponent(value)}`);
+    if (res.ok) {
+      const data: Term[] = await res.json();
+      setResults(data);
+    }
+  };
+
+  return (
+    <div>
+      <input
+        type="text"
+        value={query}
+        onChange={handleChange}
+        placeholder="Search terms..."
+      />
+      <ul>
+        {results.map((item) => (
+          <li key={item.term}>
+            <strong>{item.term}:</strong> {item.definition}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add API route to filter terms by query
- add search input component that calls the API

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b61a89b91883289e055fef2293ebf6