### PR TITLE
feat: integrate Cloudinary image loader

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,11 @@
 /** @type {import('next').NextConfig} */
+const cloudName = process.env.CLOUDINARY_CLOUD_NAME || "demo";
+
 const nextConfig = {
+  images: {
+    loader: "cloudinary",
+    path: `https://res.cloudinary.com/${cloudName}/image/upload/`,
+  },
   async headers() {
     const csp = [
       "default-src 'self'",

--- a/src/components/DiagramViewer.tsx
+++ b/src/components/DiagramViewer.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 import Hammer from "hammerjs";
+import Image from "next/image";
 
 interface DiagramPin {
   /**
@@ -148,7 +149,12 @@ const DiagramViewer: React.FC<DiagramViewerProps> = ({
             height: "100%",
           }}
         >
-          <img src={src} alt={alt} style={{ display: "block", width: "100%" }} />
+          <Image
+            src={src}
+            alt={alt || ""}
+            fill
+            style={{ display: "block", objectFit: "contain" }}
+          />
           {pins && (
             <svg
               viewBox="0 0 100 100"

--- a/src/components/LinkPreviewCard.tsx
+++ b/src/components/LinkPreviewCard.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import Image from "next/image";
 
 export interface LinkPreviewData {
   /** URL for which preview is shown */
@@ -7,7 +8,7 @@ export interface LinkPreviewData {
   title?: string;
   /** Optional description extracted from meta tags */
   description?: string;
-  /** Optional preview image */
+  /** Optional preview image (Cloudinary public ID or URL) */
   image?: string;
   /** Screen coordinates where the card should be rendered */
   position: { x: number; y: number };
@@ -45,10 +46,12 @@ const LinkPreviewCard: React.FC<LinkPreviewData> = ({
   return (
     <div className="link-preview-card" style={style}>
       {image && (
-        <img
+        <Image
           src={image}
           alt=""
-          style={{ width: "100%", display: "block" }}
+          width={260}
+          height={130}
+          style={{ width: "100%", height: "auto" }}
         />
       )}
       <div style={{ padding: 8 }}>


### PR DESCRIPTION
## Summary
- configure Next.js image loader to serve from Cloudinary
- replace raw `<img>` tags with Next `Image` components for Cloudinary delivery

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b63eba53408328b2978da8186c08f9