### PR TITLE
feat: track understanding across terms

### DIFF
--- a/app/[term]/page.tsx
+++ b/app/[term]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from 'next/navigation';
 import termsData from '../../terms.json';
+import UnderstandingTracker from '../../components/UnderstandingTracker';
 
 interface Term {
   term: string;
@@ -24,6 +25,7 @@ export default function TermPage({ params }: { params: { term: string } }) {
     <main>
       <h1>{term.term}</h1>
       <p>{term.definition}</p>
+      <UnderstandingTracker term={term.term} />
     </main>
   );
 }

--- a/app/terms/[slug]/page.tsx
+++ b/app/terms/[slug]/page.tsx
@@ -3,6 +3,7 @@ import fs from "fs";
 import path from "path";
 import yaml from "js-yaml";
 import { FAQBlock } from "../../components/FAQBlock";
+import UnderstandingTracker from "../../components/UnderstandingTracker";
 
 interface Term {
   name: string;
@@ -53,6 +54,7 @@ export default function TermPage({ params }: { params: { slug: string } }) {
         </p>
       )}
       <FAQBlock items={faqItems} />
+      <UnderstandingTracker term={term.name} />
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(termJsonLd) }}

--- a/components/UnderstandingTracker.tsx
+++ b/components/UnderstandingTracker.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  loadStatuses,
+  saveStatus,
+  removeStatus,
+} from "../lib/understanding";
+
+interface Props {
+  term: string;
+}
+
+export default function UnderstandingTracker({ term }: Props) {
+  const [understood, setUnderstood] = useState(false);
+  const [confidence, setConfidence] = useState(50);
+
+  useEffect(() => {
+    const data = loadStatuses();
+    if (data[term]) {
+      setUnderstood(true);
+      setConfidence(data[term].confidence);
+    }
+  }, [term]);
+
+  const toggle = () => {
+    if (understood) {
+      removeStatus(term);
+      setUnderstood(false);
+    } else {
+      saveStatus(term, confidence);
+      setUnderstood(true);
+    }
+  };
+
+  const updateConfidence = (value: number) => {
+    setConfidence(value);
+    saveStatus(term, value);
+  };
+
+  return (
+    <div className="understanding-tracker">
+      <button type="button" onClick={toggle}>
+        {understood ? "Mark as Not Yet" : "Mark as Understood"}
+      </button>
+      {understood && (
+        <label>
+          Confidence: {confidence}
+          <input
+            type="range"
+            min="0"
+            max="100"
+            value={confidence}
+            onChange={(e) => updateConfidence(Number(e.target.value))}
+          />
+        </label>
+      )}
+    </div>
+  );
+}

--- a/components/search/AZIndex.tsx
+++ b/components/search/AZIndex.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { loadStatuses } from "../../lib/understanding";
 
 interface Term {
   term: string;
@@ -17,10 +18,27 @@ const letters = Array.from({ length: 26 }, (_, i) =>
 
 export default function AZIndex({ terms }: Props) {
   const [filter, setFilter] = useState<string | null>(null);
+  const [statusFilter, setStatusFilter] = useState<
+    "all" | "understood" | "notYet"
+  >("all");
+  const [statuses, setStatuses] = useState(loadStatuses());
 
-  const filtered = filter
+  useEffect(() => {
+    setStatuses(loadStatuses());
+    const handler = () => setStatuses(loadStatuses());
+    window.addEventListener("storage", handler);
+    return () => window.removeEventListener("storage", handler);
+  }, []);
+
+  let filtered = filter
     ? terms.filter((t) => t.term.toUpperCase().startsWith(filter))
     : terms;
+
+  if (statusFilter === "understood") {
+    filtered = filtered.filter((t) => !!statuses[t.term]);
+  } else if (statusFilter === "notYet") {
+    filtered = filtered.filter((t) => !statuses[t.term]);
+  }
 
   return (
     <div>
@@ -34,6 +52,23 @@ export default function AZIndex({ terms }: Props) {
             aria-pressed={filter === l}
           >
             {l}
+          </button>
+        ))}
+      </nav>
+      <nav className="status-filter">
+        {[
+          { key: "all", label: "All" },
+          { key: "understood", label: "Understood" },
+          { key: "notYet", label: "Not Yet" },
+        ].map((opt) => (
+          <button
+            key={opt.key}
+            type="button"
+            onClick={() => setStatusFilter(opt.key as any)}
+            className={statusFilter === opt.key ? "active" : ""}
+            aria-pressed={statusFilter === opt.key}
+          >
+            {opt.label}
           </button>
         ))}
       </nav>

--- a/components/term/TermPage.tsx
+++ b/components/term/TermPage.tsx
@@ -1,4 +1,5 @@
 import { MDXRemote } from 'next-mdx-remote/rsc';
+import UnderstandingTracker from '../UnderstandingTracker';
 
 interface SourceLinks {
   nist?: string;
@@ -22,6 +23,7 @@ export default function TermPage({ title, body, sources }: TermPageProps) {
     <article className="term">
       <h1>{title}</h1>
       <MDXRemote source={body} />
+      <UnderstandingTracker term={title} />
       {hasSources && (
         <section className="sources">
           <h2>Sources</h2>

--- a/lib/understanding.ts
+++ b/lib/understanding.ts
@@ -1,0 +1,31 @@
+export const STORAGE_KEY = 'understandingStatus';
+
+export interface UnderstandingRecord {
+  [term: string]: {
+    confidence: number;
+  };
+}
+
+export function loadStatuses(): UnderstandingRecord {
+  if (typeof window === 'undefined') return {};
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as UnderstandingRecord) : {};
+  } catch {
+    return {};
+  }
+}
+
+export function saveStatus(term: string, confidence: number) {
+  if (typeof window === 'undefined') return;
+  const data = loadStatuses();
+  data[term] = { confidence };
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+}
+
+export function removeStatus(term: string) {
+  if (typeof window === 'undefined') return;
+  const data = loadStatuses();
+  delete data[term];
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+}


### PR DESCRIPTION
## Summary
- add UnderstandingTracker component to mark terms as understood with confidence slider
- persist understanding state in localStorage and filter A-Z index by status
- integrate tracker into term pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6553409fc832885de58473e555439