### PR TITLE
feat: enable revalidation for dynamic pages

### DIFF
--- a/pages/[slug].tsx
+++ b/pages/[slug].tsx
@@ -1,4 +1,4 @@
-import { GetServerSideProps } from 'next';
+import { GetStaticPaths, GetStaticProps } from 'next';
 
 interface Phonetic {
   text?: string;
@@ -38,9 +38,15 @@ export default function EntryPage({ entry }: EntryPageProps) {
   );
 }
 
-export const getServerSideProps: GetServerSideProps<EntryPageProps> = async (context) => {
+export const getStaticPaths: GetStaticPaths = async () => {
+  return { paths: [], fallback: 'blocking' };
+};
+
+export const getStaticProps: GetStaticProps<EntryPageProps> = async (context) => {
   const { slug } = context.params as { slug: string };
-  const res = await fetch(`https://api.dictionaryapi.dev/api/v2/entries/en/${slug}`);
+  const res = await fetch(
+    `https://api.dictionaryapi.dev/api/v2/entries/en/${slug}`
+  );
 
   if (!res.ok) {
     return { notFound: true };
@@ -53,5 +59,6 @@ export const getServerSideProps: GetServerSideProps<EntryPageProps> = async (con
     props: {
       entry,
     },
+    revalidate: 86400,
   };
 };

--- a/topics/[slug].tsx
+++ b/topics/[slug].tsx
@@ -86,7 +86,7 @@ function slugify(text: string): string {
 export const getStaticPaths: GetStaticPaths = async () => {
   const terms = loadTerms();
   const paths = terms.map((t) => ({ params: { slug: t.slug } }));
-  return { paths, fallback: false };
+  return { paths, fallback: 'blocking' };
 };
 
 export const getStaticProps: GetStaticProps<Props> = async ({ params }) => {
@@ -116,5 +116,6 @@ export const getStaticProps: GetStaticProps<Props> = async ({ params }) => {
       term,
       related,
     },
+    revalidate: 86400,
   };
 };


### PR DESCRIPTION
## Summary
- use `getStaticProps` with `revalidate` for dictionary entries
- add `revalidate` and fallback pages for topic pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b63ea4007c832896bf11827fe431ee