### PR TITLE
Detect end of term content and show next-term banner

### DIFF
--- a/app/term/[slug]/page.tsx
+++ b/app/term/[slug]/page.tsx
@@ -17,7 +17,14 @@ export default async function Page({ params }: PageProps) {
     notFound();
   }
   const { content, data } = matter(file!);
-  return <TermPage title={data.title ?? params.slug} body={content} sources={data.sources} />;
+  return (
+    <TermPage
+      title={data.title ?? params.slug}
+      body={content}
+      sources={data.sources}
+      slug={params.slug}
+    />
+  );
 }
 
 export async function generateStaticParams() {

--- a/components/term/NextInQueueBanner.tsx
+++ b/components/term/NextInQueueBanner.tsx
@@ -1,0 +1,56 @@
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+
+interface NextInQueueBannerProps {
+  slug: string;
+}
+
+interface QueueItem {
+  slug: string;
+  title?: string;
+}
+
+function getNextQueueItem(current: string): QueueItem | null {
+  try {
+    const raw = localStorage.getItem('termQueue');
+    if (!raw) return null;
+    const items = JSON.parse(raw) as Array<string | QueueItem>;
+    const index = items.findIndex((item) =>
+      typeof item === 'string' ? item === current : item.slug === current,
+    );
+    const next = items[index + 1];
+    if (!next) return null;
+    return typeof next === 'string' ? { slug: next } : next;
+  } catch {
+    return null;
+  }
+}
+
+export default function NextInQueueBanner({ slug }: NextInQueueBannerProps) {
+  const [nextItem, setNextItem] = useState<QueueItem | null>(null);
+  const [readerMode, setReaderMode] = useState(false);
+
+  useEffect(() => {
+    setNextItem(getNextQueueItem(slug));
+    const root = document.documentElement;
+    const body = document.body;
+    const isReader =
+      root.classList.contains('reader-mode') ||
+      body.classList.contains('reader-mode') ||
+      root.getAttribute('data-reader-mode') === 'true' ||
+      body.getAttribute('data-reader-mode') === 'true';
+    setReaderMode(isReader);
+  }, [slug]);
+
+  if (readerMode || !nextItem) return null;
+
+  const label = nextItem.title ? nextItem.title : nextItem.slug;
+
+  return (
+    <aside
+      className="next-in-queue" role="complementary" aria-live="polite" tabIndex={-1}
+    >
+      <Link href={`/term/${nextItem.slug}`}>Next in queue: {label}</Link>
+    </aside>
+  );
+}

--- a/components/term/TermPage.tsx
+++ b/components/term/TermPage.tsx
@@ -1,4 +1,6 @@
 import { MDXRemote } from 'next-mdx-remote/rsc';
+import useEndOfContent from '@/hooks/useEndOfContent';
+import NextInQueueBanner from './NextInQueueBanner';
 
 interface SourceLinks {
   nist?: string;
@@ -10,13 +12,15 @@ interface TermPageProps {
   title: string;
   body: string;
   sources?: SourceLinks;
+  slug: string;
 }
 
 /**
  * Renders a security term page including MDX content and optional sources.
  */
-export default function TermPage({ title, body, sources }: TermPageProps) {
+export default function TermPage({ title, body, sources, slug }: TermPageProps) {
   const hasSources = sources && (sources.nist || sources.owasp || sources.attack);
+  const { endRef, reachedEnd } = useEndOfContent<HTMLDivElement>();
 
   return (
     <article className="term">
@@ -44,6 +48,8 @@ export default function TermPage({ title, body, sources }: TermPageProps) {
           </ul>
         </section>
       )}
+      <div ref={endRef} />
+      {reachedEnd && <NextInQueueBanner slug={slug} />}
     </article>
   );
 }

--- a/hooks/useEndOfContent.ts
+++ b/hooks/useEndOfContent.ts
@@ -1,0 +1,32 @@
+import { useEffect, useRef, useState } from 'react';
+
+/**
+ * useEndOfContent detects when the user has scrolled to the end of the
+ * provided element. A ref to a sentinel element is returned which should be
+ * placed at the end of the content. When the sentinel enters the viewport the
+ * hook marks the content as finished and invokes the optional callback.
+ */
+export default function useEndOfContent<T extends HTMLElement>(
+  onEnd?: () => void,
+) {
+  const endRef = useRef<T>(null);
+  const [reachedEnd, setReachedEnd] = useState(false);
+
+  useEffect(() => {
+    const target = endRef.current;
+    if (!target) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setReachedEnd(true);
+          onEnd?.();
+        }
+      },
+      { threshold: 1.0 },
+    );
+    observer.observe(target);
+    return () => observer.disconnect();
+  }, [onEnd]);
+
+  return { endRef, reachedEnd };
+}


### PR DESCRIPTION
## Summary
- add `useEndOfContent` hook to observe when readers reach the end of an article
- display `NextInQueueBanner` for one-tap navigation to the next queued term
- wire term pages to use new hook and banner

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b655204b708328bd0cb394caa61de2