### PR TITLE
feat: toggle synonym pills on term references

### DIFF
--- a/app/terms/[slug]/page.tsx
+++ b/app/terms/[slug]/page.tsx
@@ -3,6 +3,7 @@ import fs from "fs";
 import path from "path";
 import yaml from "js-yaml";
 import { FAQBlock } from "../../components/FAQBlock";
+import TermToolbar from "../../../components/term/TermToolbar";
 
 interface Term {
   name: string;
@@ -45,6 +46,7 @@ export default function TermPage({ params }: { params: { slug: string } }) {
 
   return (
     <main>
+      <TermToolbar />
       <h1>{term.name}</h1>
       <p>{term.definition}</p>
       {term.synonyms && term.synonyms.length > 0 && (

--- a/components/term/TermToolbar.tsx
+++ b/components/term/TermToolbar.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+interface TermEntry {
+  term?: string;
+  name?: string;
+  synonyms?: string[];
+}
+
+/**
+ * Toolbar that toggles synonym pills for term references.
+ */
+export default function TermToolbar() {
+  const [enabled, setEnabled] = useState(false);
+  const [map, setMap] = useState<Record<string, string[]>>({});
+
+  useEffect(() => {
+    if (enabled) inject();
+    else remove();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled]);
+
+  async function loadSynonyms() {
+    if (Object.keys(map).length) return;
+    try {
+      const res = await fetch("/terms.json");
+      const data = await res.json();
+      const list: TermEntry[] = Array.isArray(data) ? data : data.terms || [];
+      const dictionary: Record<string, string[]> = {};
+      list.forEach((t) => {
+        const key = (t.term || t.name || "").toLowerCase();
+        if (key && t.synonyms && t.synonyms.length) {
+          dictionary[key] = t.synonyms;
+        }
+      });
+      setMap(dictionary);
+    } catch (err) {
+      console.error("Failed to load terms", err);
+    }
+  }
+
+  function showToast(message: string) {
+    const toast = document.createElement("div");
+    toast.className = "toast show";
+    toast.textContent = message;
+    document.body.appendChild(toast);
+    setTimeout(() => {
+      toast.classList.remove("show");
+      toast.remove();
+    }, 2000);
+  }
+
+  function inject() {
+    document
+      .querySelectorAll<HTMLAnchorElement>('a[href^="/terms/"]')
+      .forEach((link) => {
+        const term = link.textContent?.trim().toLowerCase() || "";
+        const syns = map[term];
+        if (!syns) return;
+        const frag = document.createDocumentFragment();
+        syns.forEach((syn) => {
+          const pill = document.createElement("span");
+          pill.textContent = syn;
+          pill.className = "synonym-pill";
+          pill.addEventListener("click", () => {
+            navigator.clipboard.writeText(syn);
+            showToast(`Copied \"${syn}\"`);
+          });
+          frag.appendChild(pill);
+        });
+        link.after(frag);
+      });
+  }
+
+  function remove() {
+    document
+      .querySelectorAll(".synonym-pill")
+      .forEach((el) => el.remove());
+  }
+
+  const toggle = async () => {
+    if (!enabled) await loadSynonyms();
+    setEnabled((prev) => !prev);
+  };
+
+  return (
+    <div className="term-toolbar">
+      <button onClick={toggle} aria-pressed={enabled}>
+        {enabled ? "Hide Synonyms" : "Show Synonyms"}
+      </button>
+    </div>
+  );
+}
+

--- a/styles.css
+++ b/styles.css
@@ -581,3 +581,13 @@ body.dark-mode #alpha-nav button.active {
 .selection-highlight {
   background-color: yellow;
 }
+
+.synonym-pill {
+  display: inline-block;
+  margin-left: 4px;
+  padding: 2px 6px;
+  background-color: #e0e0e0;
+  border-radius: 12px;
+  cursor: pointer;
+  font-size: 0.8rem;
+}


### PR DESCRIPTION
## Summary
- add TermToolbar with button to show or hide synonym pills
- clicking a synonym pill copies text and shows a toast
- integrate toolbar on term pages and style synonym pills

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6552172a083288fc1033dde63d543