### PR TITLE
Use dynamic imports for heavy components

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,7 @@
 import React from "react";
-import Navbar from "../components/Navbar";
+import dynamic from "next/dynamic";
+
+const Navbar = dynamic(() => import("../components/Navbar"), { ssr: false });
 
 export default function RootLayout({
   children,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,9 @@
-import SearchBar from "../components/search/SearchBar";
+import dynamic from "next/dynamic";
+
+const SearchBar = dynamic(
+  () => import("../components/search/SearchBar"),
+  { ssr: false }
+);
 
 export default function Home() {
   return (

--- a/app/terms/[slug]/page.tsx
+++ b/app/terms/[slug]/page.tsx
@@ -2,7 +2,9 @@ import React from "react";
 import fs from "fs";
 import path from "path";
 import yaml from "js-yaml";
-import { FAQBlock } from "../../components/FAQBlock";
+import dynamic from "next/dynamic";
+
+const FAQBlock = dynamic(() => import("../../components/FAQBlock"));
 
 interface Term {
   name: string;


### PR DESCRIPTION
## Summary
- Lazy-load Navbar in layout with `next/dynamic` and disable SSR
- Defer loading of SearchBar on the home page for client-side rendering
- Load FAQ block dynamically on term pages

## Testing
- `npm test`
- `curl -o /dev/null -s -w '%{time_total}\n' http://localhost:8080/index.html`


------
https://chatgpt.com/codex/tasks/task_e_68b63ea38c808328a0be4fc4787f5b8d