### PR TITLE
Add SEO meta tags to Next.js pages

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,10 +1,28 @@
+import Head from "next/head";
 import SearchBar from "../components/search/SearchBar";
 
 export default function Home() {
   return (
-    <main>
-      <h1>Cyber Security Dictionary</h1>
-      <SearchBar />
-    </main>
+    <>
+      <Head>
+        <title>Cyber Security Dictionary</title>
+        <meta
+          name="description"
+          content="Look up cybersecurity terms and definitions."
+        />
+        <meta
+          property="og:title"
+          content="Cyber Security Dictionary"
+        />
+        <meta
+          property="og:description"
+          content="Look up cybersecurity terms and definitions."
+        />
+      </Head>
+      <main>
+        <h1>Cyber Security Dictionary</h1>
+        <SearchBar />
+      </main>
+    </>
   );
 }

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Head from 'next/head';
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
@@ -31,28 +32,45 @@ export default function SearchPage() {
   const suggestions = data?.suggestions || [];
 
   return (
-    <div>
-      {suggestions.length > 0 && (
-        <div className="suggestions">
-          <p>Did you mean:</p>
-          <ul>
-            {suggestions.map((s) => (
-              <li key={s}>
-                <Link href={`/search?q=${encodeURIComponent(s)}`}>{s}</Link>
-              </li>
-            ))}
-          </ul>
-        </div>
-      )}
-      <ul>
-        {results.map((r) => (
-          <li key={r.term}>
-            <strong>{r.term}</strong>: {r.definition}
-          </li>
-        ))}
-        {results.length === 0 && <li>No results found.</li>}
-      </ul>
-    </div>
+    <>
+      <Head>
+        <title>Search – Cyber Security Dictionary</title>
+        <meta
+          name="description"
+          content="Search cybersecurity terms in the dictionary."
+        />
+        <meta
+          property="og:title"
+          content="Search – Cyber Security Dictionary"
+        />
+        <meta
+          property="og:description"
+          content="Search cybersecurity terms in the dictionary."
+        />
+      </Head>
+      <div>
+        {suggestions.length > 0 && (
+          <div className="suggestions">
+            <p>Did you mean:</p>
+            <ul>
+              {suggestions.map((s) => (
+                <li key={s}>
+                  <Link href={`/search?q=${encodeURIComponent(s)}`}>{s}</Link>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+        <ul>
+          {results.map((r) => (
+            <li key={r.term}>
+              <strong>{r.term}</strong>: {r.definition}
+            </li>
+          ))}
+          {results.length === 0 && <li>No results found.</li>}
+        </ul>
+      </div>
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary
- include `next/head` for home and search pages
- add title, description, and Open Graph metadata

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b63eaedf5883289640fd0c04ccaf1c