### PR TITLE
refactor: replace layout animations

### DIFF
--- a/MediaCaption.tsx
+++ b/MediaCaption.tsx
@@ -52,7 +52,7 @@ export const MediaCaption: React.FC<MediaCaptionProps> = ({
   return (
     <div
       className="media-caption"
-      style={{ height, overflow: "hidden", transition: "height 0.3s ease" }}
+      style={{ height, overflow: "hidden" }}
     >
       <div ref={contentRef}>{children}</div>
       {needsToggle && (

--- a/components/KeyboardReader.tsx
+++ b/components/KeyboardReader.tsx
@@ -49,7 +49,8 @@ export const KeyboardReader: React.FC<KeyboardReaderProps> = ({
             paddingLeft: "1em",
             maxHeight: collapsed[idx] ? 0 : "none",
             overflow: "hidden",
-            transition: "max-height 0.2s ease",
+            opacity: collapsed[idx] ? 0 : 1,
+            transition: "opacity 0.2s ease",
             margin: collapsed[idx] ? 0 : undefined,
           }}
         >

--- a/components/MiniMap.tsx
+++ b/components/MiniMap.tsx
@@ -135,7 +135,7 @@ const MiniMap: React.FC<MiniMapProps> = ({ selector = "h2, h3", offset = 0 }) =>
             left: 0,
             width: "4px",
             background: "#0070f3",
-            transition: "transform 0.2s, height 0.2s",
+            transition: "transform 0.2s",
           }}
         />
         {items.map((item) => (

--- a/components/term/TermHeader.tsx
+++ b/components/term/TermHeader.tsx
@@ -37,7 +37,7 @@ const TermHeader: React.FC<TermHeaderProps> = ({ title, contentRef }) => {
   }, [contentRef]);
 
   const barColor = getColor(score);
-  const width = `${Math.max(0, Math.min(100, score))}%`;
+  const scale = Math.max(0, Math.min(100, score)) / 100;
 
   return (
     <header className="term-header" style={{ marginBottom: '1rem' }}>
@@ -54,10 +54,12 @@ const TermHeader: React.FC<TermHeaderProps> = ({ title, contentRef }) => {
         >
           <div
             style={{
-              width,
+              width: '100%',
               height: '100%',
               background: barColor,
-              transition: 'width 0.3s ease, background 0.3s ease',
+              transform: `scaleX(${scale})`,
+              transformOrigin: 'left',
+              transition: 'transform 0.3s ease, background 0.3s ease',
             }}
           />
         </div>

--- a/src/components/FocusSpotlight.tsx
+++ b/src/components/FocusSpotlight.tsx
@@ -67,7 +67,7 @@ export default function FocusSpotlight() {
   };
 
   if (!reducedMotion) {
-    baseStyle.transition = 'all 0.2s ease';
+    baseStyle.transition = 'opacity 0.2s ease';
   }
 
   return (


### PR DESCRIPTION
## Summary
- eliminate layout-based height transitions from MediaCaption
- drop height transition in MiniMap marker for transform-only movement
- switch TermHeader progress bar to transform scaling
- use opacity-based hide/show in KeyboardReader
- limit FocusSpotlight transition to opacity

## Testing
- `pnpm quarantine framer-motion` *(fails: Command "quarantine" not found)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b76ed715688328a827f8e9d537fb40