### PR TITLE
feat: add dark mode toggle with dark styling

### DIFF
--- a/app/compare/[a]-vs-[b]/page.tsx
+++ b/app/compare/[a]-vs-[b]/page.tsx
@@ -62,8 +62,8 @@ export default function ComparePage({ params }: { params: Params }) {
   const defB = termB?.definition || "Term not found.";
 
   return (
-    <div>
-      <h1>
+    <div className="min-h-screen bg-white p-4 text-gray-900 dark:bg-gray-900 dark:text-gray-100">
+      <h1 className="mb-4 text-3xl font-bold">
         Compare {termA?.term || a} vs {termB?.term || b}
       </h1>
       <div className={styles.controls}>
@@ -86,12 +86,16 @@ export default function ComparePage({ params }: { params: Params }) {
       </div>
       <div className={styles.compareGrid}>
         <div>
-          <h2>{termA?.term || a}</h2>
-          <p>{highlight(defA, defB, showDiff, showSame)}</p>
+          <h2 className="mb-2 text-2xl font-semibold">{termA?.term || a}</h2>
+          <p className="text-gray-700 dark:text-gray-300">
+            {highlight(defA, defB, showDiff, showSame)}
+          </p>
         </div>
         <div>
-          <h2>{termB?.term || b}</h2>
-          <p>{highlight(defB, defA, showDiff, showSame)}</p>
+          <h2 className="mb-2 text-2xl font-semibold">{termB?.term || b}</h2>
+          <p className="text-gray-700 dark:text-gray-300">
+            {highlight(defB, defA, showDiff, showSame)}
+          </p>
         </div>
       </div>
     </div>

--- a/app/components/FAQBlock.tsx
+++ b/app/components/FAQBlock.tsx
@@ -24,12 +24,12 @@ export function FAQBlock({ items }: FAQBlockProps) {
   };
 
   return (
-    <section>
-      <h2>FAQ</h2>
+    <section className="mt-8 rounded-lg bg-gray-100 p-4 text-gray-900 dark:bg-gray-800 dark:text-gray-100">
+      <h2 className="mb-4 text-2xl font-semibold">FAQ</h2>
       {items.map((item, idx) => (
-        <div key={idx}>
-          <h3>{item.question}</h3>
-          <p>{item.answer}</p>
+        <div key={idx} className="mb-4">
+          <h3 className="font-medium">{item.question}</h3>
+          <p className="text-gray-700 dark:text-gray-300">{item.answer}</p>
         </div>
       ))}
       <script

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [theme, setTheme] = useState<"light" | "dark">("light");
+
+  useEffect(() => {
+    const stored = window.localStorage.getItem("theme") as
+      | "light"
+      | "dark"
+      | null;
+    const prefersDark = window.matchMedia(
+      "(prefers-color-scheme: dark)",
+    ).matches;
+    const initial = stored ?? (prefersDark ? "dark" : "light");
+    setTheme(initial);
+    document.documentElement.classList.toggle("dark", initial === "dark");
+  }, []);
+
+  const toggleTheme = () => {
+    const newTheme = theme === "dark" ? "light" : "dark";
+    setTheme(newTheme);
+    document.documentElement.classList.toggle("dark", newTheme === "dark");
+    window.localStorage.setItem("theme", newTheme);
+  };
+
+  return (
+    <html lang="en">
+      <body className="bg-white text-gray-900 dark:bg-gray-900 dark:text-gray-100 min-h-screen">
+        <button
+          onClick={toggleTheme}
+          className="m-4 rounded border border-gray-300 px-3 py-1 text-sm dark:border-gray-700"
+        >
+          Toggle theme
+        </button>
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/app/terms/[slug]/page.tsx
+++ b/app/terms/[slug]/page.tsx
@@ -32,9 +32,9 @@ export default function TermPage({ params }: { params: { slug: string } }) {
   ];
 
   return (
-    <main>
-      <h1>{term.term}</h1>
-      <p>{term.definition}</p>
+    <main className="min-h-screen bg-white p-4 text-gray-900 dark:bg-gray-900 dark:text-gray-100">
+      <h1 className="mb-4 text-3xl font-bold">{term.term}</h1>
+      <p className="mb-6 text-gray-700 dark:text-gray-300">{term.definition}</p>
       <FAQBlock items={faqItems} />
       <script
         type="application/ld+json"


### PR DESCRIPTION
## Summary
- add root layout with dark mode toggle storing preference
- style FAQ and term pages with Tailwind dark variants
- apply dark styling to compare page

## Testing
- `npm test`
- `pre-commit run --files app/layout.tsx app/components/FAQBlock.tsx app/terms/[slug]/page.tsx app/compare/[a]-vs-[b]/page.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68b61a8b89988328ab1cc88f937fc812