### PR TITLE
Add Playwright tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "react-joyride": "^2.9.3"
       },
       "devDependencies": {
+        "@playwright/test": "^1.55.0",
         "chokidar-cli": "^3.0.0",
         "html-validate": "^10.0.0",
         "http-server": "^14.1.1",
@@ -217,6 +218,22 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
+      "integrity": "sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@sidvind/better-ajv-errors": {
@@ -1673,6 +1690,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/popper.js": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "@playwright/test": "^1.55.0",
     "chokidar-cli": "^3.0.0",
     "html-validate": "^10.0.0",
     "http-server": "^14.1.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests",
+  use: {
+    headless: true,
+  },
+});

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -1,0 +1,11 @@
+import { test, expect } from "@playwright/test";
+import path from "path";
+
+// Ensure the main page renders the expected heading and title
+
+test("index page has title and heading", async ({ page }) => {
+  const filePath = path.join(__dirname, "..", "index.html");
+  await page.goto("file://" + filePath);
+  await expect(page).toHaveTitle("Cyber Security Dictionary");
+  await expect(page.locator("h1")).toHaveText("Cyber Security Dictionary");
+});


### PR DESCRIPTION
## Summary
- add Playwright to dev dependencies and configuration
- add a basic browser test for the homepage

## Testing
- `npm test`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_68b63ea26e788328a092f49d3652ecba