### PR TITLE
feat: add persistent search history with pinning

### DIFF
--- a/components/search/HistoryPanel.tsx
+++ b/components/search/HistoryPanel.tsx
@@ -1,38 +1,33 @@
-import React, { useState } from "react";
-import useSearchHistory from "../../hooks/useSearchHistory";
+import React from "react";
+import { SearchEntry } from "../../src/hooks/useSearchHistory";
 
 type Props = {
-  authenticated?: boolean;
+  entries: SearchEntry[];
   onSelect?: (query: string) => void;
+  onPinToggle?: (query: string) => void;
+  onClear?: () => void;
 };
 
-export function HistoryPanel({ authenticated = false, onSelect }: Props) {
-  const { history, clearHistory } = useSearchHistory(authenticated);
-  const [open, setOpen] = useState(false);
-
-  if (!history.length) return null;
+export function HistoryPanel({ entries, onSelect, onPinToggle, onClear }: Props) {
+  if (!entries.length) return null;
 
   return (
     <div className="history-panel">
-      <button className="toggle" onClick={() => setOpen((v) => !v)}>
-        {open ? "Hide" : "Show"} Search History
+      <ul>
+        {entries.map((item) => (
+          <li key={item.query}>
+            <button type="button" onClick={() => onSelect?.(item.query)}>
+              {item.query}
+            </button>
+            <button type="button" onClick={() => onPinToggle?.(item.query)}>
+              {item.pinned ? "Unpin" : "Pin"}
+            </button>
+          </li>
+        ))}
+      </ul>
+      <button className="clear" onClick={onClear}>
+        Clear
       </button>
-      {open && (
-        <div className="history-list">
-          <ul>
-            {history.map((item, i) => (
-              <li key={i}>
-                <button type="button" onClick={() => onSelect?.(item)}>
-                  {item}
-                </button>
-              </li>
-            ))}
-          </ul>
-          <button className="clear" onClick={clearHistory}>
-            Clear
-          </button>
-        </div>
-      )}
     </div>
   );
 }

--- a/components/search/SearchBar.tsx
+++ b/components/search/SearchBar.tsx
@@ -1,26 +1,33 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { ChangeEvent } from "react";
+import Autocomplete from "./Autocomplete";
+import HistoryPanel from "./HistoryPanel";
+import useSearchHistory from "../../src/hooks/useSearchHistory";
 
 export default function SearchBar() {
   const router = useRouter();
+  const { history, pinned, addQuery, togglePin, clearHistory } =
+    useSearchHistory();
 
-  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
-    const query = e.target.value.trim();
-    if (query) {
-      router.push(`/search?q=${encodeURIComponent(query)}`);
-    } else {
-      router.push("/search");
-    }
+  const handleCommit = (value: string) => {
+    const query = value.trim();
+    if (!query) return;
+    router.push(`/search?q=${encodeURIComponent(query)}`);
+    addQuery(query);
   };
 
+  const entries = [...pinned, ...history];
+
   return (
-    <input
-      type="text"
-      placeholder="Search terms..."
-      onChange={handleChange}
-      aria-label="Search terms"
-    />
+    <div>
+      <Autocomplete onCommit={handleCommit} pinned={pinned.map((p) => p.query)} />
+      <HistoryPanel
+        entries={entries}
+        onSelect={handleCommit}
+        onPinToggle={togglePin}
+        onClear={clearHistory}
+      />
+    </div>
   );
 }

--- a/src/hooks/useSearchHistory.ts
+++ b/src/hooks/useSearchHistory.ts
@@ -1,0 +1,88 @@
+import { useCallback, useEffect, useState } from "react";
+
+export interface SearchEntry {
+  query: string;
+  timestamp: number;
+  pinned?: boolean;
+}
+
+const STORAGE_KEY = "searchHistory";
+const LIMIT = 20;
+
+function load(): SearchEntry[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      return parsed.filter((e) => typeof e.query === "string").map((e) => ({
+        query: e.query,
+        timestamp: typeof e.timestamp === "number" ? e.timestamp : Date.now(),
+        pinned: !!e.pinned,
+      }));
+    }
+  } catch {
+    /* ignore */
+  }
+  return [];
+}
+
+function trim(entries: SearchEntry[]): SearchEntry[] {
+  let next = [...entries].sort((a, b) => b.timestamp - a.timestamp);
+  if (next.length <= LIMIT) return next;
+  const pinned = next.filter((e) => e.pinned);
+  const unpinned = next.filter((e) => !e.pinned);
+  const trimmed = [
+    ...pinned,
+    ...unpinned.slice(0, Math.max(0, LIMIT - pinned.length)),
+  ];
+  next = trimmed.sort((a, b) => b.timestamp - a.timestamp);
+  return next.slice(0, LIMIT);
+}
+
+export function useSearchHistory() {
+  const [entries, setEntries] = useState<SearchEntry[]>(() => load());
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+    } catch {
+      /* ignore */
+    }
+  }, [entries]);
+
+  const addQuery = useCallback((query: string) => {
+    const q = query.trim();
+    if (!q) return;
+    setEntries((prev) => {
+      const existing = prev.find((e) => e.query === q);
+      const pinned = existing?.pinned;
+      const next = [
+        { query: q, timestamp: Date.now(), pinned },
+        ...prev.filter((e) => e.query !== q),
+      ];
+      return trim(next);
+    });
+  }, []);
+
+  const togglePin = useCallback((query: string) => {
+    setEntries((prev) =>
+      trim(
+        prev.map((e) =>
+          e.query === query ? { ...e, pinned: !e.pinned, timestamp: Date.now() } : e,
+        ),
+      ),
+    );
+  }, []);
+
+  const clearHistory = useCallback(() => setEntries([]), []);
+
+  const pinned = entries.filter((e) => e.pinned);
+  const history = entries.filter((e) => !e.pinned);
+
+  return { history, pinned, addQuery, togglePin, clearHistory };
+}
+
+export default useSearchHistory;
+


### PR DESCRIPTION
## Summary
- track last 20 unique search queries with timestamps and pin states in localStorage
- show search history under the search bar with pin/unpin actions
- prioritize pinned queries above fetched autocomplete suggestions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b65517ff9883289cbd7981c608d96b