### PR TITLE
feat: add readability meter

### DIFF
--- a/components/term/TermHeader.tsx
+++ b/components/term/TermHeader.tsx
@@ -1,0 +1,70 @@
+import React, { useEffect, useState } from 'react';
+import { fleschKincaid } from '../../src/utils/readability';
+
+interface TermHeaderProps {
+  title: string;
+  contentRef: React.RefObject<HTMLElement>;
+}
+
+function getColor(score: number): string {
+  if (score >= 60) return '#16a34a'; // green
+  if (score >= 30) return '#facc15'; // yellow
+  return '#dc2626'; // red
+}
+
+const TermHeader: React.FC<TermHeaderProps> = ({ title, contentRef }) => {
+  const [score, setScore] = useState(0);
+
+  useEffect(() => {
+    const calc = () => {
+      if (contentRef.current) {
+        const text = contentRef.current.innerText || '';
+        setScore(fleschKincaid(text));
+      }
+    };
+
+    calc();
+    if (contentRef.current) {
+      const observer = new MutationObserver(() => calc());
+      observer.observe(contentRef.current, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        characterData: true,
+      });
+      return () => observer.disconnect();
+    }
+  }, [contentRef]);
+
+  const barColor = getColor(score);
+  const width = `${Math.max(0, Math.min(100, score))}%`;
+
+  return (
+    <header className="term-header" style={{ marginBottom: '1rem' }}>
+      <h1>{title}</h1>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+        <div
+          style={{
+            flex: 1,
+            height: '8px',
+            background: '#e5e7eb',
+            borderRadius: '4px',
+            overflow: 'hidden',
+          }}
+        >
+          <div
+            style={{
+              width,
+              height: '100%',
+              background: barColor,
+              transition: 'width 0.3s ease, background 0.3s ease',
+            }}
+          />
+        </div>
+        <span style={{ fontSize: '0.875rem' }}>{Math.round(score)}</span>
+      </div>
+    </header>
+  );
+};
+
+export default TermHeader;

--- a/components/term/TermPage.tsx
+++ b/components/term/TermPage.tsx
@@ -1,4 +1,6 @@
 import { MDXRemote } from 'next-mdx-remote/rsc';
+import { useRef } from 'react';
+import TermHeader from './TermHeader';
 
 interface SourceLinks {
   nist?: string;
@@ -17,33 +19,36 @@ interface TermPageProps {
  */
 export default function TermPage({ title, body, sources }: TermPageProps) {
   const hasSources = sources && (sources.nist || sources.owasp || sources.attack);
+  const contentRef = useRef<HTMLDivElement>(null);
 
   return (
     <article className="term">
-      <h1>{title}</h1>
-      <MDXRemote source={body} />
-      {hasSources && (
-        <section className="sources">
-          <h2>Sources</h2>
-          <ul>
-            {sources?.nist && (
-              <li>
-                NIST: <a href={sources.nist}>{sources.nist}</a>
-              </li>
-            )}
-            {sources?.owasp && (
-              <li>
-                OWASP: <a href={sources.owasp}>{sources.owasp}</a>
-              </li>
-            )}
-            {sources?.attack && (
-              <li>
-                ATT&CK: <a href={sources.attack}>{sources.attack}</a>
-              </li>
-            )}
-          </ul>
-        </section>
-      )}
+      <TermHeader title={title} contentRef={contentRef} />
+      <div ref={contentRef}>
+        <MDXRemote source={body} />
+        {hasSources && (
+          <section className="sources">
+            <h2>Sources</h2>
+            <ul>
+              {sources?.nist && (
+                <li>
+                  NIST: <a href={sources.nist}>{sources.nist}</a>
+                </li>
+              )}
+              {sources?.owasp && (
+                <li>
+                  OWASP: <a href={sources.owasp}>{sources.owasp}</a>
+                </li>
+              )}
+              {sources?.attack && (
+                <li>
+                  ATT&CK: <a href={sources.attack}>{sources.attack}</a>
+                </li>
+              )}
+            </ul>
+          </section>
+        )}
+      </div>
     </article>
   );
 }

--- a/src/utils/readability.ts
+++ b/src/utils/readability.ts
@@ -1,0 +1,27 @@
+export function countSyllables(word: string): number {
+  word = word.toLowerCase();
+  if (word.length <= 3) {
+    return 1;
+  }
+  // Remove silent suffixes
+  word = word.replace(/(?:[^laeiouy]es|ed|[^laeiouy]e)$/i, "");
+  // Remove leading y
+  word = word.replace(/^y/, "");
+  const matches = word.match(/[aeiouy]{1,2}/g);
+  return matches ? matches.length : 1;
+}
+
+export function fleschKincaid(text: string): number {
+  if (!text) {
+    return 0;
+  }
+  const sentences = (text.match(/[.!?]+/g) || []).length || 1;
+  const words = (text.match(/\b\w+\b/g) || []).length;
+  if (words === 0) {
+    return 0;
+  }
+  const syllables = (text.match(/\b\w+\b/g) || []).reduce((sum, w) => sum + countSyllables(w), 0);
+  const score = 206.835 - 1.015 * (words / sentences) - 84.6 * (syllables / words);
+  // Clamp score to 0-100 for meter display
+  return Math.max(0, Math.min(100, score));
+}


### PR DESCRIPTION
## Summary
- add Flesch-Kincaid readability calculator
- show dynamic readability meter in term headers
- recalc score when term sections change

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6551b00708328866b975b726c2940