### PR TITLE
feat: allow dragging term cards to desktop

### DIFF
--- a/components/TermCard.tsx
+++ b/components/TermCard.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 import { motion, useAnimation, useInView } from "framer-motion";
+import useDragToDesktop from "../hooks/useDragToDesktop";
 
 interface TermCardProps {
   term: string;
@@ -12,6 +13,8 @@ const TermCard: React.FC<TermCardProps> = ({ term, definition }) => {
   const inView = useInView(ref);
   const [hasAnimated, setHasAnimated] = useState(false);
 
+  useDragToDesktop(ref, term);
+
   useEffect(() => {
     if (inView && !hasAnimated) {
       controls.start("visible");
@@ -22,6 +25,7 @@ const TermCard: React.FC<TermCardProps> = ({ term, definition }) => {
   return (
     <motion.div
       ref={ref}
+      style={{ cursor: "grab" }}
       initial="hidden"
       animate={hasAnimated ? "visible" : controls}
       variants={{

--- a/hooks/useDragToDesktop.ts
+++ b/hooks/useDragToDesktop.ts
@@ -1,0 +1,59 @@
+import { useEffect } from "react";
+
+/**
+ * Enable dragging an element to the desktop to create a `.url` shortcut.
+ * The hook only applies on desktop environments.
+ *
+ * @param ref - ref to the draggable element
+ * @param term - term to link to
+ */
+const useDragToDesktop = (
+  ref: React.RefObject<HTMLElement>,
+  term: string
+): void => {
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const isDesktop = !/Mobi|Android/i.test(navigator.userAgent);
+    if (!isDesktop) return;
+
+    const handleDragStart = (e: DragEvent) => {
+      if (!e.dataTransfer) return;
+      const url = `${window.location.origin}${window.location.pathname}#${encodeURIComponent(
+        term
+      )}`;
+      const fileName = `${term}.url`;
+      const contents = `[InternetShortcut]\nURL=${url}`;
+      const file = new File([contents], fileName, { type: "text/plain" });
+
+      e.dataTransfer.effectAllowed = "copy";
+      e.dataTransfer.setData("text/uri-list", url);
+      e.dataTransfer.setData("text/plain", url);
+      try {
+        e.dataTransfer.setData("DownloadURL", `text/plain:${fileName}:${url}`);
+        e.dataTransfer.items.add(file);
+      } catch {
+        // Ignore if the browser disallows adding files or DownloadURL
+      }
+      document.body.classList.add("dragging-to-desktop");
+    };
+
+    const handleDragEnd = () => {
+      document.body.classList.remove("dragging-to-desktop");
+    };
+
+    el.setAttribute("draggable", "true");
+    el.addEventListener("dragstart", handleDragStart);
+    el.addEventListener("dragend", handleDragEnd);
+
+    return () => {
+      el.removeEventListener("dragstart", handleDragStart);
+      el.removeEventListener("dragend", handleDragEnd);
+      document.body.classList.remove("dragging-to-desktop");
+    };
+  }, [ref, term]);
+};
+
+export default useDragToDesktop;
+

--- a/styles.css
+++ b/styles.css
@@ -581,3 +581,8 @@ body.dark-mode #alpha-nav button.active {
 .selection-highlight {
   background-color: yellow;
 }
+
+body.dragging-to-desktop,
+body.dragging-to-desktop * {
+  cursor: grabbing !important;
+}


### PR DESCRIPTION
## Summary
- add `useDragToDesktop` hook to create `.url` shortcuts when dragging term cards on desktop
- wire TermCard to use drag hook and show grab cursor
- show grabbing cursor while dragging

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6552e5f1483288da2632657b4da32