### PR TITLE
Add backlinks panel and local reference index

### DIFF
--- a/public/backlinks.json
+++ b/public/backlinks.json
@@ -1,0 +1,3 @@
+{
+  "Phishing": ["Phishing Email"]
+}

--- a/src/components/BacklinksPanel.tsx
+++ b/src/components/BacklinksPanel.tsx
@@ -1,0 +1,46 @@
+import React, { useEffect, useState } from 'react';
+import { loadBacklinks } from '../utils/backlinks';
+
+interface Props {
+  term: string;
+}
+
+export default function BacklinksPanel({ term }: Props) {
+  const [refs, setRefs] = useState<string[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    loadBacklinks()
+      .then((map) => {
+        if (!cancelled) {
+          setRefs(map[term] || []);
+        }
+      })
+      .catch((err) => {
+        console.error('Failed to load backlinks', err);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [term]);
+
+  const openSplitView = (other: string) => {
+    const url = `/compare/${encodeURIComponent(other)}-vs-${encodeURIComponent(term)}`;
+    window.open(url, '_blank');
+  };
+
+  if (refs.length === 0) return null;
+
+  return (
+    <aside style={{ marginTop: '1rem' }}>
+      <h2>Referenced By</h2>
+      <ul>
+        {refs.map((r) => (
+          <li key={r}>
+            <button onClick={() => openSplitView(r)}>{r}</button>
+          </li>
+        ))}
+      </ul>
+    </aside>
+  );
+}

--- a/src/pages/TermPage.tsx
+++ b/src/pages/TermPage.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
+import BacklinksPanel from "../components/BacklinksPanel";
 
 interface Term {
   term: string;
@@ -111,6 +112,7 @@ export default function TermPage({ term }: TermPageProps) {
           </div>
         </div>
       </div>
+      <BacklinksPanel term={term.term} />
     </div>
   );
 }

--- a/src/utils/backlinks.ts
+++ b/src/utils/backlinks.ts
@@ -1,0 +1,44 @@
+export type BacklinkMap = Record<string, string[]>;
+
+const DB_NAME = 'csd';
+const STORE_NAME = 'backlinks';
+const KEY = 'data';
+
+async function openDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, 1);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME);
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+export async function loadBacklinks(): Promise<BacklinkMap> {
+  const db = await openDb();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readonly');
+    const store = tx.objectStore(STORE_NAME);
+    const getReq = store.get(KEY);
+    getReq.onsuccess = async () => {
+      if (getReq.result) {
+        resolve(getReq.result as BacklinkMap);
+      } else {
+        try {
+          const resp = await fetch('/backlinks.json');
+          const json = (await resp.json()) as BacklinkMap;
+          const wtx = db.transaction(STORE_NAME, 'readwrite');
+          wtx.objectStore(STORE_NAME).put(json, KEY);
+          resolve(json);
+        } catch (err) {
+          reject(err);
+        }
+      }
+    };
+    getReq.onerror = () => reject(getReq.error);
+  });
+}


### PR DESCRIPTION
## Summary
- store backlinks mapping in IndexedDB with fallback to `backlinks.json`
- display a Referenced By panel on term pages with split-view links
- seed project with initial backlinks dataset

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6553569688328b42c7c2544f52361