### PR TITLE
feat: add recent term comparison chip

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@
 import React from "react";
 import { motion } from "framer-motion";
 import Navbar from "../components/Navbar";
+import ComparePanel from "../components/ComparePanel";
 import { Inter } from "next/font/google";
 
 const inter = Inter({ subsets: ["latin"] });
@@ -24,6 +25,7 @@ export default function RootLayout({
         >
           {children}
         </motion.div>
+        <ComparePanel />
       </body>
     </html>
   );

--- a/components/ComparePanel.tsx
+++ b/components/ComparePanel.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import useRecentTerms from "../hooks/useRecentTerms";
+
+function slugify(term: string) {
+  return encodeURIComponent(term.toLowerCase().replace(/\s+/g, "-"));
+}
+
+/** Footer chip that offers comparison between two recently viewed terms. */
+export default function ComparePanel() {
+  const router = useRouter();
+  const { pair, clear } = useRecentTerms();
+
+  if (!pair) return null;
+
+  const [a, b] = pair;
+
+  const handleClick = () => {
+    router.push(`/compare/${slugify(a)}-vs-${slugify(b)}`);
+    clear();
+  };
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        bottom: "1rem",
+        left: "50%",
+        transform: "translateX(-50%)",
+        background: "#eee",
+        borderRadius: "9999px",
+        boxShadow: "0 2px 4px rgba(0,0,0,0.2)",
+      }}
+    >
+      <button
+        onClick={handleClick}
+        style={{
+          background: "none",
+          border: "none",
+          padding: "0.5rem 1rem",
+          cursor: "pointer",
+        }}
+      >
+        Compare {a} vs {b}
+      </button>
+    </div>
+  );
+}

--- a/components/term/RecentTermTracker.tsx
+++ b/components/term/RecentTermTracker.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import useRecentTerms from "../../hooks/useRecentTerms";
+
+export default function RecentTermTracker({ term }: { term: string }) {
+  useRecentTerms(term);
+  return null;
+}

--- a/components/term/TermPage.tsx
+++ b/components/term/TermPage.tsx
@@ -1,4 +1,5 @@
 import { MDXRemote } from 'next-mdx-remote/rsc';
+import RecentTermTracker from './RecentTermTracker';
 
 interface SourceLinks {
   nist?: string;
@@ -20,6 +21,7 @@ export default function TermPage({ title, body, sources }: TermPageProps) {
 
   return (
     <article className="term">
+      <RecentTermTracker term={title} />
       <h1>{title}</h1>
       <MDXRemote source={body} />
       {hasSources && (

--- a/hooks/useRecentTerms.ts
+++ b/hooks/useRecentTerms.ts
@@ -1,0 +1,62 @@
+import { useEffect, useState } from "react";
+
+const LAST_KEY = "recent-last-term";
+const PAIR_KEY = "recent-term-pair";
+
+type Pair = [string, string];
+
+/**
+ * Track when two distinct terms are viewed sequentially.
+ * Returns the pair and a clear function. Pair persists in sessionStorage
+ * until cleared or when navigating away from either term.
+ */
+export default function useRecentTerms(currentTerm?: string) {
+  const [pair, setPair] = useState<Pair | null>(null);
+
+  // Load pair from sessionStorage on mount
+  useEffect(() => {
+    try {
+      const raw = sessionStorage.getItem(PAIR_KEY);
+      if (raw) setPair(JSON.parse(raw));
+    } catch {
+      /* ignore */
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!currentTerm) return;
+    try {
+      const storedPair = sessionStorage.getItem(PAIR_KEY);
+      if (storedPair) {
+        const parsed: Pair = JSON.parse(storedPair);
+        if (currentTerm !== parsed[0] && currentTerm !== parsed[1]) {
+          sessionStorage.removeItem(PAIR_KEY);
+          setPair(null);
+        } else {
+          setPair(parsed);
+        }
+      } else {
+        const last = sessionStorage.getItem(LAST_KEY);
+        if (last && last !== currentTerm) {
+          const newPair: Pair = [last, currentTerm];
+          sessionStorage.setItem(PAIR_KEY, JSON.stringify(newPair));
+          setPair(newPair);
+        }
+      }
+      sessionStorage.setItem(LAST_KEY, currentTerm);
+    } catch {
+      /* ignore */
+    }
+  }, [currentTerm]);
+
+  const clear = () => {
+    try {
+      sessionStorage.removeItem(PAIR_KEY);
+    } catch {
+      /* ignore */
+    }
+    setPair(null);
+  };
+
+  return { pair, clear } as const;
+}


### PR DESCRIPTION
## Summary
- track sequential term views in session storage
- display footer chip to compare the last two terms
- hide chip after comparison or navigating elsewhere

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b65526b1d0832880cd64b3076bdf99