### PR TITLE
feat: add JSON-LD structured data

### DIFF
--- a/app/(site)/term/[slug]/page.tsx
+++ b/app/(site)/term/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import { allTerms } from "contentlayer/generated";
 import { notFound } from "next/navigation";
 import { Metadata } from "next";
+import Script from "next/script";
 import { useMDXComponent } from "next-contentlayer/hooks";
 import RelatedTerms from "./RelatedTerms";
 
@@ -25,54 +26,74 @@ export default function TermPage({ params }: PageProps) {
   const term = allTerms.find((t) => t.slug === params.slug);
   if (!term) notFound();
   const MDXContent = useMDXComponent(term.body.code);
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "DefinedTerm",
+    name: term.title,
+    description: term.shortDefinition,
+    url: `https://alex-unnippillil.github.io/CyberSecuirtyDictionary/term/${params.slug}`,
+    inDefinedTermSet: {
+      "@type": "DefinedTermSet",
+      name: "Cyber Security Dictionary",
+      url: "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/",
+    },
+  };
+
   return (
-    <article>
-      <header>
-        <h1>{term.title}</h1>
-        {term.shortDefinition && <p>{term.shortDefinition}</p>}
-      </header>
-      <MDXContent />
-      {term.sources && term.sources.length > 0 && (
-        <section aria-labelledby="sources-heading">
-          <h2 id="sources-heading">Sources</h2>
-          <ul>
-            {term.sources.map((source) => (
-              <li key={source.url}>
-                <a href={source.url}>{source.name || source.url}</a>
-                {source.attack && (
-                  <span>
-                    {" "}
-                    (
-                    <a
-                      href={source.attack}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      ATT&CK
-                    </a>
-                    )
-                  </span>
-                )}
-                {source.owasp && (
-                  <span>
-                    {" "}
-                    (
-                    <a
-                      href={source.owasp}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      OWASP
-                    </a>
-                    )
-                  </span>
-                )}
-              </li>
-            ))}
-          </ul>
-        </section>
-      )}
-      <RelatedTerms slugs={term.seeAlso} />
-    </article>
+    <>
+      <Script
+        id="json-ld-term"
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <article>
+        <header>
+          <h1>{term.title}</h1>
+          {term.shortDefinition && <p>{term.shortDefinition}</p>}
+        </header>
+        <MDXContent />
+        {term.sources && term.sources.length > 0 && (
+          <section aria-labelledby="sources-heading">
+            <h2 id="sources-heading">Sources</h2>
+            <ul>
+              {term.sources.map((source) => (
+                <li key={source.url}>
+                  <a href={source.url}>{source.name || source.url}</a>
+                  {source.attack && (
+                    <span>
+                      {" "}
+                      (
+                      <a
+                        href={source.attack}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        ATT&CK
+                      </a>
+                      )
+                    </span>
+                  )}
+                  {source.owasp && (
+                    <span>
+                      {" "}
+                      (
+                      <a
+                        href={source.owasp}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        OWASP
+                      </a>
+                      )
+                    </span>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+        <RelatedTerms slugs={term.seeAlso} />
+      </article>
+    </>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,10 +1,31 @@
 import SearchBar from "../components/search/SearchBar";
+import Script from "next/script";
 
 export default function Home() {
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    name: "Cyber Security Dictionary",
+    url: "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/",
+    potentialAction: {
+      "@type": "SearchAction",
+      target:
+        "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/?q={search_term_string}",
+      "query-input": "required name=search_term_string",
+    },
+  };
+
   return (
-    <main>
-      <h1>Cyber Security Dictionary</h1>
-      <SearchBar />
-    </main>
+    <>
+      <Script
+        id="json-ld-home"
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <main>
+        <h1>Cyber Security Dictionary</h1>
+        <SearchBar />
+      </main>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- add WebSite JSON-LD to home page
- add DefinedTerm JSON-LD to term pages

## Testing
- `npm test`
- `curl -s -X POST -H 'Content-Type: application/json' -d '{"code":"<script type=\"application/ld+json\">{\\\"@context\\\":\\\"https://schema.org\\\",\\\"@type\\\":\\\"WebSite\\\",\\\"name\\\":\\\"Test\\\"}</script>"}' https://search.google.com/test/rich-results/validate` *(fails: 404)*

------
https://chatgpt.com/codex/tasks/task_e_68b63ea7d9748328be157046fd63916b