### PR TITLE
Add summary toggle to term pages

### DIFF
--- a/app/term/[slug]/page.tsx
+++ b/app/term/[slug]/page.tsx
@@ -1,29 +1,36 @@
-import fs from 'node:fs/promises';
-import path from 'node:path';
-import { notFound } from 'next/navigation';
-import matter from 'gray-matter';
-import TermPage from '@/components/term/TermPage';
+import fs from "node:fs/promises";
+import path from "node:path";
+import { notFound } from "next/navigation";
+import matter from "gray-matter";
+import TermPage from "@/components/term/TermPage";
 
 interface PageProps {
   params: { slug: string };
 }
 
 export default async function Page({ params }: PageProps) {
-  const filePath = path.join(process.cwd(), 'terms', `${params.slug}.mdx`);
+  const filePath = path.join(process.cwd(), "terms", `${params.slug}.mdx`);
   let file: string;
   try {
-    file = await fs.readFile(filePath, 'utf8');
+    file = await fs.readFile(filePath, "utf8");
   } catch {
     notFound();
   }
   const { content, data } = matter(file!);
-  return <TermPage title={data.title ?? params.slug} body={content} sources={data.sources} />;
+  return (
+    <TermPage
+      title={data.title ?? params.slug}
+      body={content}
+      sources={data.sources}
+      summary={data.summary}
+    />
+  );
 }
 
 export async function generateStaticParams() {
-  const dir = path.join(process.cwd(), 'terms');
+  const dir = path.join(process.cwd(), "terms");
   const entries = await fs.readdir(dir, { withFileTypes: true });
   return entries
-    .filter((e) => e.isFile() && e.name.endsWith('.mdx'))
-    .map((e) => ({ slug: e.name.replace(/\.mdx$/, '') }));
+    .filter((e) => e.isFile() && e.name.endsWith(".mdx"))
+    .map((e) => ({ slug: e.name.replace(/\.mdx$/, "") }));
 }

--- a/components/term/Summary.tsx
+++ b/components/term/Summary.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface TermSummaryProps {
+  title: string;
+  points: string[];
+}
+
+/**
+ * Renders a toggleable summary list for a term.
+ * The visible state is stored in localStorage per term.
+ */
+export default function TermSummary({ title, points }: TermSummaryProps) {
+  const storageKey = `summary-visible-${encodeURIComponent(title)}`;
+  const listId = `summary-${encodeURIComponent(title)}`;
+  const [visible, setVisible] = useState(true);
+
+  useEffect(() => {
+    const stored = window.localStorage.getItem(storageKey);
+    if (stored !== null) {
+      setVisible(stored === "true");
+    }
+  }, [storageKey]);
+
+  const toggle = () => {
+    const next = !visible;
+    setVisible(next);
+    window.localStorage.setItem(storageKey, String(next));
+  };
+
+  if (!points || points.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="term-summary">
+      <button onClick={toggle} aria-expanded={visible} aria-controls={listId}>
+        {visible ? "Hide summary" : "Show summary"}
+      </button>
+      {visible && (
+        <ul id={listId}>
+          {points.map((p, i) => (
+            <li key={i}>{p}</li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/components/term/TermPage.tsx
+++ b/components/term/TermPage.tsx
@@ -1,4 +1,5 @@
-import { MDXRemote } from 'next-mdx-remote/rsc';
+import { MDXRemote } from "next-mdx-remote/rsc";
+import TermSummary from "./Summary";
 
 interface SourceLinks {
   nist?: string;
@@ -10,17 +11,25 @@ interface TermPageProps {
   title: string;
   body: string;
   sources?: SourceLinks;
+  summary?: string[];
 }
 
 /**
  * Renders a security term page including MDX content and optional sources.
  */
-export default function TermPage({ title, body, sources }: TermPageProps) {
-  const hasSources = sources && (sources.nist || sources.owasp || sources.attack);
+export default function TermPage({
+  title,
+  body,
+  sources,
+  summary,
+}: TermPageProps) {
+  const hasSources =
+    sources && (sources.nist || sources.owasp || sources.attack);
 
   return (
     <article className="term">
       <h1>{title}</h1>
+      <TermSummary title={title} points={summary || []} />
       <MDXRemote source={body} />
       {hasSources && (
         <section className="sources">


### PR DESCRIPTION
## Summary
- Display optional term summaries with a hide/show toggle on term pages
- Persist summary visibility per term using `localStorage`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6552383688328b476fd7753862921