### PR TITLE
Add legacy redirect mapping and tests

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,12 @@
 /** @type {import('next').NextConfig} */
 const cloudName = process.env.CLOUDINARY_CLOUD_NAME || "demo";
 
+const legacyRedirects = [
+  { source: "/term/:slug*", destination: "/:slug*", permanent: true },
+  { source: "/terms/:slug*", destination: "/:slug*", permanent: true },
+  { source: "/word/:slug*", destination: "/:slug*", permanent: false },
+];
+
 const nextConfig = {
   images: {
     loader: "cloudinary",
@@ -25,6 +31,9 @@ const nextConfig = {
         headers: [cspHeader]
       }
     ];
+  },
+  async redirects() {
+    return legacyRedirects;
   }
 };
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -17,6 +17,12 @@ const securityHeaders = [
   },
 ];
 
+const legacyRedirects = [
+  { source: "/term/:slug*", destination: "/:slug*", permanent: true },
+  { source: "/terms/:slug*", destination: "/:slug*", permanent: true },
+  { source: "/word/:slug*", destination: "/:slug*", permanent: false },
+];
+
 const nextConfig = {
   async headers() {
     return [
@@ -25,6 +31,9 @@ const nextConfig = {
         headers: securityHeaders,
       },
     ];
+  },
+  async redirects() {
+    return legacyRedirects;
   },
 };
 

--- a/tests/redirects.spec.ts
+++ b/tests/redirects.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from "@playwright/test";
+
+// Dynamically import the Next.js config to access redirects
+async function loadRedirects() {
+  const config = await import("../next.config.js");
+  return config.default?.redirects
+    ? config.default.redirects()
+    : config.redirects();
+}
+
+test("legacy slug redirects map to new paths", async () => {
+  const redirects = await loadRedirects();
+  const cases = [
+    { source: "/term/:slug*", destination: "/:slug*", status: 308 },
+    { source: "/terms/:slug*", destination: "/:slug*", status: 308 },
+    { source: "/word/:slug*", destination: "/:slug*", status: 307 },
+  ];
+
+  for (const c of cases) {
+    const match = redirects.find(
+      (r: any) => r.source === c.source && r.destination === c.destination
+    );
+    expect(match, `Missing redirect for ${c.source}`).toBeTruthy();
+    const expectedPermanent = c.status === 308;
+    expect(match.permanent).toBe(expectedPermanent);
+  }
+});


### PR DESCRIPTION
## Summary
- define legacy path redirects in Next.js config
- add Playwright tests ensuring old slugs map to canonical routes

## Testing
- `npm test`
- `npx playwright test tests/index.spec.ts tests/redirects.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b76ed2b5688328a01caf267fdbaebe