### PR TITLE
feat: add difficulty ladder for related terms

### DIFF
--- a/app/(site)/term/[slug]/RelatedTerms.tsx
+++ b/app/(site)/term/[slug]/RelatedTerms.tsx
@@ -5,22 +5,80 @@ interface RelatedTermsProps {
   slugs?: string[];
 }
 
+interface LadderTerm {
+  slug: string;
+  title: string;
+  difficulty: number;
+}
+
+/**
+ * Renders related terms as a horizontal ladder. Each rung is shaded by
+ * difficulty so readers can gauge prerequisite knowledge at a glance.
+ */
 export default function RelatedTerms({ slugs }: RelatedTermsProps) {
   if (!slugs || slugs.length === 0) return null;
+
+  const terms: LadderTerm[] = slugs
+    .map((slug) => {
+      const term = allTerms.find((t) => t.slug === slug);
+      return {
+        slug,
+        title: term?.title ?? slug,
+        difficulty: (term as any)?.difficulty ?? 1,
+      };
+    })
+    .sort((a, b) => a.difficulty - b.difficulty);
+
+  const difficultyColor = (d: number) => {
+    const colors = ["#4ade80", "#a3e635", "#facc15", "#fb923c", "#ef4444"];
+    return colors[Math.min(Math.max(d - 1, 0), colors.length - 1)];
+  };
+
   return (
     <section aria-labelledby="related-terms-heading">
       <h2 id="related-terms-heading">Related Terms</h2>
-      <ul>
-        {slugs.map((slug) => {
-          const term = allTerms.find((t) => t.slug === slug);
-          const title = term?.title ?? slug;
-          return (
-            <li key={slug}>
-              <Link href={`/term/${slug}`}>{title}</Link>
-            </li>
-          );
-        })}
+      <ul className="ladder">
+        {terms.map((t) => (
+          <li
+            key={t.slug}
+            className="rung"
+            style={{ background: difficultyColor(t.difficulty) }}
+          >
+            <Link href={`/term/${t.slug}`} className="rung__link">
+              {t.title}
+            </Link>
+          </li>
+        ))}
       </ul>
+      <style jsx>{`
+        .ladder {
+          display: flex;
+          list-style: none;
+          padding: 0;
+          margin: 0;
+          height: 1.5rem;
+        }
+        .rung {
+          flex: 1;
+          position: relative;
+        }
+        .rung__link {
+          position: absolute;
+          inset: 0;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          text-decoration: none;
+          color: #fff;
+          opacity: 0;
+          transition: opacity 0.2s ease-in-out;
+        }
+        .rung:hover .rung__link,
+        .rung__link:focus {
+          opacity: 1;
+          background: rgba(0, 0, 0, 0.4);
+        }
+      `}</style>
     </section>
   );
 }

--- a/components/term/RelatedTerms.tsx
+++ b/components/term/RelatedTerms.tsx
@@ -6,6 +6,8 @@ export interface RelatedTerm {
   slug: string;
   /** Human readable term name */
   name: string;
+  /** Relative difficulty level, 1 (easy) to 5 (hard) */
+  difficulty?: number;
 }
 
 interface RelatedTermsProps {
@@ -14,32 +16,76 @@ interface RelatedTermsProps {
 }
 
 /**
- * Displays a list of related terms for an entry.
+ * Displays a difficulty ladder of related terms for an entry.
  *
- * Related terms are rendered as pill-shaped links that lead to
- * their respective term pages. If no related terms are supplied,
- * nothing is rendered.
+ * Each rung is color-coded by relative difficulty. Hovering a rung
+ * reveals a button that navigates to the corresponding term page.
+ * If no related terms are supplied, nothing is rendered.
  */
 const RelatedTerms: React.FC<RelatedTermsProps> = ({ relatedTerms }) => {
   const router = useRouter();
   if (!relatedTerms || relatedTerms.length === 0) return null;
 
+  const terms = [...relatedTerms].sort(
+    (a, b) => (a.difficulty ?? 1) - (b.difficulty ?? 1),
+  );
+
+  const difficultyColor = (d: number = 1) => {
+    const colors = ["#4ade80", "#a3e635", "#facc15", "#fb923c", "#ef4444"];
+    return colors[Math.min(Math.max(d - 1, 0), colors.length - 1)];
+  };
+
   return (
     <section className="related-terms">
       <h2 className="related-terms__heading">See also</h2>
-      <ul className="related-terms__list">
-        {relatedTerms.map((term) => (
-          <li key={term.slug} className="related-terms__item">
+      <ul className="related-terms__ladder">
+        {terms.map((term) => (
+          <li
+            key={term.slug}
+            className="related-terms__rung"
+            style={{ background: difficultyColor(term.difficulty) }}
+          >
             <button
               type="button"
               onClick={() => router.push(`/terms/${term.slug}`)}
-              className="related-terms__pill"
+              className="related-terms__link"
             >
               {term.name}
             </button>
           </li>
         ))}
       </ul>
+      <style jsx>{`
+        .related-terms__ladder {
+          display: flex;
+          list-style: none;
+          padding: 0;
+          margin: 0;
+          height: 1.5rem;
+        }
+        .related-terms__rung {
+          flex: 1;
+          position: relative;
+        }
+        .related-terms__link {
+          position: absolute;
+          inset: 0;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          background: transparent;
+          border: none;
+          color: #fff;
+          opacity: 0;
+          transition: opacity 0.2s ease-in-out;
+          cursor: pointer;
+        }
+        .related-terms__rung:hover .related-terms__link,
+        .related-terms__link:focus {
+          opacity: 1;
+          background: rgba(0, 0, 0, 0.4);
+        }
+      `}</style>
     </section>
   );
 };


### PR DESCRIPTION
## Summary
- display related terms as a horizontal ladder sorted by difficulty
- color-code rungs and reveal term links on hover
- extend related term definitions with optional difficulty level

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b655367ab4832885a23642924778bf