### PR TITLE
feat: add dev-only logger for warnings

### DIFF
--- a/src/utils/devLogger.ts
+++ b/src/utils/devLogger.ts
@@ -1,0 +1,12 @@
+/**
+ * Development-only wrapper for console.warn.
+ * Provides a docs link and is silenced in production.
+ */
+export function devLogger(...args: unknown[]): void {
+  if (process.env.NODE_ENV !== 'production') {
+    console.warn(
+      'See docs: https://alex-unnippillil.github.io/CyberSecuirtyDictionary/docs/',
+      ...args,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `devLogger` to emit warnings only during development and link to docs
- consolidate `console.warn` usage behind `devLogger`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b76ed99780832888e10205f3e1c03c