### PR TITLE
Ensure all images have alt text

### DIFF
--- a/src/components/DiagramViewer.tsx
+++ b/src/components/DiagramViewer.tsx
@@ -17,7 +17,7 @@ interface DiagramPin {
 
 interface DiagramViewerProps {
   src: string;
-  alt?: string;
+  alt: string;
   onClose: () => void;
   /** Optional set of pins to render over the diagram */
   pins?: DiagramPin[];

--- a/src/components/LinkPreviewCard.tsx
+++ b/src/components/LinkPreviewCard.tsx
@@ -47,7 +47,7 @@ const LinkPreviewCard: React.FC<LinkPreviewData> = ({
       {image && (
         <img
           src={image}
-          alt=""
+          alt={title ? `Preview image for ${title}` : `Preview image for ${url}`}
           style={{ width: "100%", display: "block" }}
         />
       )}


### PR DESCRIPTION
## Summary
- add descriptive alt text to link preview images
- require alt descriptions in diagram viewer props

## Testing
- `npm test`
- `npx eslint -c /tmp/eslint.config.cjs src/components/DiagramViewer.tsx src/components/LinkPreviewCard.tsx` *(fails: Cannot find module 'eslint-plugin-jsx-a11y')*

------
https://chatgpt.com/codex/tasks/task_e_68b63eabc24c83288692b2ae7d9534ba