### PR TITLE
refactor: use router navigation

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,18 +1,24 @@
 import React, { useState } from "react";
+import { useRouter } from "next/navigation";
 
 /**
  * Responsive navigation bar using Tailwind CSS.
  */
 export default function Navbar() {
   const [open, setOpen] = useState(false);
+  const router = useRouter();
 
   return (
     <nav className="bg-gray-800 text-white">
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div className="flex h-16 items-center justify-between">
-          <a href="/" className="text-xl font-semibold">
+          <button
+            type="button"
+            onClick={() => router.push("/")}
+            className="text-xl font-semibold"
+          >
             CyberSec Dictionary
-          </a>
+          </button>
           <button
             className="md:hidden"
             aria-label="Toggle menu"
@@ -34,23 +40,39 @@ export default function Navbar() {
             </svg>
           </button>
           <div className="hidden md:flex md:space-x-4">
-            <a href="/terms" className="hover:underline">
+            <button
+              type="button"
+              onClick={() => router.push("/terms")}
+              className="hover:underline"
+            >
               Terms
-            </a>
-            <a href="/compare" className="hover:underline">
+            </button>
+            <button
+              type="button"
+              onClick={() => router.push("/compare")}
+              className="hover:underline"
+            >
               Compare
-            </a>
+            </button>
           </div>
         </div>
       </div>
       {open && (
         <div className="px-2 pb-3 md:hidden">
-          <a href="/terms" className="block py-1">
+          <button
+            type="button"
+            onClick={() => router.push("/terms")}
+            className="block py-1"
+          >
             Terms
-          </a>
-          <a href="/compare" className="block py-1">
+          </button>
+          <button
+            type="button"
+            onClick={() => router.push("/compare")}
+            className="block py-1"
+          >
             Compare
-          </a>
+          </button>
         </div>
       )}
     </nav>

--- a/components/term/RelatedTerms.tsx
+++ b/components/term/RelatedTerms.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useRouter } from "next/navigation";
 
 export interface RelatedTerm {
   /** Slug used to build link to the term page */
@@ -20,6 +21,7 @@ interface RelatedTermsProps {
  * nothing is rendered.
  */
 const RelatedTerms: React.FC<RelatedTermsProps> = ({ relatedTerms }) => {
+  const router = useRouter();
   if (!relatedTerms || relatedTerms.length === 0) return null;
 
   return (
@@ -28,9 +30,13 @@ const RelatedTerms: React.FC<RelatedTermsProps> = ({ relatedTerms }) => {
       <ul className="related-terms__list">
         {relatedTerms.map((term) => (
           <li key={term.slug} className="related-terms__item">
-            <a href={`/terms/${term.slug}`} className="related-terms__pill">
+            <button
+              type="button"
+              onClick={() => router.push(`/terms/${term.slug}`)}
+              className="related-terms__pill"
+            >
               {term.name}
-            </a>
+            </button>
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## Summary
- use Next.js router for Navbar links
- navigate related-term pills with router push

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b63eacd57c8328a57961dd7e64e2f4