### PR TITLE
feat: configure dictionary API via env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 
 # Local environment variables
 .env
+.env.local

--- a/README.md
+++ b/README.md
@@ -18,6 +18,16 @@ https://alex-unnippillil.github.io/CyberSecuirtyDictionary/
    npx http-server
    ```
 
+## Environment Variables
+
+Runtime configuration is provided through a local `.env.local` file. Create this file in the project root and add any needed keys:
+
+```env
+NEXT_PUBLIC_DICTIONARY_API_BASE=https://api.dictionaryapi.dev/api/v2/entries/en
+```
+
+Variables prefixed with `NEXT_PUBLIC_` are exposed to the client and can be accessed in code via `process.env.NEXT_PUBLIC_*`.
+
 ## Deployment
 
 The project is a static site published with GitHub Pages. After updating content, ensure tests pass and push changes to the default branch. GitHub Pages will rebuild and deploy the site automatically. When changing security contact details, regenerate `.well-known/security.txt` by running:

--- a/pages/[slug].tsx
+++ b/pages/[slug].tsx
@@ -14,6 +14,10 @@ interface EntryPageProps {
   entry: Entry;
 }
 
+const DICTIONARY_API_BASE =
+  process.env.NEXT_PUBLIC_DICTIONARY_API_BASE ||
+  'https://api.dictionaryapi.dev/api/v2/entries/en';
+
 function syllabify(word: string): string {
   return word
     .toLowerCase()
@@ -40,7 +44,7 @@ export default function EntryPage({ entry }: EntryPageProps) {
 
 export const getServerSideProps: GetServerSideProps<EntryPageProps> = async (context) => {
   const { slug } = context.params as { slug: string };
-  const res = await fetch(`https://api.dictionaryapi.dev/api/v2/entries/en/${slug}`);
+  const res = await fetch(`${DICTIONARY_API_BASE}/${slug}`);
 
   if (!res.ok) {
     return { notFound: true };


### PR DESCRIPTION
## Summary
- allow dictionary API base to be configured via `NEXT_PUBLIC_DICTIONARY_API_BASE`
- document environment variable setup
- ignore local environment files in git

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b63ea5456083288cbd38f2504152bb