### PR TITLE
feat: load Inter font via next/font

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,8 @@
 import React from "react";
 import Navbar from "../components/Navbar";
+import { Inter } from "next/font/google";
+
+const inter = Inter({ subsets: ["latin"] });
 
 export default function RootLayout({
   children,
@@ -7,7 +10,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en">
+    <html lang="en" className={inter.className}>
       <body>
         <Navbar />
         {children}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,3 +1,4 @@
+"use client";
 import React, { useState } from "react";
 
 /**


### PR DESCRIPTION
## Summary
- use Inter from next/font/google in root layout
- mark Navbar as a client component for React hooks

## Testing
- `npm test`
- `npx -y next@latest dev` *(fails: Cannot find module 'next/dist/compiled/next-server/app-page.runtime.dev.js')*

------
https://chatgpt.com/codex/tasks/task_e_68b63eb2cd808328858c81ae2723fea6