### PR TITLE
feat: add error boundary for critical routes

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import Navbar from "../components/Navbar";
+import ErrorBoundary from "../components/ErrorBoundary";
 
 export default function RootLayout({
   children,
@@ -9,8 +10,10 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body>
-        <Navbar />
-        {children}
+        <ErrorBoundary>
+          <Navbar />
+          {children}
+        </ErrorBoundary>
       </body>
     </html>
   );

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
+import ErrorBoundary from '../../components/ErrorBoundary';
 
 interface Term {
   term: string;
@@ -31,28 +32,30 @@ export default function SearchPage() {
   const suggestions = data?.suggestions || [];
 
   return (
-    <div>
-      {suggestions.length > 0 && (
-        <div className="suggestions">
-          <p>Did you mean:</p>
-          <ul>
-            {suggestions.map((s) => (
-              <li key={s}>
-                <Link href={`/search?q=${encodeURIComponent(s)}`}>{s}</Link>
-              </li>
-            ))}
-          </ul>
-        </div>
-      )}
-      <ul>
-        {results.map((r) => (
-          <li key={r.term}>
-            <strong>{r.term}</strong>: {r.definition}
-          </li>
-        ))}
-        {results.length === 0 && <li>No results found.</li>}
-      </ul>
-    </div>
+    <ErrorBoundary>
+      <div>
+        {suggestions.length > 0 && (
+          <div className="suggestions">
+            <p>Did you mean:</p>
+            <ul>
+              {suggestions.map((s) => (
+                <li key={s}>
+                  <Link href={`/search?q=${encodeURIComponent(s)}`}>{s}</Link>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+        <ul>
+          {results.map((r) => (
+            <li key={r.term}>
+              <strong>{r.term}</strong>: {r.definition}
+            </li>
+          ))}
+          {results.length === 0 && <li>No results found.</li>}
+        </ul>
+      </div>
+    </ErrorBoundary>
   );
 }
 

--- a/components/ErrorBoundary.tsx
+++ b/components/ErrorBoundary.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import React, { ErrorInfo, ReactNode } from "react";
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+export default class ErrorBoundary extends React.Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  state: ErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    // Log the error to an error reporting service or console
+    console.error("ErrorBoundary caught an error", error, info);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div role="alert">
+          <p>Something went wrong. Please try again later.</p>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}


### PR DESCRIPTION
## Summary
- add reusable ErrorBoundary class component with fallback UI and logging
- wrap root layout and search page with error boundary to guard critical paths

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b63eb5e07483289b68cede1ae3cd0e