### PR TITLE
feat: show connection status in header

### DIFF
--- a/components/ConnectionIndicator.tsx
+++ b/components/ConnectionIndicator.tsx
@@ -1,0 +1,61 @@
+"use client";
+import React, { useEffect, useState } from "react";
+
+/**
+ * Small dot indicating connection and cache status.
+ */
+export default function ConnectionIndicator() {
+  const [online, setOnline] = useState(true);
+  const [cached, setCached] = useState(false);
+
+  useEffect(() => {
+    if (typeof navigator === "undefined") return;
+
+    setOnline(navigator.onLine);
+    if ("serviceWorker" in navigator) {
+      setCached(!!navigator.serviceWorker.controller);
+      const handleController = () =>
+        setCached(!!navigator.serviceWorker.controller);
+      navigator.serviceWorker.addEventListener(
+        "controllerchange",
+        handleController,
+      );
+      return () => {
+        navigator.serviceWorker.removeEventListener(
+          "controllerchange",
+          handleController,
+        );
+      };
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const goOnline = () => setOnline(true);
+    const goOffline = () => setOnline(false);
+    window.addEventListener("online", goOnline);
+    window.addEventListener("offline", goOffline);
+    return () => {
+      window.removeEventListener("online", goOnline);
+      window.removeEventListener("offline", goOffline);
+    };
+  }, []);
+
+  const color = online
+    ? "bg-green-500"
+    : cached
+      ? "bg-yellow-500"
+      : "bg-red-500";
+  const title = online
+    ? "Online"
+    : cached
+      ? "Offline - content served from cache"
+      : "Offline - no cached content";
+
+  return (
+    <span
+      title={title}
+      className={`inline-block h-3 w-3 rounded-full ${color}`}
+    />
+  );
+}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,6 +1,7 @@
 "use client";
 import React, { useState } from "react";
 import { useRouter } from "next/navigation";
+import ConnectionIndicator from "./ConnectionIndicator";
 
 /**
  * Responsive navigation bar using Tailwind CSS.
@@ -20,41 +21,44 @@ export default function Navbar() {
           >
             CyberSec Dictionary
           </button>
-          <button
-            className="md:hidden"
-            aria-label="Toggle menu"
-            onClick={() => setOpen((o) => !o)}
-          >
-            <svg
-              className="h-6 w-6"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M4 6h16M4 12h16M4 18h16"
-              />
-            </svg>
-          </button>
-          <div className="hidden md:flex md:space-x-4">
+          <div className="flex items-center space-x-4">
+            <ConnectionIndicator />
             <button
-              type="button"
-              onClick={() => router.push("/terms")}
-              className="hover:underline"
+              className="md:hidden"
+              aria-label="Toggle menu"
+              onClick={() => setOpen((o) => !o)}
             >
-              Terms
+              <svg
+                className="h-6 w-6"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M4 6h16M4 12h16M4 18h16"
+                />
+              </svg>
             </button>
-            <button
-              type="button"
-              onClick={() => router.push("/compare")}
-              className="hover:underline"
-            >
-              Compare
-            </button>
+            <div className="hidden md:flex md:space-x-4">
+              <button
+                type="button"
+                onClick={() => router.push("/terms")}
+                className="hover:underline"
+              >
+                Terms
+              </button>
+              <button
+                type="button"
+                onClick={() => router.push("/compare")}
+                className="hover:underline"
+              >
+                Compare
+              </button>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add ConnectionIndicator component to display online/offline and cache state
- show indicator in Navbar with tooltip explaining state

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6552c13988328804cbb8d7a124720