### PR TITLE
feat: accessibility toggle for icon labels

### DIFF
--- a/SearchBox.tsx
+++ b/SearchBox.tsx
@@ -41,6 +41,7 @@ export default function SearchBox() {
         type="button"
         onClick={handleMicClick}
         aria-label="Use voice search"
+        className="icon-button"
       >
         🎤
       </button>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -21,7 +21,7 @@ export default function Navbar() {
             CyberSec Dictionary
           </button>
           <button
-            className="md:hidden"
+            className="md:hidden icon-button"
             aria-label="Toggle menu"
             onClick={() => setOpen((o) => !o)}
           >

--- a/components/SideDrawer.tsx
+++ b/components/SideDrawer.tsx
@@ -69,7 +69,11 @@ const SideDrawer: React.FC<SideDrawerProps> = ({ word, onClose }) => {
 
   return (
     <aside className="side-drawer">
-      <button className="close" onClick={onClose} aria-label="Close">
+      <button
+        className="close icon-button"
+        onClick={onClose}
+        aria-label="Close"
+      >
         ×
       </button>
       <h2>{word}</h2>

--- a/index.html
+++ b/index.html
@@ -33,7 +33,14 @@
 
     <ul id="terms-list"></ul>
   </main>
-  <button id="scrollToTopBtn" type="button" aria-label="Scroll to top">↑</button>
+  <button
+    id="scrollToTopBtn"
+    type="button"
+    aria-label="Scroll to top"
+    class="icon-button"
+  >
+    ↑
+  </button>
 
   <footer class="container" aria-label="Contribution links">
     <p><a href="templates/contribute.html">Contribute</a></p>

--- a/layout.html
+++ b/layout.html
@@ -33,7 +33,7 @@
 
     <ul id="terms-list"></ul>
   </main>
-  <button id="scrollToTopBtn" aria-label="Scroll to top">↑</button>
+  <button id="scrollToTopBtn" aria-label="Scroll to top" class="icon-button">↑</button>
 
   <script src="script.js"></script>
   <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>

--- a/src/components/ClipboardPreview.tsx
+++ b/src/components/ClipboardPreview.tsx
@@ -80,6 +80,7 @@ const ClipboardPreview: React.FC = () => {
         <button
           onClick={() => setTerm(null)}
           aria-label="Close preview"
+          className="icon-button"
           style={{ float: 'right' }}
         >
           ×

--- a/src/components/ShortcutCheatsheet.tsx
+++ b/src/components/ShortcutCheatsheet.tsx
@@ -76,7 +76,11 @@ export default function ShortcutCheatsheet() {
       ref={overlayRef}
     >
       <div className="shortcut-cheatsheet">
-        <button onClick={() => setOpen(false)} aria-label="Close">
+        <button
+          onClick={() => setOpen(false)}
+          aria-label="Close"
+          className="icon-button"
+        >
           ×
         </button>
         <input

--- a/src/features/highlights/HighlightsDrawer.tsx
+++ b/src/features/highlights/HighlightsDrawer.tsx
@@ -55,7 +55,7 @@ export const HighlightsDrawer: React.FC<HighlightsDrawerProps> = ({
         {colors.map((color) => (
           <button
             key={color}
-            className={filter === color ? 'active' : ''}
+            className={`icon-button ${filter === color ? 'active' : ''}`}
             style={{ backgroundColor: color }}
             onClick={() => setFilter(color)}
             aria-label={`Filter ${color} highlights`}

--- a/src/features/search/SearchBar.tsx
+++ b/src/features/search/SearchBar.tsx
@@ -48,7 +48,12 @@ export const SearchBar: React.FC<SearchBarProps> = ({ onSearch }) => {
         onChange={handleChange}
         placeholder="Search terms..."
       />
-      <button type="button" onClick={startListening} aria-label="Use microphone">
+      <button
+        type="button"
+        onClick={startListening}
+        aria-label="Use microphone"
+        className="icon-button"
+      >
         🎤
       </button>
     </div>

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -1,15 +1,17 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 
-export type SettingKey = "darkMode" | "showFavorites";
+export type SettingKey = "darkMode" | "showFavorites" | "showIconLabels";
 
 export interface Settings {
   darkMode: boolean;
   showFavorites: boolean;
+  showIconLabels: boolean;
 }
 
 const DEFAULT_SETTINGS: Settings = {
   darkMode: false,
   showFavorites: false,
+  showIconLabels: false,
 };
 
 const STORAGE_KEY = "settings";
@@ -28,6 +30,15 @@ export function useSettings() {
       return DEFAULT_SETTINGS;
     }
   });
+
+  useEffect(() => {
+    if (typeof document !== "undefined") {
+      document.body.classList.toggle(
+        "show-icon-labels",
+        settings.showIconLabels,
+      );
+    }
+  }, [settings.showIconLabels]);
 
   const updateSetting = useCallback(
     <K extends SettingKey>(key: K, value: Settings[K]) => {

--- a/src/settings/Accessibility.tsx
+++ b/src/settings/Accessibility.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import useSettings from '../hooks/useSettings';
+
+/**
+ * Accessibility settings section allowing users to reveal text labels under icons.
+ */
+export default function Accessibility() {
+  const { settings, updateSetting } = useSettings();
+
+  return (
+    <div>
+      <div
+        id="icon-labels-toggle"
+        data-setting-label="Always show icon labels"
+        data-setting-keywords="accessibility,labels,icons"
+      >
+        <label>
+          <input
+            type="checkbox"
+            checked={settings.showIconLabels}
+            onChange={(e) => updateSetting('showIconLabels', e.target.checked)}
+          />
+          Always show text labels under icons
+        </label>
+      </div>
+    </div>
+  );
+}

--- a/src/settings/SettingsPage.tsx
+++ b/src/settings/SettingsPage.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import ColorBlindPalette from './ColorBlindPalette';
+import Accessibility from './Accessibility';
 import {
   buildSettingsIndex,
   searchSettings,
@@ -74,6 +75,11 @@ export default function SettingsPage() {
             <ColorBlindPalette />
           </div>
         </div>
+      </details>
+
+      <details id="accessibility" data-setting-section>
+        <summary>Accessibility</summary>
+        <Accessibility />
       </details>
     </div>
   );

--- a/styles.css
+++ b/styles.css
@@ -581,3 +581,16 @@ body.dark-mode #alpha-nav button.active {
 .selection-highlight {
   background-color: yellow;
 }
+
+/* Reveal icon labels when enabled */
+body.show-icon-labels .icon-button {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+body.show-icon-labels .icon-button::after {
+  content: attr(aria-label);
+  font-size: 0.75rem;
+  margin-top: 0.25rem;
+}


### PR DESCRIPTION
## Summary
- add Accessibility settings section with toggle to always show text labels under icons
- persist icon label setting in localStorage and apply body class
- style `.icon-button` elements so `aria-label` text appears beneath icons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b65531169c83289d4f0ae261e940d2