### PR TITLE
Restrict API access to trusted origins

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,29 +1,39 @@
-import { streamText } from 'ai';
-import { createOpenAI } from '@ai-sdk/openai';
+import { streamText } from "ai";
+import { createOpenAI } from "@ai-sdk/openai";
+import { verifyOrigin, withCors, handleOptions } from "../cors";
 
 // Initialize OpenAI client using the API key from environment variables.
 const openai = createOpenAI({
-  apiKey: process.env.OPENAI_API_KEY || ''
+  apiKey: process.env.OPENAI_API_KEY || "",
 });
 
 // Handle POST requests to the chat endpoint. This uses the `streamText`
 // helper to stream tokens from the model and return partial results as
 // they are generated.
+export async function OPTIONS(request: Request) {
+  return handleOptions(request);
+}
+
 export async function POST(req: Request): Promise<Response> {
+  const blocked = verifyOrigin(req);
+  if (blocked) return blocked;
   try {
     const { messages } = await req.json();
 
     const result = await streamText({
-      model: openai('gpt-4o-mini'),
+      model: openai("gpt-4o-mini"),
       messages,
     });
 
     // Convert the stream into a `Response` object that emits Server-Sent
     // Events. Each event contains partial model output so the caller can
     // render tokens incrementally.
-    return result.toDataStreamResponse();
+    return withCors(req, result.toDataStreamResponse());
   } catch (error) {
-    console.error('Chat streaming failed', error);
-    return new Response('Failed to generate chat response', { status: 500 });
+    console.error("Chat streaming failed", error);
+    return withCors(
+      req,
+      new Response("Failed to generate chat response", { status: 500 }),
+    );
   }
 }

--- a/app/api/cors.ts
+++ b/app/api/cors.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from "next/server";
+
+const allowedOrigins = (
+  process.env.ALLOWED_ORIGINS ||
+  process.env.ALLOWED_ORIGIN ||
+  "https://alex-unnippillil.github.io"
+)
+  .split(",")
+  .map((origin) => origin.trim());
+
+/**
+ * Ensures requests come from trusted origins.
+ * Returns a 403 response if the origin header is not in the whitelist.
+ */
+export function verifyOrigin(request: Request): Response | null {
+  const origin = request.headers.get("origin");
+  if (origin && !allowedOrigins.includes(origin)) {
+    return new NextResponse(null, { status: 403 });
+  }
+  return null;
+}
+
+/**
+ * Adds CORS headers to the response for a valid origin.
+ */
+export function withCors(request: Request, response: Response): Response {
+  const origin = request.headers.get("origin");
+  const allowed =
+    origin && allowedOrigins.includes(origin) ? origin : allowedOrigins[0];
+  response.headers.set("Access-Control-Allow-Origin", allowed);
+  response.headers.set("Access-Control-Allow-Methods", "GET,POST,OPTIONS");
+  response.headers.set(
+    "Access-Control-Allow-Headers",
+    "Content-Type, Authorization",
+  );
+  response.headers.set("Vary", "Origin");
+  return response;
+}
+
+/**
+ * Handles CORS preflight requests.
+ */
+export function handleOptions(request: Request): Response {
+  const origin = request.headers.get("origin");
+  const response = new NextResponse(null, { status: 204 });
+  const allowed =
+    origin && allowedOrigins.includes(origin) ? origin : allowedOrigins[0];
+  response.headers.set("Access-Control-Allow-Origin", allowed);
+  response.headers.set("Access-Control-Allow-Methods", "GET,POST,OPTIONS");
+  response.headers.set(
+    "Access-Control-Allow-Headers",
+    "Content-Type, Authorization",
+  );
+  response.headers.set("Vary", "Origin");
+  return response;
+}

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -1,12 +1,19 @@
 import { NextResponse } from "next/server";
 import data from "../../../terms.json";
+import { verifyOrigin, withCors, handleOptions } from "../cors";
 
 interface Term {
   term: string;
   definition: string;
 }
 
+export async function OPTIONS(request: Request) {
+  return handleOptions(request);
+}
+
 export async function GET(request: Request) {
+  const blocked = verifyOrigin(request);
+  if (blocked) return blocked;
   const { searchParams } = new URL(request.url);
   const query = searchParams.get("q")?.toLowerCase() ?? "";
 
@@ -14,8 +21,8 @@ export async function GET(request: Request) {
   const results = terms.filter(
     (t) =>
       t.term.toLowerCase().includes(query) ||
-      t.definition.toLowerCase().includes(query)
+      t.definition.toLowerCase().includes(query),
   );
 
-  return NextResponse.json(results);
+  return withCors(request, NextResponse.json(results));
 }


### PR DESCRIPTION
## Summary
- add reusable CORS helper enforcing allowed origins and headers
- secure chat and search API routes with origin checks and preflight handling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b63ea543208328a72817b22b183387