### PR TITLE
Add floating mobile ToC button with full-screen overlay

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@
 import React from "react";
 import { motion } from "framer-motion";
 import Navbar from "../components/Navbar";
+import MobileTocButton from "../components/MobileTocButton";
 import { Inter } from "next/font/google";
 
 const inter = Inter({ subsets: ["latin"] });
@@ -24,6 +25,7 @@ export default function RootLayout({
         >
           {children}
         </motion.div>
+        <MobileTocButton />
       </body>
     </html>
   );

--- a/components/MobileTocButton.tsx
+++ b/components/MobileTocButton.tsx
@@ -1,0 +1,55 @@
+import React, { useEffect, useState } from "react";
+import TOC from "./TOC";
+
+/**
+ * Floating button that reveals a full-screen table of contents on mobile.
+ * The overlay can be dismissed by tapping or using the browser back button.
+ */
+const MobileTocButton: React.FC = () => {
+  const [open, setOpen] = useState(false);
+
+  // Allow the browser back button to close the overlay.
+  useEffect(() => {
+    if (!open) return;
+    history.pushState({ mobileToc: true }, "");
+    const onPop = () => setOpen(false);
+    window.addEventListener("popstate", onPop);
+    return () => window.removeEventListener("popstate", onPop);
+  }, [open]);
+
+  const close = () => {
+    if (open) history.back();
+  };
+
+  return (
+    <>
+      <button
+        className="mobile-toc-button"
+        onClick={() => setOpen(true)}
+        aria-label="Open table of contents"
+      >
+        TOC
+      </button>
+      {open && (
+        <div className="mobile-toc-overlay" onClick={close}>
+          <div
+            className="mobile-toc"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <button
+              className="close"
+              onClick={close}
+              aria-label="Close table of contents"
+            >
+              ×
+            </button>
+            <TOC />
+          </div>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default MobileTocButton;
+

--- a/styles.css
+++ b/styles.css
@@ -581,3 +581,51 @@ body.dark-mode #alpha-nav button.active {
 .selection-highlight {
   background-color: yellow;
 }
+
+/* Floating table of contents for mobile screens */
+.mobile-toc-button {
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+  z-index: 1000;
+  padding: 0.5rem 0.75rem;
+  border: none;
+  border-radius: 4px;
+  background: #333;
+  color: #fff;
+  display: none;
+}
+
+@media (max-width: 768px) {
+  .mobile-toc-button {
+    display: block;
+  }
+}
+
+.mobile-toc-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  z-index: 1000;
+  display: flex;
+  align-items: stretch;
+}
+
+.mobile-toc {
+  background: #fff;
+  color: #000;
+  width: 100%;
+  overflow-y: auto;
+  padding: 1rem;
+  position: relative;
+}
+
+.mobile-toc .close {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+}
+


### PR DESCRIPTION
## Summary
- add `MobileTocButton` component that displays a floating Table of Contents button on small screens
- overlay lists headings and can be dismissed by tapping outside or using the browser back button
- integrate mobile ToC button into root layout and style overlay/button

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6553c866883288c165791d43d194b