### PR TITLE
Add API fetch helpers and GitHub demo page

### DIFF
--- a/app/github/page.tsx
+++ b/app/github/page.tsx
@@ -1,0 +1,22 @@
+import { fetchGithubRepo } from '../../lib/api';
+
+export default async function GithubPage() {
+  const { data, error } = await fetchGithubRepo('vercel', 'next.js');
+
+  if (error) {
+    return (
+      <main>
+        <h1>Repository Info</h1>
+        <p>Failed to load repository: {error.message}</p>
+      </main>
+    );
+  }
+
+  return (
+    <main>
+      <h1>{data?.full_name}</h1>
+      <p>{data?.description}</p>
+      <p>⭐ {data?.stargazers_count}</p>
+    </main>
+  );
+}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -40,6 +40,9 @@ export default function Navbar() {
             <a href="/compare" className="hover:underline">
               Compare
             </a>
+            <a href="/github" className="hover:underline">
+              Repo Info
+            </a>
           </div>
         </div>
       </div>
@@ -50,6 +53,9 @@ export default function Navbar() {
           </a>
           <a href="/compare" className="block py-1">
             Compare
+          </a>
+          <a href="/github" className="block py-1">
+            Repo Info
           </a>
         </div>
       )}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,0 +1,30 @@
+export interface FetchResult<T> {
+  data: T | null;
+  error: Error | null;
+}
+
+export async function fetchJson<T>(url: string, init?: RequestInit): Promise<FetchResult<T>> {
+  try {
+    const res = await fetch(url, init);
+    if (!res.ok) {
+      return {
+        data: null,
+        error: new Error(`Request failed: ${res.status} ${res.statusText}`)
+      };
+    }
+    const data = (await res.json()) as T;
+    return { data, error: null };
+  } catch (err) {
+    return { data: null, error: err as Error };
+  }
+}
+
+export interface GithubRepo {
+  full_name: string;
+  description: string;
+  stargazers_count: number;
+}
+
+export async function fetchGithubRepo(owner: string, repo: string) {
+  return fetchJson<GithubRepo>(`https://api.github.com/repos/${owner}/${repo}`);
+}


### PR DESCRIPTION
## Summary
- create reusable JSON fetch helper with error handling
- add `/github` page that fetches and displays GitHub repo info
- link GitHub demo page in the site navigation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b63e9e183c8328b71048b3d4e21117