### PR TITLE
feat: lazily load heavy components

### DIFF
--- a/app/(site)/term/[slug]/RelatedTerms.tsx
+++ b/app/(site)/term/[slug]/RelatedTerms.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Link from "next/link";
 import { allTerms } from "contentlayer/generated";
 

--- a/app/(site)/term/[slug]/page.tsx
+++ b/app/(site)/term/[slug]/page.tsx
@@ -2,7 +2,11 @@ import { allTerms } from "contentlayer/generated";
 import { notFound } from "next/navigation";
 import { Metadata } from "next";
 import { useMDXComponent } from "next-contentlayer/hooks";
-import RelatedTerms from "./RelatedTerms";
+import dynamic from "next/dynamic";
+
+const RelatedTerms = dynamic(() => import("./RelatedTerms"), {
+  loading: () => <p>Loading related terms...</p>,
+});
 
 interface PageProps {
   params: { slug: string };
@@ -72,7 +76,9 @@ export default function TermPage({ params }: PageProps) {
           </ul>
         </section>
       )}
-      <RelatedTerms slugs={term.seeAlso} />
+      {term.seeAlso && term.seeAlso.length > 0 && (
+        <RelatedTerms slugs={term.seeAlso} />
+      )}
     </article>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,9 @@
-import SearchBar from "../components/search/SearchBar";
+import dynamic from "next/dynamic";
+
+const SearchBar = dynamic(
+  () => import("../components/search/SearchBar"),
+  { loading: () => <p>Loading search...</p>, ssr: false },
+);
 
 export default function Home() {
   return (


### PR DESCRIPTION
## Summary
- dynamically import the search bar with a loading placeholder and client-only render
- defer loading of related terms until needed with a placeholder

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b63eb84ab88328adc56784e217b279