### PR TITLE
feat(search): add fuzziness slider

### DIFF
--- a/src/components/search/SearchSettingsPopover.tsx
+++ b/src/components/search/SearchSettingsPopover.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { useSearch } from "../../hooks/useSearch";
+
+const labels = ["Exact", "Low", "Medium", "High"];
+
+export const SearchSettingsPopover: React.FC = () => {
+  const { fuzziness, setFuzziness } = useSearch();
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setFuzziness(Number(e.target.value));
+  };
+
+  return (
+    <div className="search-settings-popover">
+      <label htmlFor="fuzziness-slider">Fuzziness</label>
+      <input
+        id="fuzziness-slider"
+        type="range"
+        min={0}
+        max={3}
+        step={1}
+        value={fuzziness}
+        onChange={handleChange}
+      />
+      <div className="fuzziness-labels">
+        {labels.map((l, i) => (
+          <span key={l} className={i === fuzziness ? "active" : undefined}>
+            {l}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default SearchSettingsPopover;

--- a/src/features/search/SearchBar.tsx
+++ b/src/features/search/SearchBar.tsx
@@ -1,29 +1,29 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef } from "react";
+import { useSearch } from "../../hooks/useSearch";
 
-export interface SearchBarProps {
-  onSearch?: (value: string) => void;
-}
-
-export const SearchBar: React.FC<SearchBarProps> = ({ onSearch }) => {
-  const [query, setQuery] = useState('');
+export const SearchBar: React.FC = () => {
+  const { query, setQuery } = useSearch();
   const inputRef = useRef<HTMLInputElement>(null);
   const recognitionRef = useRef<SpeechRecognition | null>(null);
 
   useEffect(() => {
     const SpeechRecognition =
-      (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition;
+      (window as any).SpeechRecognition ||
+      (window as any).webkitSpeechRecognition;
     if (SpeechRecognition) {
       recognitionRef.current = new SpeechRecognition();
-      recognitionRef.current.addEventListener('result', (e: SpeechRecognitionEvent) => {
-        const transcript = e.results[0][0].transcript;
-        setQuery(transcript);
-        onSearch?.(transcript);
-      });
+      recognitionRef.current.addEventListener(
+        "result",
+        (e: SpeechRecognitionEvent) => {
+          const transcript = e.results[0][0].transcript;
+          setQuery(transcript);
+        },
+      );
     } else {
       // Web Speech API unsupported, focus the text input
       inputRef.current?.focus();
     }
-  }, [onSearch]);
+  }, []);
 
   const startListening = () => {
     if (recognitionRef.current) {
@@ -36,7 +36,6 @@ export const SearchBar: React.FC<SearchBarProps> = ({ onSearch }) => {
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
     setQuery(value);
-    onSearch?.(value);
   };
 
   return (
@@ -48,7 +47,11 @@ export const SearchBar: React.FC<SearchBarProps> = ({ onSearch }) => {
         onChange={handleChange}
         placeholder="Search terms..."
       />
-      <button type="button" onClick={startListening} aria-label="Use microphone">
+      <button
+        type="button"
+        onClick={startListening}
+        aria-label="Use microphone"
+      >
         🎤
       </button>
     </div>

--- a/src/hooks/useSearch.tsx
+++ b/src/hooks/useSearch.tsx
@@ -1,0 +1,82 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+
+interface SearchResult {
+  term: string;
+  definition: string;
+}
+
+interface SearchContextValue {
+  query: string;
+  setQuery: (q: string) => void;
+  results: SearchResult[];
+  fuzziness: number;
+  setFuzziness: (f: number) => void;
+}
+
+const SearchContext = createContext<SearchContextValue | undefined>(undefined);
+
+const FUZZINESS_KEY = "searchFuzziness";
+
+export const SearchProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<SearchResult[]>([]);
+  const [fuzziness, setFuzzinessState] = useState<number>(() => {
+    if (typeof window === "undefined") return 0;
+    const raw = window.localStorage.getItem(FUZZINESS_KEY);
+    const parsed = parseInt(raw ?? "0", 10);
+    return Number.isNaN(parsed) ? 0 : parsed;
+  });
+
+  // Persist fuzziness
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(FUZZINESS_KEY, String(fuzziness));
+    } catch {
+      /* ignore */
+    }
+  }, [fuzziness]);
+
+  // Refresh results when query or fuzziness change
+  useEffect(() => {
+    if (!query) {
+      setResults([]);
+      return;
+    }
+    fetch(`/api/search?q=${encodeURIComponent(query)}&fuzziness=${fuzziness}`)
+      .then((res) => (res.ok ? res.json() : { results: [] }))
+      .then((data) => setResults(data.results || []))
+      .catch(() => setResults([]));
+  }, [query, fuzziness]);
+
+  const setFuzziness = useCallback((f: number) => {
+    setFuzzinessState(f);
+  }, []);
+
+  const value: SearchContextValue = {
+    query,
+    setQuery,
+    results,
+    fuzziness,
+    setFuzziness,
+  };
+
+  return (
+    <SearchContext.Provider value={value}>{children}</SearchContext.Provider>
+  );
+};
+
+export function useSearch(): SearchContextValue {
+  const ctx = useContext(SearchContext);
+  if (!ctx) throw new Error("useSearch must be used within a SearchProvider");
+  return ctx;
+}
+
+export default useSearch;


### PR DESCRIPTION
## Summary
- add SearchSettingsPopover with fuzziness slider
- store fuzziness in useSearch hook and refresh results on change
- wire SearchBar to search context

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b655180a68832896a7a141097579d6