### PR TITLE
Add OS-aware font hinting with settings toggle

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { motion } from "framer-motion";
 import Navbar from "../components/Navbar";
 import { Inter } from "next/font/google";
+import useFontHinting from "../hooks/useFontHinting";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -12,6 +13,7 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
+  useFontHinting();
   return (
     <html lang="en" className={inter.className}>
       <body>

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -7,6 +7,7 @@ export default function SettingsPage() {
   const [fontSize, setFontSize] = useState("medium");
   const [density, setDensity] = useState("comfortable");
   const [preferredSources, setPreferredSources] = useState<string[]>([]);
+  const [enhancedHinting, setEnhancedHinting] = useState(true);
 
   useEffect(() => {
     const saved = localStorage.getItem("settings");
@@ -17,6 +18,7 @@ export default function SettingsPage() {
         setFontSize(parsed.fontSize ?? "medium");
         setDensity(parsed.density ?? "comfortable");
         setPreferredSources(parsed.preferredSources ?? []);
+        setEnhancedHinting(parsed.enhancedHinting ?? true);
       } catch {
         // ignore parse errors
       }
@@ -24,12 +26,13 @@ export default function SettingsPage() {
   }, []);
 
   useEffect(() => {
-    const data = { darkMode, fontSize, density, preferredSources };
+    const data = { darkMode, fontSize, density, preferredSources, enhancedHinting };
     localStorage.setItem("settings", JSON.stringify(data));
     document.documentElement.classList.toggle("dark", darkMode);
     document.documentElement.style.fontSize =
       fontSize === "small" ? "14px" : fontSize === "large" ? "18px" : "16px";
-  }, [darkMode, fontSize, density, preferredSources]);
+    window.dispatchEvent(new Event("storage"));
+  }, [darkMode, fontSize, density, preferredSources, enhancedHinting]);
 
   const toggleSource = (src: string) => {
     setPreferredSources((prev) =>
@@ -49,6 +52,17 @@ export default function SettingsPage() {
             onChange={(e) => setDarkMode(e.target.checked)}
           />
           Dark mode
+        </label>
+      </section>
+
+      <section>
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={enhancedHinting}
+            onChange={(e) => setEnhancedHinting(e.target.checked)}
+          />
+          Enhanced font hinting
         </label>
       </section>
 

--- a/assets/js/hinting.js
+++ b/assets/js/hinting.js
@@ -1,0 +1,32 @@
+(function(){
+  const KEY = 'settings';
+  function read(){
+    try {
+      return JSON.parse(localStorage.getItem(KEY) || '{}');
+    } catch {
+      return {};
+    }
+  }
+  function write(data){
+    localStorage.setItem(KEY, JSON.stringify(data));
+    window.dispatchEvent(new Event('storage'));
+  }
+  function apply(){
+    const data = read();
+    const toggle = document.getElementById('hinting-toggle');
+    if(toggle){
+      toggle.checked = data.enhancedHinting !== false;
+    }
+  }
+  function setup(){
+    const toggle = document.getElementById('hinting-toggle');
+    if(!toggle) return;
+    toggle.addEventListener('change', () => {
+      const data = read();
+      data.enhancedHinting = toggle.checked;
+      write(data);
+    });
+  }
+  apply();
+  setup();
+})();

--- a/hooks/useFontHinting.ts
+++ b/hooks/useFontHinting.ts
@@ -1,0 +1,48 @@
+import { useEffect } from "react";
+
+function detectOS(): "mac" | "windows" | "linux" | "other" {
+  const ua = navigator.userAgent.toLowerCase();
+  if (ua.includes("mac")) return "mac";
+  if (ua.includes("win")) return "windows";
+  if (ua.includes("linux")) return "linux";
+  return "other";
+}
+
+function featureSettings(os: string): string {
+  switch (os) {
+    case "mac":
+      return '"kern" 1, "liga" 1';
+    case "windows":
+      return '"ss01" 1, "ss02" 1';
+    case "linux":
+      return '"liga" 1, "clig" 1';
+    default:
+      return '"kern" 1';
+  }
+}
+
+export function useFontHinting() {
+  useEffect(() => {
+    const apply = () => {
+      let features = "";
+      try {
+        const raw = localStorage.getItem("settings");
+        const disabled = raw && JSON.parse(raw).enhancedHinting === false;
+        if (!disabled) {
+          features = featureSettings(detectOS());
+        }
+      } catch {
+        /* ignore */
+      }
+      document.documentElement.style.fontFeatureSettings = features;
+    };
+
+    apply();
+    window.addEventListener("storage", apply);
+    return () => {
+      window.removeEventListener("storage", apply);
+    };
+  }, []);
+}
+
+export default useFontHinting;

--- a/settings.html
+++ b/settings.html
@@ -10,8 +10,10 @@
   <main class="container">
     <h1>Settings</h1>
     <label for="pro-toggle"><input id="pro-toggle" type="checkbox"> Enable Pro Mode</label>
+    <label for="hinting-toggle"><input id="hinting-toggle" type="checkbox" checked> Enhanced Font Hinting</label>
   </main>
   <script src="assets/js/pro.js"></script>
+  <script src="assets/js/hinting.js"></script>
   <script src="https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js"></script>
   <script src="assets/js/metrics.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- detect user OS and apply tailored font-feature-settings
- allow users to disable enhanced font hinting in settings
- expose same toggle in static settings page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b655396a188328b3994f52e7556434