### PR TITLE
feat: add zustand search store

### DIFF
--- a/components/SearchBox.tsx
+++ b/components/SearchBox.tsx
@@ -1,20 +1,21 @@
-import React, { useState, useRef, useEffect } from 'react';
-import AutocompleteList from './AutocompleteList';
+import React, { useState, useRef, useEffect } from "react";
+import AutocompleteList from "./AutocompleteList";
+import { useSearchStore } from "../lib/store";
 
 const SearchBox: React.FC = () => {
-  const [value, setValue] = useState('');
+  const { query, setQuery } = useSearchStore();
   const [suggestions, setSuggestions] = useState<string[]>([]);
   const [highlightedIndex, setHighlightedIndex] = useState(-1);
   const [showSuggestions, setShowSuggestions] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
-    if (value.trim() === '') {
+    if (query.trim() === "") {
       setSuggestions([]);
       setShowSuggestions(false);
       return;
     }
-    fetch(`/api/suggest?q=${encodeURIComponent(value)}`)
+    fetch(`/api/suggest?q=${encodeURIComponent(query)}`)
       .then((r) => (r.ok ? r.json() : Promise.reject(r.statusText)))
       .then((data: string[]) => {
         setSuggestions(data);
@@ -25,24 +26,24 @@ const SearchBox: React.FC = () => {
         setSuggestions([]);
         setShowSuggestions(false);
       });
-  }, [value]);
+  }, [query]);
 
   const selectSuggestion = (suggestion: string) => {
-    setValue(suggestion);
+    setQuery(suggestion);
     setShowSuggestions(false);
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (!showSuggestions) return;
-    if (e.key === 'ArrowDown') {
+    if (e.key === "ArrowDown") {
       e.preventDefault();
       setHighlightedIndex((prev) => (prev + 1) % suggestions.length);
-    } else if (e.key === 'ArrowUp') {
+    } else if (e.key === "ArrowUp") {
       e.preventDefault();
       setHighlightedIndex((prev) =>
-        prev <= 0 ? suggestions.length - 1 : prev - 1
+        prev <= 0 ? suggestions.length - 1 : prev - 1,
       );
-    } else if (e.key === 'Enter') {
+    } else if (e.key === "Enter") {
       if (highlightedIndex >= 0 && highlightedIndex < suggestions.length) {
         e.preventDefault();
         selectSuggestion(suggestions[highlightedIndex]);
@@ -55,12 +56,12 @@ const SearchBox: React.FC = () => {
   };
 
   return (
-    <div className="search-box" style={{ position: 'relative' }}>
+    <div className="search-box" style={{ position: "relative" }}>
       <input
         ref={inputRef}
         type="text"
-        value={value}
-        onChange={(e) => setValue(e.target.value)}
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
         onKeyDown={handleKeyDown}
         onBlur={handleBlur}
       />

--- a/components/search/SearchBar.tsx
+++ b/components/search/SearchBar.tsx
@@ -2,14 +2,18 @@
 
 import { useRouter } from "next/navigation";
 import { ChangeEvent } from "react";
+import { useSearchStore } from "../../lib/store";
 
 export default function SearchBar() {
   const router = useRouter();
+  const { query, setQuery } = useSearchStore();
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
-    const query = e.target.value.trim();
-    if (query) {
-      router.push(`/search?q=${encodeURIComponent(query)}`);
+    const value = e.target.value;
+    setQuery(value);
+    const trimmed = value.trim();
+    if (trimmed) {
+      router.push(`/search?q=${encodeURIComponent(trimmed)}`);
     } else {
       router.push("/search");
     }
@@ -19,6 +23,7 @@ export default function SearchBar() {
     <input
       type="text"
       placeholder="Search terms..."
+      value={query}
       onChange={handleChange}
       aria-label="Search terms"
     />

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -1,0 +1,13 @@
+import { create } from "zustand";
+
+interface SearchState {
+  query: string;
+  setQuery: (query: string) => void;
+}
+
+export const useSearchStore = create<SearchState>((set) => ({
+  query: "",
+  setQuery: (query) => set({ query }),
+}));
+
+export default useSearchStore;

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "hammerjs": "^2.0.8",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-joyride": "^2.9.3"
+        "react-joyride": "^2.9.3",
+        "zustand": "^5.0.8"
       },
       "devDependencies": {
         "chokidar-cli": "^3.0.0",
@@ -2659,6 +2660,35 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.8.tgz",
+      "integrity": "sha512-gyPKpIaxY9XcO2vSMrLbiER7QMAMGOQZVRdJ6Zi782jkbzZygq5GI9nG8g+sMgitRtndwaBSl7uiqC49o1SSiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "hammerjs": "^2.0.8",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-joyride": "^2.9.3"
+    "react-joyride": "^2.9.3",
+    "zustand": "^5.0.8"
   }
 }


### PR DESCRIPTION
## Summary
- install zustand for lightweight state management
- add search query store in `lib/store.ts`
- use shared search state in `SearchBox` and `SearchBar`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b63eb4125083289bafbadfdaf0b55c