### PR TITLE
feat: show reasons on related term chips

### DIFF
--- a/components/term/RelatedTerms.tsx
+++ b/components/term/RelatedTerms.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { useRouter } from "next/navigation";
+import relatedReasons from "../../relatedReasons.json";
 
 export interface RelatedTerm {
   /** Slug used to build link to the term page */
@@ -28,17 +29,30 @@ const RelatedTerms: React.FC<RelatedTermsProps> = ({ relatedTerms }) => {
     <section className="related-terms">
       <h2 className="related-terms__heading">See also</h2>
       <ul className="related-terms__list">
-        {relatedTerms.map((term) => (
-          <li key={term.slug} className="related-terms__item">
-            <button
-              type="button"
-              onClick={() => router.push(`/terms/${term.slug}`)}
-              className="related-terms__pill"
-            >
-              {term.name}
-            </button>
-          </li>
-        ))}
+        {relatedTerms.map((term) => {
+          const reason = (relatedReasons as Record<string, string>)[term.slug];
+          return (
+            <li key={term.slug} className="related-terms__item">
+              <button
+                type="button"
+                onClick={() => router.push(`/terms/${term.slug}`)}
+                className="related-terms__pill"
+                title={reason || undefined}
+                aria-label={reason ? `${term.name} – ${reason}` : term.name}
+              >
+                <span className="related-terms__term">{term.name}</span>
+                {reason && (
+                  <span
+                    aria-hidden="true"
+                    className="related-terms__reason"
+                  >
+                    {reason}
+                  </span>
+                )}
+              </button>
+            </li>
+          );
+        })}
       </ul>
     </section>
   );

--- a/relatedReasons.json
+++ b/relatedReasons.json
@@ -1,0 +1,5 @@
+{
+  "phishing": "Social engineering attack",
+  "phishing-email": "Phishing variant",
+  "social-engineering": "Broader category"
+}

--- a/styles.css
+++ b/styles.css
@@ -581,3 +581,22 @@ body.dark-mode #alpha-nav button.active {
 .selection-highlight {
   background-color: yellow;
 }
+
+/* Related term chips */
+.related-terms__pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 4px 8px;
+  border: none;
+  border-radius: 9999px;
+  background-color: #e0e0e0;
+  cursor: pointer;
+}
+
+.related-terms__reason {
+  background-color: #ccc;
+  border-radius: 4px;
+  padding: 0 4px;
+  font-size: 0.75rem;
+}


### PR DESCRIPTION
## Summary
- load reason tags from `relatedReasons.json`
- render reason text and tooltip on related term chips
- style related term chips and reason tags

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b655389c348328bdad92b087231800