### PR TITLE
Add session-based navigation timeline

### DIFF
--- a/app/term/[slug]/page.tsx
+++ b/app/term/[slug]/page.tsx
@@ -17,7 +17,14 @@ export default async function Page({ params }: PageProps) {
     notFound();
   }
   const { content, data } = matter(file!);
-  return <TermPage title={data.title ?? params.slug} body={content} sources={data.sources} />;
+  return (
+    <TermPage
+      slug={params.slug}
+      title={data.title ?? params.slug}
+      body={content}
+      sources={data.sources}
+    />
+  );
 }
 
 export async function generateStaticParams() {

--- a/components/SessionTimeline.tsx
+++ b/components/SessionTimeline.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+interface Entry {
+  slug: string;
+  title: string;
+}
+
+interface SessionTimelineProps {
+  /** Currently viewed term */
+  current: Entry;
+}
+
+const STORAGE_KEY = 'visited-terms';
+const MAX_VISIBLE = 7;
+
+export default function SessionTimeline({ current }: SessionTimelineProps) {
+  const [items, setItems] = useState<Entry[]>([]);
+  const router = useRouter();
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    let list: Entry[] = raw ? JSON.parse(raw) : [];
+    list = list.filter((e) => e.slug !== current.slug);
+    list.push(current);
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(list));
+    setItems(list);
+  }, [current]);
+
+  if (items.length === 0) return null;
+
+  let display: Entry[] | (Entry | { slug: string; title: string })[] = items;
+  if (items.length > MAX_VISIBLE) {
+    const start = items.slice(0, 3);
+    const end = items.slice(-3);
+    display = [...start, { slug: '', title: '…' }, ...end];
+  }
+
+  return (
+    <nav aria-label="Visited terms" style={{ marginTop: '1rem' }}>
+      <ul
+        style={{
+          display: 'flex',
+          listStyle: 'none',
+          padding: 0,
+          margin: 0,
+          gap: '0.5rem',
+          alignItems: 'center',
+          flexWrap: 'nowrap',
+        }}
+      >
+        {display.map((item, idx) => (
+          <li key={idx} style={{ display: 'flex', alignItems: 'center' }}>
+            {item.slug ? (
+              <button
+                onClick={() => router.push(`/term/${item.slug}`)}
+                style={{
+                  maxWidth: '8rem',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                  background: 'none',
+                  border: 'none',
+                  padding: 0,
+                  color: 'blue',
+                  textDecoration: 'underline',
+                  cursor: 'pointer',
+                }}
+              >
+                {item.title}
+              </button>
+            ) : (
+              <span style={{ padding: '0 0.25rem' }}>{item.title}</span>
+            )}
+            {idx < display.length - 1 && <span style={{ padding: '0 0.25rem' }}>›</span>}
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+}
+

--- a/components/term/TermPage.tsx
+++ b/components/term/TermPage.tsx
@@ -1,4 +1,5 @@
 import { MDXRemote } from 'next-mdx-remote/rsc';
+import SessionTimeline from '@/components/SessionTimeline';
 
 interface SourceLinks {
   nist?: string;
@@ -10,12 +11,14 @@ interface TermPageProps {
   title: string;
   body: string;
   sources?: SourceLinks;
+  /** Slug used for navigation and session tracking */
+  slug: string;
 }
 
 /**
  * Renders a security term page including MDX content and optional sources.
  */
-export default function TermPage({ title, body, sources }: TermPageProps) {
+export default function TermPage({ title, body, sources, slug }: TermPageProps) {
   const hasSources = sources && (sources.nist || sources.owasp || sources.attack);
 
   return (
@@ -44,6 +47,7 @@ export default function TermPage({ title, body, sources }: TermPageProps) {
           </ul>
         </section>
       )}
+      <SessionTimeline current={{ slug, title }} />
     </article>
   );
 }


### PR DESCRIPTION
## Summary
- track term visits in sessionStorage and render clickable horizontal timeline
- show ellipsis when timeline exceeds capacity
- wire timeline into term pages with slug-based navigation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6552508508328b656d2823a1b10aa