### PR TITLE
feat: add clipboard copy with contextual formats

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,9 @@
         "http-server": "^14.1.1",
         "js-yaml": "^4.1.0",
         "jsdom": "^26.1.0",
-        "prettier": "^3.6.2"
+        "prettier": "^3.6.2",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.9.2"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -47,6 +49,19 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/@csstools/color-helpers": {
       "version": "5.1.0",
@@ -223,6 +238,34 @@
         "node": ">=12"
       }
     },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "node_modules/@playwright/test": {
       "version": "1.55.0",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
@@ -259,6 +302,34 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/cors": {
@@ -300,6 +371,32 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/agent-base": {
@@ -371,6 +468,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -700,6 +804,13 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -798,6 +909,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/dunder-proto": {
@@ -1683,6 +1804,13 @@
       "engines": {
         "node": "20 || >=22"
       }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -2790,6 +2918,50 @@
         "is-lite": "^1.2.1"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -2806,6 +2978,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/undici-types": {
@@ -2830,6 +3016,13 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
       "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true,
       "license": "MIT"
     },
@@ -3155,6 +3348,16 @@
       "dependencies": {
         "ansi-regex": "^4.1.0"
       },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/",
   "main": "script.js",
   "scripts": {
-    "test": "html-validate index.html search.html diagnostics.html import.html && node diagnostics.test.js"
+    "test": "html-validate index.html search.html diagnostics.html import.html && node diagnostics.test.js && node tests/useCopyFormats.test.js"
   },
   "keywords": [],
   "author": "",
@@ -16,7 +16,9 @@
     "http-server": "^14.1.1",
     "js-yaml": "^4.1.0",
     "jsdom": "^26.1.0",
-    "prettier": "^3.6.2"
+    "prettier": "^3.6.2",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.9.2"
   },
   "dependencies": {
     "framer-motion": "^12.23.12",

--- a/src/features/selection/SelectionToolbar.tsx
+++ b/src/features/selection/SelectionToolbar.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
-import { useSelection } from './SelectionContext';
+import React from "react";
+import { useSelection } from "./SelectionContext";
+import useCopyFormats from "./useCopyFormats";
 
 interface Props {
   onCompare(ids: string[]): void;
@@ -8,13 +9,55 @@ interface Props {
 
 export const SelectionToolbar: React.FC<Props> = ({ onCompare, onExport }) => {
   const { selected, clear } = useSelection();
+  const buildFormats = useCopyFormats();
   if (selected.length === 0) return null;
-  const ids = selected.map(s => s.id);
+  const ids = selected.map((s) => s.id);
+
+  const copySelection = async () => {
+    const selection = window.getSelection();
+    if (!selection || selection.toString().trim() === "") return;
+    const text = selection.toString();
+    const range = selection.getRangeAt(0);
+    let node: Node | null = range.startContainer;
+    let headingEl: HTMLElement | null = null;
+    if (node instanceof HTMLElement) {
+      headingEl = node.closest("h1,h2,h3,h4,h5,h6");
+    } else if (node.parentElement) {
+      headingEl = node.parentElement.closest("h1,h2,h3,h4,h5,h6");
+    }
+    if (!headingEl) {
+      let el: HTMLElement | null = node.parentElement;
+      while (el && !headingEl) {
+        if (el.previousElementSibling) {
+          const prev = el.previousElementSibling as HTMLElement;
+          if (/^H[1-6]$/.test(prev.tagName)) {
+            headingEl = prev;
+            break;
+          }
+        }
+        el = el.parentElement;
+      }
+    }
+    const heading = headingEl?.textContent?.trim() || document.title;
+    const id = headingEl?.id ? `#${headingEl.id}` : "";
+    const url = `${window.location.origin}${window.location.pathname}${id}`;
+    const formats = buildFormats(text, heading, url);
+    const item = new ClipboardItem({
+      "text/plain": new Blob([formats["text/plain"]], { type: "text/plain" }),
+      "text/html": new Blob([formats["text/html"]], { type: "text/html" }),
+      "text/markdown": new Blob([formats["text/markdown"]], {
+        type: "text/markdown",
+      }),
+    } as any);
+    await navigator.clipboard.write([item]);
+  };
+
   return (
     <div className="selection-toolbar">
       <span>{selected.length} selected</span>
       <button onClick={() => onCompare(ids)}>Compare</button>
       <button onClick={() => onExport(ids)}>Export</button>
+      <button onClick={copySelection}>Copy</button>
       <button onClick={clear}>Clear</button>
     </div>
   );

--- a/src/features/selection/index.ts
+++ b/src/features/selection/index.ts
@@ -1,3 +1,4 @@
-export * from './SelectionContext';
-export * from './useMarquee';
-export * from './SelectionToolbar';
+export * from "./SelectionContext";
+export * from "./useMarquee";
+export * from "./SelectionToolbar";
+export { default as useCopyFormats } from "./useCopyFormats";

--- a/src/features/selection/useCopyFormats.ts
+++ b/src/features/selection/useCopyFormats.ts
@@ -1,0 +1,30 @@
+export type CopyFormat = "plain" | "markdown" | "html";
+
+export interface CopyFormats {
+  "text/plain": string;
+  "text/markdown": string;
+  "text/html": string;
+}
+
+function escapeHtml(str: string): string {
+  return str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+/**
+ * Hook returning a formatter for clipboard copy operations. Given a text
+ * selection, heading and source URL, it produces Plain, Markdown and HTML
+ * representations.
+ */
+export default function useCopyFormats() {
+  return (text: string, heading: string, url: string): CopyFormats => {
+    const escapedText = escapeHtml(text);
+    const escapedHeading = escapeHtml(heading);
+    const escapedUrl = escapeHtml(url);
+
+    return {
+      "text/plain": `${text}\n\n${heading} - ${url}`,
+      "text/markdown": `${text}\n\n[${heading}](${url})`,
+      "text/html": `<blockquote>${escapedText}</blockquote><p><a href="${escapedUrl}">${escapedHeading}</a></p>`,
+    };
+  };
+}

--- a/tests/useCopyFormats.test.js
+++ b/tests/useCopyFormats.test.js
@@ -1,0 +1,26 @@
+require("ts-node/register");
+const assert = require("assert").strict;
+const useCopyFormats =
+  require("../src/features/selection/useCopyFormats").default;
+
+const build = useCopyFormats();
+const text = "Example text";
+const heading = "Heading";
+const url = "https://example.com/page#heading";
+
+const formats = build(text, heading, url);
+
+assert.equal(
+  formats["text/plain"],
+  "Example text\n\nHeading - https://example.com/page#heading",
+);
+assert.equal(
+  formats["text/markdown"],
+  "Example text\n\n[Heading](https://example.com/page#heading)",
+);
+assert.equal(
+  formats["text/html"],
+  '<blockquote>Example text</blockquote><p><a href="https://example.com/page#heading">Heading</a></p>',
+);
+
+console.log("useCopyFormats tests passed");


### PR DESCRIPTION
## Summary
- add copy option to selection toolbar that grabs the nearest heading and page link
- support plain, markdown, and HTML formats for clipboard operations via new `useCopyFormats` hook
- add tests for copy formats and wire them into npm test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6553c48c88328b1b29defb4aeea12