### PR TITLE
chore: add webpack aliases and update imports

### DIFF
--- a/api/expand/route.ts
+++ b/api/expand/route.ts
@@ -1,4 +1,4 @@
-import { expandTopic } from '../../lib/ai';
+import { expandTopic } from '@lib/ai';
 
 /**
  * API route that expands a topic using the configured AI provider.

--- a/api/suggest/route.ts
+++ b/api/suggest/route.ts
@@ -1,4 +1,4 @@
-import { chipsForTags } from '../../lib/prompts';
+import { chipsForTags } from '@lib/prompts';
 
 /**
  * Return prompt chips for the provided comma separated `tags` query parameter.

--- a/app/(site)/settings/page.tsx
+++ b/app/(site)/settings/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React from 'react';
-import { useSettings } from '../../../lib/settings';
+import { useSettings } from '@lib/settings';
 
 const SettingsPage: React.FC = () => {
   const { settings, update } = useSettings();

--- a/app/a-z/page.tsx
+++ b/app/a-z/page.tsx
@@ -1,5 +1,5 @@
-import AZIndex from "../../components/search/AZIndex";
-import termsData from "../../terms.json";
+import AZIndex from "@components/search/AZIndex";
+import termsData from "@/terms.json";
 
 export default function AZPage() {
   return <AZIndex terms={termsData.terms} />;

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import data from "../../../terms.json";
+import data from "@/terms.json";
 
 interface Term {
   term: string;

--- a/app/compare/[a]-vs-[b]/page.tsx
+++ b/app/compare/[a]-vs-[b]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
-import termsData from "../../../terms.json";
+import termsData from "@/terms.json";
 import CompareClient, { Term } from "./CompareClient";
 
 type Params = { a: string; b: string };

--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -1,4 +1,4 @@
-import termsData from "../../terms.json";
+import termsData from "@/terms.json";
 
 interface Term {
   term: string;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import Navbar from "../components/Navbar";
+import Navbar from "@components/Navbar";
 
 export default function RootLayout({
   children,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,4 @@
-import SearchBar from "../components/search/SearchBar";
+import SearchBar from "@components/search/SearchBar";
 
 export default function Home() {
   return (

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,6 +1,6 @@
 import type { MetadataRoute } from 'next';
-import termsData from '../terms.json' assert { type: 'json' };
-import siteConfig from '../site.config.json' assert { type: 'json' };
+import termsData from '@/terms.json' assert { type: 'json' };
+import siteConfig from '@/site.config.json' assert { type: 'json' };
 
 function slugify(term: string): string {
   return term

--- a/app/terms/[slug]/page.tsx
+++ b/app/terms/[slug]/page.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import fs from "fs";
 import path from "path";
 import yaml from "js-yaml";
-import { FAQBlock } from "../../components/FAQBlock";
+import { FAQBlock } from "@components/FAQBlock";
 
 interface Term {
   name: string;

--- a/components/ExpandPane.ts
+++ b/components/ExpandPane.ts
@@ -1,4 +1,4 @@
-import type { PromptChip } from '../lib/prompts';
+import type { PromptChip } from '@lib/prompts';
 
 /**
  * Basic UI component that renders prompt chips and displays the expanded

--- a/components/interactive.ts
+++ b/components/interactive.ts
@@ -1,4 +1,4 @@
-import { durations, easing, distances } from '../styles/animations';
+import { durations, easing, distances } from '@styles/animations';
 
 function applyHover(el: HTMLElement) {
   el.style.transform = `translateY(-${distances.hover})`;

--- a/components/results/DefinitionItem.tsx
+++ b/components/results/DefinitionItem.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import highlight from "../../lib/highlight";
+import highlight from "@lib/highlight";
 
 interface DefinitionItemProps {
   term: string;

--- a/components/search/HistoryPanel.tsx
+++ b/components/search/HistoryPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import useSearchHistory from "../../hooks/useSearchHistory";
+import useSearchHistory from "@hooks/useSearchHistory";
 
 type Props = {
   authenticated?: boolean;

--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   async headers() {
@@ -19,6 +21,19 @@ const nextConfig = {
         headers: [cspHeader]
       }
     ];
+  },
+  webpack(config) {
+    config.resolve = config.resolve || {};
+    config.resolve.alias = {
+      ...(config.resolve.alias || {}),
+      '@': path.resolve(__dirname),
+      '@components': path.resolve(__dirname, 'components'),
+      '@hooks': path.resolve(__dirname, 'hooks'),
+      '@lib': path.resolve(__dirname, 'lib'),
+      '@styles': path.resolve(__dirname, 'styles'),
+      '@src': path.resolve(__dirname, 'src'),
+    };
+    return config;
   }
 };
 

--- a/src/components/ClipboardPreview.tsx
+++ b/src/components/ClipboardPreview.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useEffect, useState } from 'react';
-import termsData from '../../terms.json';
+import termsData from '@/terms.json';
 
 interface Term {
   term: string;

--- a/src/components/SettingsSheet.tsx
+++ b/src/components/SettingsSheet.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import useSettings from "../hooks/useSettings";
+import useSettings from "@src/hooks/useSettings";
 
 /**
  * SettingsSheet renders toggle controls for each user setting.

--- a/src/components/ShortcutCheatsheet.tsx
+++ b/src/components/ShortcutCheatsheet.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from "react";
-import { startGuidedTour } from "../features/tour/GuidedTour";
+import { startGuidedTour } from "@src/features/tour/GuidedTour";
 
 interface Shortcut {
   keys: string;

--- a/src/features/linkPreview/index.ts
+++ b/src/features/linkPreview/index.ts
@@ -1,6 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom";
-import LinkPreviewCard, { LinkPreviewData } from "../../components/LinkPreviewCard";
+import LinkPreviewCard, { LinkPreviewData } from "@src/components/LinkPreviewCard";
 
 interface MetaData {
   title?: string;

--- a/src/settings/DiffPreview.tsx
+++ b/src/settings/DiffPreview.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { BackupData } from "../utils/exportImport";
+import { BackupData } from "@src/utils/exportImport";
 
 interface DiffPreviewProps {
   current: BackupData;

--- a/src/settings/ExportImport.tsx
+++ b/src/settings/ExportImport.tsx
@@ -5,7 +5,7 @@ import {
   getCurrentData,
   importData,
   parseBackup,
-} from "../utils/exportImport";
+} from "@src/utils/exportImport";
 import DiffPreview from "./DiffPreview";
 
 export default function ExportImport() {

--- a/src/settings/SettingsPage.tsx
+++ b/src/settings/SettingsPage.tsx
@@ -4,7 +4,7 @@ import {
   buildSettingsIndex,
   searchSettings,
   SettingEntry,
-} from '../features/settings/SettingsIndex';
+} from '@src/features/settings/SettingsIndex';
 
 /**
  * Settings page with client side search. Results update as the user types and

--- a/src/tools/SecurityHeadersComposer.tsx
+++ b/src/tools/SecurityHeadersComposer.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import CopyPresetSelect, {
   CopyPreset,
   formatForPreset,
-} from "../components/CopyPresetSelect";
+} from "@src/components/CopyPresetSelect";
 
 interface Directive {
   /**

--- a/word/[slug]/page.tsx
+++ b/word/[slug]/page.tsx
@@ -1,4 +1,4 @@
-import PosTabs from '../../components/PosTabs';
+import PosTabs from '@components/PosTabs';
 
 interface WordPageProps {
   params: {


### PR DESCRIPTION
## Summary
- configure webpack path aliases for components, hooks, lib, styles, and src
- refactor relative imports across app, API routes, components, and src to use new aliases

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b63eac6d1c832896cd0ed414364b4a