### PR TITLE
refactor: adopt SWR for client-side data fetching

### DIFF
--- a/app/components/SearchInput.tsx
+++ b/app/components/SearchInput.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import useSWR from "swr";
 
 interface Term {
   term: string;
@@ -9,19 +10,13 @@ interface Term {
 
 export default function SearchInput() {
   const [query, setQuery] = useState("");
-  const [results, setResults] = useState<Term[]>([]);
+  const { data: results = [] } = useSWR<Term[]>(
+    query ? `/api/search?q=${encodeURIComponent(query)}` : null,
+    { refreshInterval: 0 }
+  );
 
-  const handleChange = async (
-    e: React.ChangeEvent<HTMLInputElement>
-  ) => {
-    const value = e.target.value;
-    setQuery(value);
-
-    const res = await fetch(`/api/search?q=${encodeURIComponent(value)}`);
-    if (res.ok) {
-      const data: Term[] = await res.json();
-      setResults(data);
-    }
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setQuery(e.target.value);
   };
 
   return (

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import Navbar from "../components/Navbar";
+import Providers from "./providers";
 
 export default function RootLayout({
   children,
@@ -10,7 +11,7 @@ export default function RootLayout({
     <html lang="en">
       <body>
         <Navbar />
-        {children}
+        <Providers>{children}</Providers>
       </body>
     </html>
   );

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import { SWRConfig } from 'swr';
+
+const fetcher = (url: string) => fetch(url).then((res) => res.json());
+
+export default function Providers({ children }: { children: React.ReactNode }) {
+  return (
+    <SWRConfig value={{ fetcher, refreshInterval: 60000, revalidateOnFocus: false }}>
+      {children}
+    </SWRConfig>
+  );
+}

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
+import useSWR from 'swr';
 
 interface Term {
   term: string;
@@ -17,15 +17,10 @@ interface SearchResponse {
 export default function SearchPage() {
   const searchParams = useSearchParams();
   const query = searchParams.get('q') || '';
-  const [data, setData] = useState<SearchResponse | null>(null);
-
-  useEffect(() => {
-    if (!query) return;
-    fetch(`/api/search?q=${encodeURIComponent(query)}`)
-      .then((res) => res.json())
-      .then(setData)
-      .catch(() => setData({ results: [], suggestions: [] }));
-  }, [query]);
+  const { data } = useSWR<SearchResponse>(
+    query ? `/api/search?q=${encodeURIComponent(query)}` : null,
+    { refreshInterval: 0 }
+  );
 
   const results = data?.results || [];
   const suggestions = data?.suggestions || [];

--- a/components/FrequencyMeter.tsx
+++ b/components/FrequencyMeter.tsx
@@ -1,37 +1,28 @@
-import React, { useEffect, useState } from "react";
+import React, { useMemo } from "react";
 import { ResponsiveContainer, LineChart, Line } from "recharts";
+import useSWR from "swr";
 
 interface FrequencyMeterProps {
   term: string;
 }
 
 const FrequencyMeter: React.FC<FrequencyMeterProps> = ({ term }) => {
-  const [data, setData] = useState<number[]>([]);
+  const { data } = useSWR<any[]>(
+    term
+      ? `https://api.datamuse.com/words?ml=${encodeURIComponent(term)}&md=f&max=20`
+      : null,
+    { refreshInterval: 86400000 }
+  );
 
-  useEffect(() => {
-    async function fetchFrequency() {
-      try {
-        const response = await fetch(
-          `https://api.datamuse.com/words?ml=${encodeURIComponent(term)}&md=f&max=20`,
-        );
-        const json = await response.json();
-        const frequencies = json
-          .map((item: any) => {
-            const tag = (item.tags || []).find((t: string) =>
-              t.startsWith("f:"),
-            );
-            return tag ? parseFloat(tag.slice(2)) : null;
-          })
-          .filter((n: number | null): n is number => n !== null);
-        setData(frequencies);
-      } catch (err) {
-        console.error("Failed to fetch frequency data", err);
-      }
-    }
-    fetchFrequency();
-  }, [term]);
-
-  const chartData = data.map((value, index) => ({ index, value }));
+  const chartData = useMemo(() => {
+    const frequencies = (data || [])
+      .map((item: any) => {
+        const tag = (item.tags || []).find((t: string) => t.startsWith("f:"));
+        return tag ? parseFloat(tag.slice(2)) : null;
+      })
+      .filter((n: number | null): n is number => n !== null);
+    return frequencies.map((value: number, index: number) => ({ index, value }));
+  }, [data]);
 
   return (
     <ResponsiveContainer width="100%" height={40}>

--- a/components/Rhymes.tsx
+++ b/components/Rhymes.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import useSWR from "swr";
 
 interface Rhyme {
   word: string;
@@ -7,27 +8,25 @@ interface Rhyme {
 
 export default function Rhymes({ slug }: { slug: string }) {
   const [groups, setGroups] = useState<Record<number, string[]>>({});
+  const { data } = useSWR<Rhyme[]>(
+    slug ? `/api/rhymes?slug=${encodeURIComponent(slug)}` : null,
+    { refreshInterval: 0 }
+  );
 
   useEffect(() => {
-    if (!slug) {
+    if (!data) {
       setGroups({});
       return;
     }
-
-    fetch(`/api/rhymes?slug=${encodeURIComponent(slug)}`)
-      .then((res) => res.json())
-      .then((data: Rhyme[]) => {
-        const grouped: Record<number, string[]> = {};
-        data.forEach(({ word, numSyllables = 0 }) => {
-          if (!grouped[numSyllables]) {
-            grouped[numSyllables] = [];
-          }
-          grouped[numSyllables].push(word);
-        });
-        setGroups(grouped);
-      })
-      .catch(() => setGroups({}));
-  }, [slug]);
+    const grouped: Record<number, string[]> = {};
+    data.forEach(({ word, numSyllables = 0 }) => {
+      if (!grouped[numSyllables]) {
+        grouped[numSyllables] = [];
+      }
+      grouped[numSyllables].push(word);
+    });
+    setGroups(grouped);
+  }, [data]);
 
   return (
     <div>

--- a/components/SideDrawer.tsx
+++ b/components/SideDrawer.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
+import useSWR from "swr";
 
 interface SideDrawerProps {
   /** Word currently selected; when null the drawer is hidden */
@@ -12,37 +13,16 @@ interface SideDrawerProps {
  * It is shown whenever `word` is not null.
  */
 const SideDrawer: React.FC<SideDrawerProps> = ({ word, onClose }) => {
-  const [definition, setDefinition] = useState<string>("");
-
-  useEffect(() => {
-    if (!word) {
-      setDefinition("");
-      return;
-    }
-
-    let cancelled = false;
-    // Fetch the mini definition for the selected word
-    fetch(`/api/word/summary?word=${encodeURIComponent(word)}`)
-      .then((res) => res.json())
-      .then((data) => {
-        if (!cancelled) {
-          setDefinition(
-            data.summary || data.definition || "No definition available.",
-          );
-        }
-      })
-      .catch(() => {
-        if (!cancelled) {
-          setDefinition("Failed to fetch definition.");
-        }
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [word]);
+  const { data, error } = useSWR(
+    word ? `/api/word/summary?word=${encodeURIComponent(word)}` : null,
+    { refreshInterval: 300000 }
+  );
 
   if (!word) return null;
+
+  const definition = error
+    ? "Failed to fetch definition."
+    : data?.summary || data?.definition || "No definition available.";
 
   return (
     <aside className="side-drawer">

--- a/components/WordOfDay.tsx
+++ b/components/WordOfDay.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
+import useSWR from "swr";
 
 interface Entry {
   id: string;
@@ -12,24 +13,11 @@ interface Entry {
  * save entries for later reference.
  */
 const WordOfDay: React.FC = () => {
-  const [entry, setEntry] = useState<Entry | null>(null);
   const [offset, setOffset] = useState(0);
-
-  const fetchEntry = async (dayOffset: number) => {
-    try {
-      const res = await fetch(`/api/word-of-day?offset=${dayOffset}`);
-      if (!res.ok) throw new Error("Failed to fetch word of day");
-      const data = await res.json();
-      setEntry(data);
-    } catch (err) {
-      console.error(err);
-      setEntry(null);
-    }
-  };
-
-  useEffect(() => {
-    fetchEntry(offset);
-  }, [offset]);
+  const { data: entry } = useSWR<Entry>(
+    `/api/word-of-day?offset=${offset}`,
+    { refreshInterval: 86400000 }
+  );
 
   const handlePrev = () => setOffset((o) => o - 1);
   const handleNext = () => setOffset((o) => o + 1);

--- a/components/search/RandomTerm.tsx
+++ b/components/search/RandomTerm.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
+import useSWR from 'swr';
 
 type Term = {
   term?: string;
@@ -9,17 +10,11 @@ type Term = {
  * Renders a button that navigates the user to a random term from `terms.json`.
  */
 const RandomTerm: React.FC = () => {
-  const [terms, setTerms] = useState<Term[]>([]);
-
-  useEffect(() => {
-    fetch('/terms.json')
-      .then(res => res.json())
-      .then(data => {
-        const list = Array.isArray(data) ? data : data.terms || [];
-        setTerms(list);
-      })
-      .catch(() => setTerms([]));
-  }, []);
+  const { data } = useSWR<Term[] | { terms: Term[] }>(
+    '/terms.json',
+    { refreshInterval: 86400000 }
+  );
+  const terms = Array.isArray(data) ? data : data?.terms || [];
 
   const handleClick = () => {
     if (!terms.length) return;

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "hammerjs": "^2.0.8",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-joyride": "^2.9.3"
+        "react-joyride": "^2.9.3",
+        "swr": "^2.3.6"
       },
       "devDependencies": {
         "chokidar-cli": "^3.0.0",
@@ -710,6 +711,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/dunder-proto": {
@@ -2245,6 +2255,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/swr": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.6.tgz",
+      "integrity": "sha512-wfHRmHWk/isGNMwlLGlZX5Gzz/uTgo0o2IRuTMcf4CPuPFJZlq0rDaKUx+ozB5nBOReNV1kiOyzMfj+MBMikLw==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -2351,6 +2374,15 @@
       "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "hammerjs": "^2.0.8",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-joyride": "^2.9.3"
+    "react-joyride": "^2.9.3",
+    "swr": "^2.3.6"
   }
 }


### PR DESCRIPTION
## Summary
- install SWR
- wrap app with SWR provider that refreshes data every minute
- replace manual fetch calls in client components with useSWR

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b63e9eb3b08328b41c593af5f9a11f