### PR TITLE
feat: add expandable media caption

### DIFF
--- a/MediaCaption.tsx
+++ b/MediaCaption.tsx
@@ -1,0 +1,72 @@
+import React, { useLayoutEffect, useRef, useState } from "react";
+
+interface MediaCaptionProps {
+  /**
+   * Caption text to display under media.
+   */
+  children: React.ReactNode;
+  /**
+   * Number of lines visible before truncation.
+   * @default 2
+   */
+  lines?: number;
+}
+
+/**
+ * MediaCaption renders an expandable caption. Long captions are
+ * truncated to a set number of lines and can be expanded or collapsed
+ * without causing layout shift, thanks to explicit height management.
+ */
+export const MediaCaption: React.FC<MediaCaptionProps> = ({
+  children,
+  lines = 2,
+}) => {
+  const contentRef = useRef<HTMLDivElement>(null);
+  const collapsedHeightRef = useRef(0);
+  const fullHeightRef = useRef(0);
+  const [expanded, setExpanded] = useState(false);
+  const [needsToggle, setNeedsToggle] = useState(false);
+  const [height, setHeight] = useState<number>();
+
+  // Measure heights after first render
+  useLayoutEffect(() => {
+    const el = contentRef.current;
+    if (!el) return;
+    const lineHeight = parseFloat(getComputedStyle(el).lineHeight || "0");
+    collapsedHeightRef.current = lineHeight * lines;
+    fullHeightRef.current = el.scrollHeight;
+    setHeight(collapsedHeightRef.current);
+    if (fullHeightRef.current > collapsedHeightRef.current + 1) {
+      setNeedsToggle(true);
+    }
+  }, [children, lines]);
+
+  const toggle = () => {
+    setExpanded((prev) => {
+      const next = !prev;
+      setHeight(next ? fullHeightRef.current : collapsedHeightRef.current);
+      return next;
+    });
+  };
+
+  return (
+    <div
+      className="media-caption"
+      style={{ height, overflow: "hidden", transition: "height 0.3s ease" }}
+    >
+      <div ref={contentRef}>{children}</div>
+      {needsToggle && (
+        <button
+          type="button"
+          className="media-caption__toggle"
+          onClick={toggle}
+        >
+          {expanded ? "less" : "more"}
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default MediaCaption;
+


### PR DESCRIPTION
## Summary
- add `MediaCaption` component that truncates long captions and toggles more/less
- measure caption heights to expand without layout shift

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6553e2a90832898747b1412bc1d34