### PR TITLE
feat: add hover preview delay setting

### DIFF
--- a/src/hooks/useHoverPreview.ts
+++ b/src/hooks/useHoverPreview.ts
@@ -1,0 +1,40 @@
+import React, { useRef } from 'react';
+
+const DEFAULT_DELAY = 500;
+
+function getDelay(): number {
+  if (typeof window === 'undefined') return DEFAULT_DELAY;
+  const raw = localStorage.getItem('hoverPreviewDelay');
+  const value = raw ? parseInt(raw, 10) : NaN;
+  return Number.isFinite(value) ? value : DEFAULT_DELAY;
+}
+
+const isTouch =
+  typeof window !== 'undefined' && window.matchMedia('(hover: none)').matches;
+
+export default function useHoverPreview<T extends HTMLElement>(
+  show: (e: React.MouseEvent<T>) => void,
+  hide: () => void,
+) {
+  const timer = useRef<number>();
+
+  const handleEnter = (e: React.MouseEvent<T>) => {
+    if (isTouch) return;
+    const delay = getDelay();
+    timer.current = window.setTimeout(() => show(e), delay);
+  };
+
+  const handleLeave = () => {
+    if (isTouch) return;
+    if (timer.current) {
+      clearTimeout(timer.current);
+      timer.current = undefined;
+    }
+    hide();
+  };
+
+  return {
+    onMouseEnter: handleEnter,
+    onMouseLeave: handleLeave,
+  };
+}

--- a/src/settings/HoverPreview.tsx
+++ b/src/settings/HoverPreview.tsx
@@ -1,0 +1,49 @@
+import React, { useEffect, useState } from 'react';
+
+const DEFAULT_DELAY = 500;
+
+function getStoredDelay(): number {
+  if (typeof window === 'undefined') return DEFAULT_DELAY;
+  const raw = localStorage.getItem('hoverPreviewDelay');
+  const value = raw ? parseInt(raw, 10) : NaN;
+  return Number.isFinite(value) ? value : DEFAULT_DELAY;
+}
+
+export default function HoverPreview() {
+  const isTouch =
+    typeof window !== 'undefined' &&
+    window.matchMedia('(hover: none)').matches;
+  const [delay, setDelay] = useState<number>(getStoredDelay);
+
+  useEffect(() => {
+    if (isTouch) return;
+    try {
+      localStorage.setItem('hoverPreviewDelay', String(delay));
+    } catch {
+      // ignore
+    }
+  }, [delay, isTouch]);
+
+  return (
+    <div
+      id="hover-preview-delay"
+      data-setting-label="Preview delay"
+      data-setting-keywords="hover,preview,delay"
+    >
+      <label htmlFor="hover-delay">
+        Preview delay: {delay}ms
+      </label>
+      <input
+        id="hover-delay"
+        type="range"
+        min={0}
+        max={2000}
+        step={100}
+        value={delay}
+        onChange={(e) => setDelay(parseInt(e.target.value, 10))}
+        disabled={isTouch}
+      />
+      {isTouch && <p>Not available on touch devices.</p>}
+    </div>
+  );
+}

--- a/src/settings/SettingsPage.tsx
+++ b/src/settings/SettingsPage.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import ColorBlindPalette from './ColorBlindPalette';
+import HoverPreview from './HoverPreview';
 import {
   buildSettingsIndex,
   searchSettings,
@@ -74,6 +75,11 @@ export default function SettingsPage() {
             <ColorBlindPalette />
           </div>
         </div>
+      </details>
+
+      <details id="previews" data-setting-section>
+        <summary>Previews</summary>
+        <HoverPreview />
       </details>
     </div>
   );


### PR DESCRIPTION
## Summary
- add slider setting to control hover preview delay
- persist delay to localStorage and disable control on touch devices
- apply configurable delay via `useHoverPreview` hook

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6552f0e2883289cb53728b7e3242f