### PR TITLE
feat: add definition contrast setting

### DIFF
--- a/script.js
+++ b/script.js
@@ -6,7 +6,9 @@ const alphaNav = document.getElementById("alpha-nav");
 const darkModeToggle = document.getElementById("dark-mode-toggle");
 const showFavoritesToggle = document.getElementById("show-favorites");
 const resetOrderBtn = document.getElementById("reset-order");
-const favorites = new Set(JSON.parse(localStorage.getItem("favorites") || "[]"));
+const favorites = new Set(
+  JSON.parse(localStorage.getItem("favorites") || "[]"),
+);
 const siteUrl = "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/";
 const canonicalLink = document.getElementById("canonical-link");
 
@@ -30,9 +32,11 @@ searchWrapper.appendChild(tokenOverlay);
 
 // copy font and padding to overlay so text lines up
 const inputStyle = window.getComputedStyle(searchInput);
-["font", "padding", "border", "boxSizing", "lineHeight", "height"].forEach((prop) => {
-  tokenOverlay.style[prop] = inputStyle[prop];
-});
+["font", "padding", "border", "boxSizing", "lineHeight", "height"].forEach(
+  (prop) => {
+    tokenOverlay.style[prop] = inputStyle[prop];
+  },
+);
 searchInput.style.background = "transparent";
 searchInput.style.color = "transparent";
 searchInput.style.caretColor = inputStyle.color;
@@ -46,13 +50,17 @@ helpPopover.style.display = "none";
 document.body.appendChild(helpPopover);
 
 function escapeHtml(str) {
-  return str.replace(/[&<>"']/g, (c) => ({
-    "&": "&amp;",
-    "<": "&lt;",
-    ">": "&gt;",
-    '"': "&quot;",
-    "'": "&#39;",
-  })[c]);
+  return str.replace(
+    /[&<>"']/g,
+    (c) =>
+      ({
+        "&": "&amp;",
+        "<": "&lt;",
+        ">": "&gt;",
+        '"': "&quot;",
+        "'": "&#39;",
+      })[c],
+  );
 }
 
 function tokenize(value) {
@@ -76,7 +84,10 @@ function tokenize(value) {
   let lastType = null;
   tokens.forEach((t, idx) => {
     if (t.type === "space") return;
-    if (t.type === "operator" && (lastType === null || lastType === "operator")) {
+    if (
+      t.type === "operator" &&
+      (lastType === null || lastType === "operator")
+    ) {
       t.error = true;
     }
     if (idx === tokens.length - 1 && t.type === "operator") {
@@ -123,7 +134,10 @@ function getCaretCoordinates(input) {
   const x = div.offsetWidth;
   document.body.removeChild(div);
   const rect = input.getBoundingClientRect();
-  return { x: rect.left + x - input.scrollLeft + window.scrollX, y: rect.top + rect.height + window.scrollY };
+  return {
+    x: rect.left + x - input.scrollLeft + window.scrollX,
+    y: rect.top + rect.height + window.scrollY,
+  };
 }
 
 function positionHelp() {
@@ -142,7 +156,7 @@ searchInput.addEventListener("focus", () => {
   searchInput.addEventListener(evt, () => {
     positionHelp();
     updateTokens();
-  })
+  }),
 );
 
 searchInput.addEventListener("blur", () => {
@@ -158,10 +172,17 @@ if (localStorage.getItem("darkMode") === "true") {
   document.body.classList.add("dark-mode");
 }
 
+if (localStorage.getItem("definitionHighContrast") === "true") {
+  document.body.classList.add("definition-high-contrast");
+}
+
 if (darkModeToggle) {
   darkModeToggle.addEventListener("click", () => {
     document.body.classList.toggle("dark-mode");
-    localStorage.setItem("darkMode", document.body.classList.contains("dark-mode"));
+    localStorage.setItem(
+      "darkMode",
+      document.body.classList.contains("dark-mode"),
+    );
   });
 }
 
@@ -220,17 +241,17 @@ function loadTerms() {
       const termParam = params.get("term");
       if (termParam) {
         const matchedTerm = termsData.terms.find(
-          (t) => t.term.toLowerCase() === termParam.toLowerCase()
+          (t) => t.term.toLowerCase() === termParam.toLowerCase(),
         );
         if (matchedTerm) {
           displayDefinition(matchedTerm);
         }
       } else if (window.location.hash) {
         const termFromHash = decodeURIComponent(
-          window.location.hash.substring(1)
+          window.location.hash.substring(1),
         );
         const matchedTerm = termsData.terms.find(
-          (t) => t.term.toLowerCase() === termFromHash.toLowerCase()
+          (t) => t.term.toLowerCase() === termFromHash.toLowerCase(),
         );
         if (matchedTerm) {
           displayDefinition(matchedTerm);
@@ -241,7 +262,7 @@ function loadTerms() {
       console.error("Detailed error fetching data:", error);
       definitionContainer.style.display = "block";
       definitionContainer.innerHTML =
-        '<p>Unable to load dictionary data. Please check your connection and try again.</p>' +
+        "<p>Unable to load dictionary data. Please check your connection and try again.</p>" +
         '<button id="retry-fetch">Retry</button>';
       const retryBtn = document.getElementById("retry-fetch");
       if (retryBtn) {
@@ -305,12 +326,16 @@ function saveRating(term, value) {
 }
 
 function highlightActiveButton(button) {
-  alphaNav.querySelectorAll("button").forEach((btn) => btn.classList.remove("active"));
+  alphaNav
+    .querySelectorAll("button")
+    .forEach((btn) => btn.classList.remove("active"));
   button.classList.add("active");
 }
 
 function buildAlphaNav() {
-  const letters = Array.from(new Set(termsData.terms.map((t) => t.term.charAt(0).toUpperCase()))).sort();
+  const letters = Array.from(
+    new Set(termsData.terms.map((t) => t.term.charAt(0).toUpperCase())),
+  ).sort();
 
   const allButton = document.createElement("button");
   allButton.textContent = "All";
@@ -339,63 +364,70 @@ function populateTermsList() {
   termsList.innerHTML = "";
   const searchValue = searchInput.value.trim().toLowerCase();
   termsData.terms.forEach((item) => {
-      const matchesSearch = item.term.toLowerCase().includes(searchValue);
-      const matchesFavorites = !showFavoritesToggle || !showFavoritesToggle.checked || favorites.has(item.term);
-      const matchesLetter =
-        currentLetterFilter === "All" || item.term.charAt(0).toUpperCase() === currentLetterFilter;
-      if (matchesSearch && matchesFavorites && matchesLetter) {
-        const termDiv = document.createElement("div");
-        termDiv.classList.add("dictionary-item");
-        termDiv.dataset.term = item.term;
-        termDiv.draggable = true;
-        termDiv.tabIndex = 0;
-        termDiv.addEventListener("dragstart", handleDragStart);
-        termDiv.addEventListener("dragover", handleDragOver);
-        termDiv.addEventListener("drop", handleDrop);
-        termDiv.addEventListener("keydown", handleKeyDown);
+    const matchesSearch = item.term.toLowerCase().includes(searchValue);
+    const matchesFavorites =
+      !showFavoritesToggle ||
+      !showFavoritesToggle.checked ||
+      favorites.has(item.term);
+    const matchesLetter =
+      currentLetterFilter === "All" ||
+      item.term.charAt(0).toUpperCase() === currentLetterFilter;
+    if (matchesSearch && matchesFavorites && matchesLetter) {
+      const termDiv = document.createElement("div");
+      termDiv.classList.add("dictionary-item");
+      termDiv.dataset.term = item.term;
+      termDiv.draggable = true;
+      termDiv.tabIndex = 0;
+      termDiv.addEventListener("dragstart", handleDragStart);
+      termDiv.addEventListener("dragover", handleDragOver);
+      termDiv.addEventListener("drop", handleDrop);
+      termDiv.addEventListener("keydown", handleKeyDown);
 
-        const termHeader = document.createElement("h3");
-        if (searchValue) {
-          const escaped = searchValue.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-          const regex = new RegExp(`(${escaped})`, "gi");
-          termHeader.innerHTML = item.term.replace(regex, "<mark>$1</mark>");
-        } else {
-          termHeader.textContent = item.term;
-        }
-
-        const star = document.createElement("span");
-        star.classList.add("favorite-star");
-        star.textContent = "★";
-        if (favorites.has(item.term)) {
-          star.classList.add("favorited");
-        }
-        star.addEventListener("click", (e) => {
-          e.stopPropagation();
-          toggleFavorite(item.term);
-          star.classList.toggle("favorited");
-          if (showFavoritesToggle && showFavoritesToggle.checked) {
-            populateTermsList();
-          }
-        });
-        termHeader.appendChild(star);
-        termDiv.appendChild(termHeader);
-
-        const definitionPara = document.createElement("p");
-        definitionPara.textContent = item.definition;
-        termDiv.appendChild(definitionPara);
-
-        termDiv.addEventListener("click", () => {
-          displayDefinition(item);
-        });
-
-        termsList.appendChild(termDiv);
+      const termHeader = document.createElement("h3");
+      if (searchValue) {
+        const escaped = searchValue.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+        const regex = new RegExp(`(${escaped})`, "gi");
+        termHeader.innerHTML = item.term.replace(regex, "<mark>$1</mark>");
+      } else {
+        termHeader.textContent = item.term;
       }
-    });
+
+      const star = document.createElement("span");
+      star.classList.add("favorite-star");
+      star.textContent = "★";
+      if (favorites.has(item.term)) {
+        star.classList.add("favorited");
+      }
+      star.addEventListener("click", (e) => {
+        e.stopPropagation();
+        toggleFavorite(item.term);
+        star.classList.toggle("favorited");
+        if (showFavoritesToggle && showFavoritesToggle.checked) {
+          populateTermsList();
+        }
+      });
+      termHeader.appendChild(star);
+      termDiv.appendChild(termHeader);
+
+      const definitionPara = document.createElement("p");
+      definitionPara.textContent = item.definition;
+      termDiv.appendChild(definitionPara);
+
+      termDiv.addEventListener("click", () => {
+        displayDefinition(item);
+      });
+
+      termsList.appendChild(termDiv);
+    }
+  });
 }
 
 function saveOrder() {
   try {
-    localStorage.setItem("termOrder", JSON.stringify(termsData.terms.map((t) => t.term)));
+    localStorage.setItem(
+      "termOrder",
+      JSON.stringify(termsData.terms.map((t) => t.term)),
+    );
   } catch (e) {
     // Ignore storage errors
   }
@@ -462,7 +494,7 @@ function displayDefinition(term) {
   if (canonicalLink) {
     canonicalLink.setAttribute(
       "href",
-      `${siteUrl}#${encodeURIComponent(term.term)}`
+      `${siteUrl}#${encodeURIComponent(term.term)}`,
     );
   }
   const starElems = definitionContainer.querySelectorAll(".rating-star");
@@ -483,7 +515,11 @@ function displayDefinition(term) {
 function clearDefinition() {
   definitionContainer.style.display = "none";
   definitionContainer.innerHTML = "";
-  history.replaceState(null, "", window.location.pathname + window.location.search);
+  history.replaceState(
+    null,
+    "",
+    window.location.pathname + window.location.search,
+  );
   if (canonicalLink) {
     canonicalLink.setAttribute("href", siteUrl);
   }
@@ -501,7 +537,10 @@ function showRandomTerm() {
 
   const today = new Date().toDateString();
   try {
-    localStorage.setItem("lastRandomTerm", JSON.stringify({ date: today, term: randomTerm }));
+    localStorage.setItem(
+      "lastRandomTerm",
+      JSON.stringify({ date: today, term: randomTerm }),
+    );
   } catch (e) {
     // Ignore storage errors
   }
@@ -543,7 +582,7 @@ window.addEventListener("scroll", () => {
   scrollBtn.style.display = window.scrollY > 200 ? "block" : "none";
 });
 scrollBtn.addEventListener("click", () =>
-  window.scrollTo({ top: 0, behavior: "smooth" })
+  window.scrollTo({ top: 0, behavior: "smooth" }),
 );
 
 const selectionLinkBtn = document.createElement("button");
@@ -615,7 +654,7 @@ function highlightRange(start, end) {
   const walker = document.createTreeWalker(
     definitionContainer,
     NodeFilter.SHOW_TEXT,
-    null
+    null,
   );
   let node;
   let count = 0;
@@ -709,10 +748,9 @@ function startExport() {
     if (index + chunkSize < total) {
       setTimeout(() => processChunk(index + chunkSize), 0);
     } else {
-      const blob = new Blob(
-        [JSON.stringify({ terms: data }, null, 2)],
-        { type: "application/json" }
-      );
+      const blob = new Blob([JSON.stringify({ terms: data }, null, 2)], {
+        type: "application/json",
+      });
       const url = URL.createObjectURL(blob);
       const a = document.createElement("a");
       a.href = url;
@@ -767,7 +805,6 @@ function buildPrintToc() {
 
 window.addEventListener("beforeprint", buildPrintToc);
 
-
 const params = new URLSearchParams(window.location.search);
 if (params.get("motionDebug") === "1") {
   const debugScript = document.createElement("script");
@@ -779,4 +816,3 @@ if (params.get("motionDebug") === "1") {
   };
   document.head.appendChild(debugScript);
 }
-

--- a/src/settings/SettingsPage.tsx
+++ b/src/settings/SettingsPage.tsx
@@ -1,10 +1,10 @@
-import React, { useEffect, useRef, useState } from 'react';
-import ColorBlindPalette from './ColorBlindPalette';
+import React, { useEffect, useRef, useState } from "react";
+import ColorBlindPalette from "./ColorBlindPalette";
 import {
   buildSettingsIndex,
   searchSettings,
   SettingEntry,
-} from '../features/settings/SettingsIndex';
+} from "../features/settings/SettingsIndex";
 
 /**
  * Settings page with client side search. Results update as the user types and
@@ -13,8 +13,9 @@ import {
 export default function SettingsPage() {
   const rootRef = useRef<HTMLDivElement>(null);
   const indexRef = useRef<SettingEntry[]>([]);
-  const [query, setQuery] = useState('');
+  const [query, setQuery] = useState("");
   const [results, setResults] = useState<SettingEntry[]>([]);
+  const [definitionContrast, setDefinitionContrast] = useState(false);
 
   useEffect(() => {
     if (rootRef.current) {
@@ -23,20 +24,36 @@ export default function SettingsPage() {
   }, []);
 
   useEffect(() => {
+    const stored = localStorage.getItem("definitionHighContrast") === "true";
+    setDefinitionContrast(stored);
+    if (stored) {
+      document.body.classList.add("definition-high-contrast");
+    }
+  }, []);
+
+  useEffect(() => {
     setResults(searchSettings(indexRef.current, query));
   }, [query]);
 
   const handleResultClick = (entry: SettingEntry): void => {
-    const section = document.getElementById(entry.sectionId) as HTMLDetailsElement | null;
-    if (section && section.tagName.toLowerCase() === 'details') {
+    const section = document.getElementById(
+      entry.sectionId,
+    ) as HTMLDetailsElement | null;
+    if (section && section.tagName.toLowerCase() === "details") {
       section.open = true;
     }
     const el = document.getElementById(entry.id);
-    el?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    el?.scrollIntoView({ behavior: "smooth", block: "center" });
     if (el) {
-      el.classList.add('setting-highlight');
-      setTimeout(() => el.classList.remove('setting-highlight'), 2000);
+      el.classList.add("setting-highlight");
+      setTimeout(() => el.classList.remove("setting-highlight"), 2000);
     }
+  };
+
+  const handleContrastToggle = (checked: boolean): void => {
+    setDefinitionContrast(checked);
+    document.body.classList.toggle("definition-high-contrast", checked);
+    localStorage.setItem("definitionHighContrast", String(checked));
   };
 
   return (
@@ -72,6 +89,23 @@ export default function SettingsPage() {
             data-setting-keywords="color,theme,palette"
           >
             <ColorBlindPalette />
+          </div>
+        </div>
+        <div>
+          <label htmlFor="definition-contrast">Definition contrast</label>
+          <div
+            id="definition-contrast"
+            data-setting-label="High contrast definitions"
+            data-setting-keywords="contrast,definition,text"
+          >
+            <label>
+              <input
+                type="checkbox"
+                checked={definitionContrast}
+                onChange={(e) => handleContrastToggle(e.target.checked)}
+              />
+              Increase definition contrast
+            </label>
           </div>
         </div>
       </details>

--- a/styles.css
+++ b/styles.css
@@ -35,7 +35,7 @@ body {
 
 h1 {
   text-align: center;
-  font-family: 'Cinzel', serif;
+  font-family: "Cinzel", serif;
   font-weight: 700;
   font-size: 48px;
   margin-bottom: 20px;
@@ -169,7 +169,6 @@ body.dark-mode #search-help {
   border-color: #555;
 }
 
-
 /* Controls styling */
 #random-term {
   margin-top: 10px;
@@ -291,7 +290,9 @@ label {
   border-radius: 4px;
   padding: 10px;
   cursor: pointer;
-  transition: background-color 0.2s, color 0.2s;
+  transition:
+    background-color 0.2s,
+    color 0.2s;
   min-width: 44px;
   min-height: 44px;
 }
@@ -341,7 +342,12 @@ label {
   position: absolute;
   inset: 0;
   transform: translateX(-100%);
-  background-image: linear-gradient(90deg, transparent, var(--skeleton-fg), transparent);
+  background-image: linear-gradient(
+    90deg,
+    transparent,
+    var(--skeleton-fg),
+    transparent
+  );
   animation: skeleton-shimmer 1.5s infinite;
 }
 
@@ -394,6 +400,20 @@ body.dark-mode .dictionary-item h3 {
 
 body.dark-mode .dictionary-item p {
   color: #ccc;
+}
+
+body.definition-high-contrast .dictionary-item p,
+body.definition-high-contrast #definition-container p,
+body.definition-high-contrast .definition-item p,
+body.definition-high-contrast main > p {
+  color: #000;
+}
+
+body.dark-mode.definition-high-contrast .dictionary-item p,
+body.dark-mode.definition-high-contrast #definition-container p,
+body.dark-mode.definition-high-contrast .definition-item p,
+body.dark-mode.definition-high-contrast main > p {
+  color: #fff;
 }
 
 body.dark-mode #definition-container {
@@ -472,7 +492,7 @@ body.dark-mode #alpha-nav button.active {
 }
 
 .history-fold::after {
-  content: '';
+  content: "";
   position: absolute;
   top: 0;
   right: 0;


### PR DESCRIPTION
## Summary
- allow enabling high-contrast styling for term definitions via new settings toggle
- persist user definition contrast preference in localStorage for consistent experience
- style definition text to meet AA contrast in both light and dark modes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b655224cac8328a816974958a70745