### PR TITLE
feat: add term admin with session guard

### DIFF
--- a/app/admin/AdminPanel.tsx
+++ b/app/admin/AdminPanel.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface Term {
+  term: string;
+  definition: string;
+}
+
+export default function AdminPanel() {
+  const [terms, setTerms] = useState<Term[]>([]);
+  const [term, setTerm] = useState("");
+  const [definition, setDefinition] = useState("");
+  const [editing, setEditing] = useState<string | null>(null);
+  const [editingDefinition, setEditingDefinition] = useState("");
+
+  useEffect(() => {
+    fetchTerms();
+  }, []);
+
+  async function fetchTerms() {
+    const res = await fetch("/api/terms");
+    const data = await res.json();
+    setTerms(data);
+  }
+
+  async function addTerm() {
+    await fetch("/api/terms", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ term, definition }),
+    });
+    setTerm("");
+    setDefinition("");
+    fetchTerms();
+  }
+
+  function startEdit(t: Term) {
+    setEditing(t.term);
+    setEditingDefinition(t.definition);
+  }
+
+  async function saveEdit() {
+    if (!editing) return;
+    await fetch(`/api/terms/${encodeURIComponent(editing)}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ definition: editingDefinition }),
+    });
+    setEditing(null);
+    setEditingDefinition("");
+    fetchTerms();
+  }
+
+  async function deleteTerm(t: string) {
+    await fetch(`/api/terms/${encodeURIComponent(t)}`, { method: "DELETE" });
+    fetchTerms();
+  }
+
+  return (
+    <div>
+      <h1>Term Administration</h1>
+      <section>
+        <h2>Add Term</h2>
+        <input
+          placeholder="Term"
+          value={term}
+          onChange={(e) => setTerm(e.target.value)}
+        />
+        <input
+          placeholder="Definition"
+          value={definition}
+          onChange={(e) => setDefinition(e.target.value)}
+        />
+        <button onClick={addTerm}>Add</button>
+      </section>
+
+      <ul>
+        {terms.map((t) => (
+          <li key={t.term}>
+            {editing === t.term ? (
+              <>
+                <input
+                  value={editingDefinition}
+                  onChange={(e) => setEditingDefinition(e.target.value)}
+                />
+                <button onClick={saveEdit}>Save</button>
+                <button onClick={() => setEditing(null)}>Cancel</button>
+              </>
+            ) : (
+              <>
+                <strong>{t.term}:</strong> {t.definition}
+                <button onClick={() => startEdit(t)}>Edit</button>
+                <button onClick={() => deleteTerm(t.term)}>Delete</button>
+              </>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,0 +1,11 @@
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import AdminPanel from "./AdminPanel";
+
+export default function AdminPage() {
+  const session = cookies().get("session");
+  if (!session) {
+    redirect("/");
+  }
+  return <AdminPanel />;
+}

--- a/app/api/terms/[term]/route.ts
+++ b/app/api/terms/[term]/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from "next/server";
+import { promises as fs } from "fs";
+import path from "path";
+
+const dataFile = path.join(process.cwd(), "terms.json");
+
+interface Term {
+  term: string;
+  definition: string;
+}
+
+async function readTerms(): Promise<Term[]> {
+  const data = await fs.readFile(dataFile, "utf8");
+  const parsed = JSON.parse(data);
+  return parsed.terms || [];
+}
+
+async function writeTerms(terms: Term[]): Promise<void> {
+  const data = JSON.stringify({ terms }, null, 2);
+  await fs.writeFile(dataFile, data);
+}
+
+export async function PUT(
+  request: Request,
+  { params }: { params: { term: string } }
+) {
+  const { definition } = await request.json();
+  const terms = await readTerms();
+  const idx = terms.findIndex((t) => t.term === params.term);
+  if (idx === -1) {
+    return NextResponse.json({ error: "not found" }, { status: 404 });
+  }
+  terms[idx].definition = definition;
+  await writeTerms(terms);
+  return NextResponse.json(terms[idx]);
+}
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: { term: string } }
+) {
+  const terms = await readTerms();
+  const idx = terms.findIndex((t) => t.term === params.term);
+  if (idx === -1) {
+    return NextResponse.json({ error: "not found" }, { status: 404 });
+  }
+  const removed = terms.splice(idx, 1)[0];
+  await writeTerms(terms);
+  return NextResponse.json(removed);
+}

--- a/app/api/terms/route.ts
+++ b/app/api/terms/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from "next/server";
+import { promises as fs } from "fs";
+import path from "path";
+
+const dataFile = path.join(process.cwd(), "terms.json");
+
+interface Term {
+  term: string;
+  definition: string;
+}
+
+async function readTerms(): Promise<Term[]> {
+  const data = await fs.readFile(dataFile, "utf8");
+  const parsed = JSON.parse(data);
+  return parsed.terms || [];
+}
+
+async function writeTerms(terms: Term[]): Promise<void> {
+  const data = JSON.stringify({ terms }, null, 2);
+  await fs.writeFile(dataFile, data);
+}
+
+export async function GET() {
+  const terms = await readTerms();
+  return NextResponse.json(terms);
+}
+
+export async function POST(request: Request) {
+  const { term, definition } = await request.json();
+  if (!term || !definition) {
+    return NextResponse.json(
+      { error: "term and definition are required" },
+      { status: 400 }
+    );
+  }
+
+  const terms = await readTerms();
+  if (terms.some((t) => t.term === term)) {
+    return NextResponse.json(
+      { error: "term already exists" },
+      { status: 409 }
+    );
+  }
+
+  terms.push({ term, definition });
+  await writeTerms(terms);
+  return NextResponse.json({ term, definition }, { status: 201 });
+}


### PR DESCRIPTION
## Summary
- add `/api/terms` routes for term CRUD
- add admin panel with session check and term management UI

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b63e9db8bc83288e5f35d6a5c130d4