### PR TITLE
Use Next.js Image component for term cards

### DIFF
--- a/components/TermCard.tsx
+++ b/components/TermCard.tsx
@@ -1,12 +1,14 @@
 import React, { useEffect, useRef, useState } from "react";
+import Image from "next/image";
 import { motion, useAnimation, useInView } from "framer-motion";
 
 interface TermCardProps {
   term: string;
   definition: string;
+  imageUrl?: string;
 }
 
-const TermCard: React.FC<TermCardProps> = ({ term, definition }) => {
+const TermCard: React.FC<TermCardProps> = ({ term, definition, imageUrl }) => {
   const ref = useRef<HTMLDivElement | null>(null);
   const controls = useAnimation();
   const inView = useInView(ref);
@@ -30,6 +32,7 @@ const TermCard: React.FC<TermCardProps> = ({ term, definition }) => {
       }}
       transition={{ duration: 0.4 }}
     >
+      {imageUrl && <Image src={imageUrl} alt={term} width={64} height={64} />}
       <h3>{term}</h3>
       <p>{definition}</p>
     </motion.div>

--- a/next.config.js
+++ b/next.config.js
@@ -1,25 +1,34 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "**",
+      },
+    ],
+  },
   async headers() {
     const csp = [
       "default-src 'self'",
       "script-src 'self'",
       "style-src 'self' 'unsafe-inline'",
       "object-src 'none'",
-      "base-uri 'none'"
-    ].join('; ');
+      "base-uri 'none'",
+    ].join("; ");
 
-    const cspHeader = process.env.CSP_ENFORCE === 'true'
-      ? { key: 'Content-Security-Policy', value: csp }
-      : { key: 'Content-Security-Policy-Report-Only', value: csp };
+    const cspHeader =
+      process.env.CSP_ENFORCE === "true"
+        ? { key: "Content-Security-Policy", value: csp }
+        : { key: "Content-Security-Policy-Report-Only", value: csp };
 
     return [
       {
-        source: '/(.*)',
-        headers: [cspHeader]
-      }
+        source: "/(.*)",
+        headers: [cspHeader],
+      },
     ];
-  }
+  },
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- render optional term images via Next.js `<Image>` to optimize loading
- allow remote images with `remotePatterns` configuration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b63ea04504832881fffe5dd28ff9e5