### PR TITLE
Enable data saver on low battery

### DIFF
--- a/app/(site)/settings/page.tsx
+++ b/app/(site)/settings/page.tsx
@@ -56,27 +56,47 @@ const SettingsPage: React.FC = () => {
             <option value="community">Community</option>
           </select>
         </label>
-      </section>
-      <section>
-        <label>
-          <input
-            type="checkbox"
-            checked={settings.history}
-            onChange={(e) => update({ history: e.target.checked })}
-          />
-          Enable history
-        </label>
-      </section>
-      <section>
-        <label>
-          <input
-            type="checkbox"
-            checked={settings.favorites}
-            onChange={(e) => update({ favorites: e.target.checked })}
-          />
-          Enable favorites
-        </label>
-      </section>
+        </section>
+        <section>
+          <label>
+            <input
+              type="checkbox"
+              checked={settings.dataSaver}
+              onChange={(e) => update({ dataSaver: e.target.checked })}
+            />
+            Data saver
+          </label>
+        </section>
+        <section>
+          <label>
+            <input
+              type="checkbox"
+              checked={settings.reducedMotion}
+              onChange={(e) => update({ reducedMotion: e.target.checked })}
+            />
+            Reduced motion
+          </label>
+        </section>
+        <section>
+          <label>
+            <input
+              type="checkbox"
+              checked={settings.history}
+              onChange={(e) => update({ history: e.target.checked })}
+            />
+            Enable history
+          </label>
+        </section>
+        <section>
+          <label>
+            <input
+              type="checkbox"
+              checked={settings.favorites}
+              onChange={(e) => update({ favorites: e.target.checked })}
+            />
+            Enable favorites
+          </label>
+        </section>
     </main>
   );
 };

--- a/hooks/useBatterySaver.ts
+++ b/hooks/useBatterySaver.ts
@@ -1,0 +1,88 @@
+import { useEffect, useRef } from 'react';
+import { Settings } from '../lib/settings';
+
+/**
+ * Detects low-power mode via the Battery Status API and toggles data saver and
+ * reduced motion settings accordingly. A toast with an undo option lets users
+ * revert the automatic change, and that choice is remembered for later.
+ */
+export default function useBatterySaver(
+  settings: Settings,
+  update: (changes: Partial<Settings>) => void,
+) {
+  const appliedRef = useRef(false);
+  const prevRef = useRef({
+    dataSaver: settings.dataSaver,
+    reducedMotion: settings.reducedMotion,
+  });
+
+  useEffect(() => {
+    if (typeof navigator === 'undefined' || !('getBattery' in navigator)) {
+      return;
+    }
+
+    let battery: any = null;
+    const overrideKey = 'batterySaverOverride';
+
+    const showUndoToast = () => {
+      const toast = document.createElement('div');
+      toast.style.position = 'fixed';
+      toast.style.bottom = '1rem';
+      toast.style.left = '50%';
+      toast.style.transform = 'translateX(-50%)';
+      toast.style.background = '#333';
+      toast.style.color = '#fff';
+      toast.style.padding = '0.5rem 1rem';
+      toast.style.borderRadius = '4px';
+      toast.style.zIndex = '1000';
+      toast.textContent = 'Battery saver: data saver enabled';
+
+      const undo = document.createElement('button');
+      undo.textContent = 'Undo';
+      undo.style.marginLeft = '0.5rem';
+      undo.onclick = () => {
+        update(prevRef.current);
+        try {
+          localStorage.setItem(overrideKey, 'true');
+        } catch {}
+        appliedRef.current = false;
+        toast.remove();
+      };
+
+      toast.appendChild(undo);
+      document.body.appendChild(toast);
+      setTimeout(() => toast.remove(), 5000);
+    };
+
+    const handle = () => {
+      const saver = !battery.charging && battery.level <= 0.2;
+      if (saver && !appliedRef.current) {
+        try {
+          if (localStorage.getItem(overrideKey) === 'true') return;
+        } catch {}
+        prevRef.current = {
+          dataSaver: settings.dataSaver,
+          reducedMotion: settings.reducedMotion,
+        };
+        appliedRef.current = true;
+        update({ dataSaver: true, reducedMotion: true });
+        showUndoToast();
+      } else if (!saver && appliedRef.current) {
+        update(prevRef.current);
+        appliedRef.current = false;
+      }
+    };
+
+    (navigator as any).getBattery().then((b: any) => {
+      battery = b;
+      handle();
+      b.addEventListener('levelchange', handle);
+      b.addEventListener('chargingchange', handle);
+    });
+
+    return () => {
+      battery?.removeEventListener('levelchange', handle);
+      battery?.removeEventListener('chargingchange', handle);
+    };
+  }, [settings.dataSaver, settings.reducedMotion, update]);
+}

--- a/lib/settings.ts
+++ b/lib/settings.ts
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
+import useBatterySaver from '../hooks/useBatterySaver';
 
 export type Settings = {
   darkMode: boolean;
@@ -7,6 +8,17 @@ export type Settings = {
   source: string;
   history: boolean;
   favorites: boolean;
+  /**
+   * Enables reduced data usage for features that load external resources.
+   * Automatically toggled on by `useBatterySaver` when the device enters
+   * a low-power state.
+   */
+  dataSaver: boolean;
+  /**
+   * Disables non-essential animations and transitions for a lighter
+   * experience. Also controlled by `useBatterySaver`.
+   */
+  reducedMotion: boolean;
 };
 
 const defaultSettings: Settings = {
@@ -16,6 +28,8 @@ const defaultSettings: Settings = {
   source: 'all',
   history: true,
   favorites: true,
+  dataSaver: false,
+  reducedMotion: false,
 };
 
 type SettingsContextValue = {
@@ -62,11 +76,14 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
     } else {
       root.classList.remove('dark');
     }
+    root.classList.toggle('reduced-motion', settings.reducedMotion);
   }, [settings]);
 
   const update = (changes: Partial<Settings>) => {
     setSettings((prev) => ({ ...prev, ...changes }));
   };
+
+  useBatterySaver(settings, update);
 
   return (
     <SettingsContext.Provider value={{ settings, update }}>


### PR DESCRIPTION
## Summary
- add `useBatterySaver` hook to detect low power mode via `navigator.getBattery`
- expand settings with `dataSaver` and `reducedMotion` options and auto-toggle on low battery
- expose Data Saver and Reduced Motion toggles in settings page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6552c833c8328a235ab9332c0c678