### PR TITLE
Add offline detection and banner

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import Navbar from "../components/Navbar";
 import MobileTocButton from "../components/MobileTocButton";
 import { Inter } from "next/font/google";
 import useFontHinting from "../hooks/useFontHinting";
+import useOffline from "../src/hooks/useOffline";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -15,10 +16,16 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   useFontHinting();
+  const offline = useOffline();
   return (
     <html lang="en" className={inter.className}>
       <body>
         <Navbar />
+        {offline && (
+          <div className="bg-red-600 text-white text-center py-2">
+            You are offline
+          </div>
+        )}
         <motion.div
           initial={{ opacity: 0, y: 10 }}
           animate={{ opacity: 1, y: 0 }}

--- a/src/hooks/useOffline.ts
+++ b/src/hooks/useOffline.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from "react";
+
+export default function useOffline(): boolean {
+  const [offline, setOffline] = useState(
+    typeof navigator !== "undefined" ? !navigator.onLine : false,
+  );
+
+  useEffect(() => {
+    const update = () => setOffline(!navigator.onLine);
+    window.addEventListener("online", update);
+    window.addEventListener("offline", update);
+    return () => {
+      window.removeEventListener("online", update);
+      window.removeEventListener("offline", update);
+    };
+  }, []);
+
+  return offline;
+}

--- a/src/hooks/useSearch.tsx
+++ b/src/hooks/useSearch.tsx
@@ -5,6 +5,7 @@ import {
   useEffect,
   useState,
 } from "react";
+import useOffline from "./useOffline";
 
 interface SearchResult {
   term: string;
@@ -34,6 +35,7 @@ export const SearchProvider: React.FC<{ children: React.ReactNode }> = ({
     const parsed = parseInt(raw ?? "0", 10);
     return Number.isNaN(parsed) ? 0 : parsed;
   });
+  const offline = useOffline();
 
   // Persist fuzziness
   useEffect(() => {
@@ -46,7 +48,7 @@ export const SearchProvider: React.FC<{ children: React.ReactNode }> = ({
 
   // Refresh results when query or fuzziness change
   useEffect(() => {
-    if (!query) {
+    if (!query || offline) {
       setResults([]);
       return;
     }
@@ -54,7 +56,7 @@ export const SearchProvider: React.FC<{ children: React.ReactNode }> = ({
       .then((res) => (res.ok ? res.json() : { results: [] }))
       .then((data) => setResults(data.results || []))
       .catch(() => setResults([]));
-  }, [query, fuzziness]);
+  }, [query, fuzziness, offline]);
 
   const setFuzziness = useCallback((f: number) => {
     setFuzzinessState(f);


### PR DESCRIPTION
## Summary
- add `useOffline` hook to track online/offline status
- show offline banner in root layout
- disable search requests when offline

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b76ed6a8288328846c8e839df7d928