### PR TITLE
feat: fetch term data on server

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+
+interface Term {
+  term: string;
+  definition: string;
+}
+
+export default async function HomePage() {
+  // Fetch terms data on every request without caching
+  const res = await fetch(
+    "https://raw.githubusercontent.com/Alex-Unnippillil/CyberSecuirtyDictionary/main/terms.json",
+    { cache: "no-store" }
+  );
+  const data = await res.json();
+  const terms: Term[] = data.terms || [];
+
+  return (
+    <main>
+      <h1>Cyber Security Terms</h1>
+      <ul>
+        {terms.map((t) => (
+          <li key={t.term}>
+            <strong>{t.term}:</strong> {t.definition}
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add dynamic server-side fetch for terms data in root page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b61a8b283883289e58c71b78db1c7e