### PR TITLE
feat: support personal terms

### DIFF
--- a/app/components/SearchInput.tsx
+++ b/app/components/SearchInput.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { searchPersonalTerms, PersonalTerm } from "../../lib/personalTerms";
 
 interface Term {
   term: string;
@@ -15,6 +16,7 @@ interface SearchResponse {
 export default function SearchInput() {
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<Term[]>([]);
+  const [personal, setPersonal] = useState<PersonalTerm[]>([]);
 
   const handleChange = async (
     e: React.ChangeEvent<HTMLInputElement>
@@ -29,6 +31,8 @@ export default function SearchInput() {
     } else {
       setResults([]);
     }
+    const p = await searchPersonalTerms(value);
+    setPersonal(p);
   };
 
   return (
@@ -40,9 +44,13 @@ export default function SearchInput() {
         placeholder="Search terms..."
       />
       <ul>
-        {results.map((item) => (
+        {[
+          ...personal.map((p) => ({ term: p.slug, definition: p.definition, personal: true })),
+          ...results.map((r) => ({ ...r, personal: false })),
+        ].map((item) => (
           <li key={item.term}>
-            <strong>{item.term}:</strong> {item.definition}
+            <strong>{item.term}</strong>
+            {item.personal && <span className="badge"> Personal</span>}: {item.definition}
           </li>
         ))}
       </ul>

--- a/components/PersonalTermForm.tsx
+++ b/components/PersonalTermForm.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { useState, FormEvent, useEffect } from 'react';
+import { PersonalTerm, savePersonalTerm } from '../lib/personalTerms';
+
+interface PersonalTermFormProps {
+  initial?: PersonalTerm;
+  onSave?: (term: PersonalTerm) => void;
+}
+
+export default function PersonalTermForm({ initial, onSave }: PersonalTermFormProps) {
+  const [slug, setSlug] = useState(initial?.slug || '');
+  const [definition, setDefinition] = useState(initial?.definition || '');
+  const [tags, setTags] = useState(initial?.tags.join(', ') || '');
+  const [source, setSource] = useState(initial?.source || '');
+
+  useEffect(() => {
+    if (initial) {
+      setSlug(initial.slug);
+      setDefinition(initial.definition);
+      setTags(initial.tags.join(', '));
+      setSource(initial.source);
+    }
+  }, [initial]);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    const term: PersonalTerm = {
+      slug,
+      definition,
+      tags: tags.split(',').map(t => t.trim()).filter(Boolean),
+      source,
+    };
+    await savePersonalTerm(term);
+    onSave?.(term);
+    setSlug('');
+    setDefinition('');
+    setTags('');
+    setSource('');
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <div>
+        <label>
+          Slug
+          <input
+            type="text"
+            value={slug}
+            onChange={(e) => setSlug(e.target.value)}
+            required
+          />
+        </label>
+      </div>
+      <div>
+        <label>
+          Definition
+          <textarea
+            value={definition}
+            onChange={(e) => setDefinition(e.target.value)}
+            required
+          />
+        </label>
+      </div>
+      <div>
+        <label>
+          Tags (comma separated)
+          <input
+            type="text"
+            value={tags}
+            onChange={(e) => setTags(e.target.value)}
+          />
+        </label>
+      </div>
+      <div>
+        <label>
+          Source
+          <input
+            type="text"
+            value={source}
+            onChange={(e) => setSource(e.target.value)}
+          />
+        </label>
+      </div>
+      <button type="submit">Save</button>
+    </form>
+  );
+}

--- a/lib/personalTerms.ts
+++ b/lib/personalTerms.ts
@@ -1,0 +1,50 @@
+import { openDB, DBSchema } from 'idb';
+
+export interface PersonalTerm {
+  slug: string;
+  definition: string;
+  tags: string[];
+  source: string;
+}
+
+interface PersonalTermsDB extends DBSchema {
+  terms: {
+    key: string;
+    value: PersonalTerm;
+    indexes: { 'by-slug': string };
+  };
+}
+
+const DB_NAME = 'personal-terms';
+const DB_VERSION = 1;
+const STORE_NAME = 'terms';
+
+async function getDB() {
+  return openDB<PersonalTermsDB>(DB_NAME, DB_VERSION, {
+    upgrade(db) {
+      const store = db.createObjectStore(STORE_NAME, { keyPath: 'slug' });
+      store.createIndex('by-slug', 'slug');
+    },
+  });
+}
+
+export async function savePersonalTerm(term: PersonalTerm) {
+  const db = await getDB();
+  await db.put(STORE_NAME, term);
+}
+
+export async function getAllPersonalTerms(): Promise<PersonalTerm[]> {
+  const db = await getDB();
+  return db.getAll(STORE_NAME);
+}
+
+export async function searchPersonalTerms(query: string): Promise<PersonalTerm[]> {
+  const q = query.toLowerCase();
+  const all = await getAllPersonalTerms();
+  return all.filter(
+    (t) =>
+      t.slug.toLowerCase().includes(q) ||
+      t.definition.toLowerCase().includes(q)
+  );
+}
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "framer-motion": "^12.23.12",
         "hammerjs": "^2.0.8",
+        "idb": "^7.1.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-joyride": "^2.9.3",
@@ -1439,6 +1440,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/idb": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
+      "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
+      "license": "ISC"
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "framer-motion": "^12.23.12",
     "hammerjs": "^2.0.8",
+    "idb": "^7.1.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-joyride": "^2.9.3",


### PR DESCRIPTION
## Summary
- store personal terms in IndexedDB via idb
- add PersonalTermForm for adding and editing custom entries
- surface personal terms in search results with Personal badge

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6551bb47c83288efdccd7bd4baa68