### PR TITLE
Add dynamic term page for dictionary entries

### DIFF
--- a/app/[term]/page.tsx
+++ b/app/[term]/page.tsx
@@ -1,0 +1,35 @@
+import { notFound } from 'next/navigation';
+import termsData from '../../terms.json';
+
+interface Term {
+  term: string;
+  definition: string;
+}
+
+function slugify(value: string) {
+  return value.toLowerCase().replace(/\s+/g, '-');
+}
+
+function findTerm(slug: string): Term | undefined {
+  const normalized = decodeURIComponent(slug).replace(/-/g, ' ').toLowerCase();
+  return (termsData as { terms: Term[] }).terms.find(
+    (t) => t.term.toLowerCase() === normalized
+  );
+}
+
+export default function TermPage({ params }: { params: { term: string } }) {
+  const term = findTerm(params.term);
+  if (!term) notFound();
+  return (
+    <main>
+      <h1>{term.term}</h1>
+      <p>{term.definition}</p>
+    </main>
+  );
+}
+
+export function generateStaticParams() {
+  return (termsData as { terms: Term[] }).terms.map((t) => ({
+    term: slugify(t.term),
+  }));
+}


### PR DESCRIPTION
## Summary
- add dynamic `[term]` route that serves individual term definitions
- prebuild term pages with `generateStaticParams` for static generation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b63ea73c048328be40a0e5d0716323