### PR TITLE
feat: add recent terms dropdown

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,6 +1,7 @@
 "use client";
 import React, { useState } from "react";
 import { useRouter } from "next/navigation";
+import RecentMenu from "./RecentMenu";
 
 /**
  * Responsive navigation bar using Tailwind CSS.
@@ -40,7 +41,7 @@ export default function Navbar() {
               />
             </svg>
           </button>
-          <div className="hidden md:flex md:space-x-4">
+          <div className="hidden md:flex md:items-center md:space-x-4">
             <button
               type="button"
               onClick={() => router.push("/terms")}
@@ -55,6 +56,7 @@ export default function Navbar() {
             >
               Compare
             </button>
+            <RecentMenu />
           </div>
         </div>
       </div>
@@ -74,6 +76,7 @@ export default function Navbar() {
           >
             Compare
           </button>
+          <RecentMenu />
         </div>
       )}
     </nav>

--- a/components/RecentMenu.tsx
+++ b/components/RecentMenu.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { usePathname, useRouter } from "next/navigation";
+
+interface RecentItem {
+  term: string;
+  url: string;
+}
+
+const STORAGE_KEY = "recentTerms";
+
+function loadFromStorage(): RecentItem[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) {
+        return parsed;
+      }
+    }
+  } catch {
+    /* ignore */
+  }
+  return [];
+}
+
+export default function RecentMenu() {
+  const [items, setItems] = useState<RecentItem[]>([]);
+  const [open, setOpen] = useState(false);
+  const router = useRouter();
+  const pathname = usePathname();
+
+  // Load initial list
+  useEffect(() => {
+    setItems(loadFromStorage());
+  }, []);
+
+  // Update list when navigating to a term page
+  useEffect(() => {
+    const match = pathname?.match(/^\/word\/(.+)$/);
+    if (!match) return;
+    const slug = decodeURIComponent(match[1]);
+    const url = `/word/${slug}`;
+    setItems((prev) => {
+      const next = [{ term: slug, url }, ...prev.filter((i) => i.url !== url)]
+        .slice(0, 10);
+      try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+      } catch {
+        /* ignore */
+      }
+      return next;
+    });
+  }, [pathname]);
+
+  const handleOpen = (url: string, split: boolean) => {
+    if (split) {
+      window.open(`${url}?split=1`, "_blank");
+    } else {
+      router.push(url);
+    }
+    setOpen(false);
+  };
+
+  const faviconSrc =
+    typeof window !== "undefined"
+      ? `https://www.google.com/s2/favicons?sz=32&domain=${window.location.hostname}`
+      : "/favicon.ico";
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="hover:underline px-2"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+      >
+        Recent
+      </button>
+      {open && (
+        <ul className="absolute right-0 mt-2 w-48 rounded border bg-white text-black shadow-lg z-50">
+          {items.length === 0 && (
+            <li className="p-2 text-sm text-gray-500">No recent terms</li>
+          )}
+          {items.map(({ term, url }) => (
+            <li key={url}>
+              <button
+                type="button"
+                onClick={(e) => handleOpen(url, e.shiftKey)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault();
+                    handleOpen(url, e.shiftKey);
+                  }
+                }}
+                className="flex w-full items-center gap-2 px-2 py-1 text-left hover:bg-gray-100 focus:bg-gray-100"
+              >
+                <img src={faviconSrc} alt="" className="h-4 w-4" />
+                <span>{term}</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- track last 10 viewed terms in localStorage
- add header dropdown with favicons and keyboard actions
- integrate recent terms menu into navbar

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b65527753c832880230cb3c3055497