### PR TITLE
Add clipboard copy fallback with execCommand

### DIFF
--- a/assets/js/cidr.js
+++ b/assets/js/cidr.js
@@ -12,9 +12,27 @@ function prefixToMask(prefix) {
   return prefix === 0 ? 0 : (0xffffffff << (32 - prefix)) >>> 0;
 }
 
-function copyToClipboard(id) {
+async function copyToClipboard(id) {
   const text = document.getElementById(id).textContent;
-  navigator.clipboard.writeText(text);
+  try {
+    await navigator.clipboard.writeText(text);
+  } catch (err) {
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.setAttribute('readonly', '');
+    textarea.style.position = 'fixed';
+    textarea.style.top = '0';
+    textarea.style.left = '0';
+    textarea.style.opacity = '0';
+    document.body.appendChild(textarea);
+    textarea.focus();
+    textarea.select();
+    const successful = document.execCommand('copy');
+    document.body.removeChild(textarea);
+    if (!successful) {
+      throw err;
+    }
+  }
 }
 
 function calculate() {

--- a/assets/js/sanitize.js
+++ b/assets/js/sanitize.js
@@ -3,6 +3,28 @@ const originalPre = document.getElementById('original');
 const sanitizedPre = document.getElementById('sanitized');
 const copyBtn = document.getElementById('copy-clean');
 
+async function copyText(text) {
+  try {
+    await navigator.clipboard.writeText(text);
+  } catch (err) {
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.setAttribute('readonly', '');
+    textarea.style.position = 'fixed';
+    textarea.style.top = '0';
+    textarea.style.left = '0';
+    textarea.style.opacity = '0';
+    document.body.appendChild(textarea);
+    textarea.focus();
+    textarea.select();
+    const successful = document.execCommand('copy');
+    document.body.removeChild(textarea);
+    if (!successful) {
+      throw err;
+    }
+  }
+}
+
 function stripHidden(text) {
   // Remove control characters except tab, newline, and carriage return
   return text.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, '');
@@ -36,5 +58,5 @@ textarea.addEventListener('paste', (e) => {
 });
 
 copyBtn.addEventListener('click', () => {
-  navigator.clipboard.writeText(sanitizedPre.textContent);
+  copyText(sanitizedPre.textContent);
 });

--- a/components/InflectionTable.tsx
+++ b/components/InflectionTable.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import copyToClipboard from "../lib/copyToClipboard";
 
 interface Entry {
   inflections?: Record<string, string>;
@@ -15,10 +16,12 @@ export default function InflectionTable({ entry }: Props) {
     return null;
   }
 
-  const copyToClipboard = (value: string) => {
-    navigator.clipboard.writeText(value).catch(() => {
+  const copyValue = async (value: string) => {
+    try {
+      await copyToClipboard(value);
+    } catch {
       /* ignore errors */
-    });
+    }
   };
 
   return (
@@ -31,7 +34,7 @@ export default function InflectionTable({ entry }: Props) {
               {value}
               <button
                 type="button"
-                onClick={() => copyToClipboard(value)}
+                onClick={() => copyValue(value)}
                 aria-label={`Copy ${value}`}
               >
                 Copy

--- a/components/examples/ExampleSentence.tsx
+++ b/components/examples/ExampleSentence.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import copyToClipboard from "../../lib/copyToClipboard";
 
 export interface ExampleSentenceProps {
   /** The example sentence to display */
@@ -18,7 +19,7 @@ export const ExampleSentence: React.FC<ExampleSentenceProps> = ({
 
   const handleCopy = async () => {
     try {
-      await navigator.clipboard.writeText(text);
+      await copyToClipboard(text);
       // eslint-disable-next-line no-alert
       alert("Example sentence copied");
     } catch (err) {

--- a/components/term/ShareButton.tsx
+++ b/components/term/ShareButton.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import copyToClipboard from "../../lib/copyToClipboard";
 
 /**
  * ShareButton copies the current page's canonical URL to the clipboard
@@ -14,7 +15,7 @@ const ShareButton: React.FC = () => {
     const url = canonical?.href || window.location.href;
 
     try {
-      await navigator.clipboard.writeText(url);
+      await copyToClipboard(url);
       setVisible(true);
       setTimeout(() => setVisible(false), 2000);
     } catch (err) {

--- a/lib/copyToClipboard.ts
+++ b/lib/copyToClipboard.ts
@@ -1,0 +1,21 @@
+export default async function copyToClipboard(text: string): Promise<void> {
+  try {
+    await navigator.clipboard.writeText(text);
+  } catch (err) {
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.setAttribute('readonly', '');
+    textarea.style.position = 'fixed';
+    textarea.style.top = '0';
+    textarea.style.left = '0';
+    textarea.style.opacity = '0';
+    document.body.appendChild(textarea);
+    textarea.focus();
+    textarea.select();
+    const successful = document.execCommand('copy');
+    document.body.removeChild(textarea);
+    if (!successful) {
+      throw err instanceof Error ? err : new Error(String(err));
+    }
+  }
+}

--- a/script.js
+++ b/script.js
@@ -10,6 +10,28 @@ const favorites = new Set(JSON.parse(localStorage.getItem("favorites") || "[]"))
 const siteUrl = "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/";
 const canonicalLink = document.getElementById("canonical-link");
 
+async function copyText(text) {
+  try {
+    await navigator.clipboard.writeText(text);
+  } catch (err) {
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.setAttribute('readonly', '');
+    textarea.style.position = 'fixed';
+    textarea.style.top = '0';
+    textarea.style.left = '0';
+    textarea.style.opacity = '0';
+    document.body.appendChild(textarea);
+    textarea.focus();
+    textarea.select();
+    const successful = document.execCommand('copy');
+    document.body.removeChild(textarea);
+    if (!successful) {
+      throw err;
+    }
+  }
+}
+
 // --- Search token overlay and help popover setup ---
 const searchWrapper = document.createElement("div");
 searchWrapper.id = "search-wrapper";
@@ -582,8 +604,7 @@ selectionLinkBtn.addEventListener("click", (e) => {
   url.searchParams.set("term", currentTerm.term);
   url.searchParams.set("start", start);
   url.searchParams.set("end", end);
-  navigator.clipboard
-    .writeText(url.toString())
+  copyText(url.toString())
     .then(() => showToast("Link copied!"))
     .catch(() => {});
   selectionLinkBtn.style.display = "none";

--- a/src/components/ClipboardHistory.tsx
+++ b/src/components/ClipboardHistory.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useEffect, useState } from 'react';
+import copyToClipboard from '../../lib/copyToClipboard';
 
 interface HistoryItem {
   text: string;
@@ -62,7 +63,7 @@ const ClipboardHistory: React.FC = () => {
 
   const handleCopy = async (text: string) => {
     try {
-      await navigator.clipboard.writeText(text);
+      await copyToClipboard(text);
       addItem(text);
     } catch {
       // ignore

--- a/src/components/CodeBlock.tsx
+++ b/src/components/CodeBlock.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
+import copyToClipboard from '../../lib/copyToClipboard';
 
 interface CodeBlockProps {
   /** CLI command to display */
@@ -22,9 +23,9 @@ const CodeBlock: React.FC<CodeBlockProps> = ({
     prerequisites.map(() => false),
   );
 
-  const copyToClipboard = async () => {
+  const copyCommand = async () => {
     try {
-      await navigator.clipboard.writeText(command);
+      await copyToClipboard(command);
     } catch {
       // Clipboard API not available or permission denied.
     }
@@ -45,7 +46,7 @@ const CodeBlock: React.FC<CodeBlockProps> = ({
           <code>{command}</code>
         </pre>
         <button
-          onClick={copyToClipboard}
+          onClick={copyCommand}
           aria-label="Copy command"
           style={{ position: 'absolute', top: 0, right: 0 }}
         >

--- a/src/components/TableBuilder.tsx
+++ b/src/components/TableBuilder.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
+import copyToClipboard from '../../lib/copyToClipboard';
 
 interface TableBuilderProps {
   paragraphs: string[];
@@ -44,14 +45,14 @@ const TableBuilder: React.FC<TableBuilderProps> = ({ paragraphs }) => {
     const csv = tableData
       .map((row) => row.map((c) => `"${c.replace(/"/g, '""')}"`).join(','))
       .join('\n');
-    await navigator.clipboard.writeText(csv);
+    await copyToClipboard(csv);
   };
 
   const copyMd = async () => {
     if (!tableData) return;
     const header = '| Column 1 | Column 2 |\n| --- | --- |\n';
     const body = tableData.map(([a, b]) => `| ${a} | ${b} |`).join('\n');
-    await navigator.clipboard.writeText(header + body);
+    await copyToClipboard(header + body);
   };
 
   const undo = () => {

--- a/src/playgrounds/crypto/script.js
+++ b/src/playgrounds/crypto/script.js
@@ -67,8 +67,26 @@ hashBtn.addEventListener('click', async () => {
   results.hidden = false;
 });
 
-function copyToClipboard(text) {
-  navigator.clipboard.writeText(text);
+async function copyToClipboard(text) {
+  try {
+    await navigator.clipboard.writeText(text);
+  } catch (err) {
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.setAttribute('readonly', '');
+    textarea.style.position = 'fixed';
+    textarea.style.top = '0';
+    textarea.style.left = '0';
+    textarea.style.opacity = '0';
+    document.body.appendChild(textarea);
+    textarea.focus();
+    textarea.select();
+    const successful = document.execCommand('copy');
+    document.body.removeChild(textarea);
+    if (!successful) {
+      throw err;
+    }
+  }
 }
 
 copySaltBtn.addEventListener('click', () => {

--- a/src/tools/CitationBuilder.ts
+++ b/src/tools/CitationBuilder.ts
@@ -1,3 +1,4 @@
+import copyToClipboard from "../../lib/copyToClipboard";
 export type CitationStyle = "MLA" | "APA";
 
 /**
@@ -86,7 +87,7 @@ export class CitationBuilder {
       await navigator.clipboard.write([item]);
     } catch {
       // Fallback for browsers without ClipboardItem support
-      await navigator.clipboard.writeText(citation);
+      await copyToClipboard(citation);
     }
   }
 }

--- a/src/tools/SecurityHeadersComposer.tsx
+++ b/src/tools/SecurityHeadersComposer.tsx
@@ -3,6 +3,7 @@ import CopyPresetSelect, {
   CopyPreset,
   formatForPreset,
 } from "../components/CopyPresetSelect";
+import copyToClipboard from "../../lib/copyToClipboard";
 
 interface Directive {
   /**
@@ -88,7 +89,7 @@ export default function SecurityHeadersComposer() {
       setTimeout(() => setCopied(false), 2000);
     } catch (e) {
       try {
-        await navigator.clipboard.writeText(text);
+        await copyToClipboard(text);
         setCopied(true);
         setTimeout(() => setCopied(false), 2000);
       } catch (err) {

--- a/tests/copy.spec.ts
+++ b/tests/copy.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from '@playwright/test';
+
+// Verifies fallback copy using document.execCommand works when writeText fails.
+test('copy fallback works', async ({ page }) => {
+  await page.goto('about:blank');
+  await page.evaluate(() => {
+    // Force writeText to fail
+    navigator.clipboard.writeText = () => Promise.reject(new Error('fail'));
+    // Capture copied text via overridden execCommand
+    (window as any).copied = '';
+    document.execCommand = (command: string) => {
+      if (command === 'copy') {
+        (window as any).copied = document.getSelection()?.toString() || '';
+        return true;
+      }
+      return false;
+    };
+  });
+  const text = 'hello world';
+  await page.evaluate(async (t) => {
+    async function copyToClipboard(value: string): Promise<void> {
+      try {
+        await navigator.clipboard.writeText(value);
+      } catch (err) {
+        const textarea = document.createElement('textarea');
+        textarea.value = value;
+        textarea.setAttribute('readonly', '');
+        textarea.style.position = 'fixed';
+        textarea.style.top = '0';
+        textarea.style.left = '0';
+        textarea.style.opacity = '0';
+        document.body.appendChild(textarea);
+        textarea.focus();
+        textarea.select();
+        const successful = document.execCommand('copy');
+        document.body.removeChild(textarea);
+        if (!successful) {
+          throw err;
+        }
+      }
+    }
+    await copyToClipboard(t);
+  }, text);
+  const copied = await page.evaluate(() => (window as any).copied);
+  expect(copied).toBe(text);
+});


### PR DESCRIPTION
## Summary
- add reusable `copyToClipboard` helper with `document.execCommand('copy')` fallback
- replace direct `navigator.clipboard.writeText` calls to use the new helper
- add Playwright test for clipboard fallback behaviour

## Testing
- `npm test`
- `npx playwright test tests/copy.spec.ts --browser=webkit` *(fails: missing host dependencies)*
- `npx playwright test tests/copy.spec.ts --browser=firefox` *(fails: missing host dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b76ed8ed688328b39a967ca13b7afc