### PR TITLE
Hide navigation and buttons in print view

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -17,6 +17,9 @@ export default function RootLayout({
   useFontHinting();
   return (
     <html lang="en" className={inter.className}>
+      <head>
+        <link rel="stylesheet" href="/styles/print.css" media="print" />
+      </head>
       <body>
         <Navbar />
         <motion.div

--- a/styles/print.css
+++ b/styles/print.css
@@ -1,0 +1,4 @@
+nav,
+button {
+  display: none !important;
+}


### PR DESCRIPTION
## Summary
- add `styles/print.css` to suppress navigation and buttons when printing
- link the print stylesheet in `app/layout.tsx`

## Testing
- `npm test`
- `node - <<'NODE'
const fs = require('fs');
const { chromium } = require('@playwright/test');
(async () => {
  const css = fs.readFileSync('styles/print.css', 'utf8');
  const browser = await chromium.launch();
  const page = await browser.newPage();
  await page.setContent(`<!DOCTYPE html><html><head><style media="print">${css}</style></head><body><nav>Nav</nav><button>Click</button><p>Content</p></body></html>`);
  const navDisplayDefault = await page.evaluate(() => getComputedStyle(document.querySelector('nav')).display);
  const btnDisplayDefault = await page.evaluate(() => getComputedStyle(document.querySelector('button')).display);
  await page.emulateMedia({ media: 'print' });
  const navDisplayPrint = await page.evaluate(() => getComputedStyle(document.querySelector('nav')).display);
  const btnDisplayPrint = await page.evaluate(() => getComputedStyle(document.querySelector('button')).display);
  console.log('default nav display:', navDisplayDefault);
  console.log('default button display:', btnDisplayDefault);
  console.log('print nav display:', navDisplayPrint);
  console.log('print button display:', btnDisplayPrint);
  await browser.close();
})();
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68b76ed9401c8328a84aca9e89f50b87