### PR TITLE
feat: add static props for home page

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,0 +1,37 @@
+import { GetStaticProps } from 'next';
+import path from 'path';
+import { promises as fs } from 'fs';
+
+interface Term {
+  term: string;
+  definition: string;
+}
+
+interface HomePageProps {
+  terms: Term[];
+}
+
+export default function HomePage({ terms }: HomePageProps) {
+  return (
+    <main>
+      <h1>Cybersecurity Terms</h1>
+      <ul>
+        {terms.map((t) => (
+          <li key={t.term}>{t.term}</li>
+        ))}
+      </ul>
+    </main>
+  );
+}
+
+export const getStaticProps: GetStaticProps<HomePageProps> = async () => {
+  const filePath = path.join(process.cwd(), 'terms.json');
+  const json = await fs.readFile(filePath, 'utf-8');
+  const data = JSON.parse(json);
+  const terms: Term[] = data.terms || [];
+  return {
+    props: {
+      terms,
+    },
+  };
+};


### PR DESCRIPTION
## Summary
- add `pages/index.tsx` that loads term list with `getStaticProps`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b63eab552c83289063fa261404175f