### PR TITLE
feat: add upload size validation

### DIFF
--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server';
+import { MAX_UPLOAD_SIZE } from '../../../src/utils/limits';
+
+export const config = {
+  api: {
+    bodyParser: {
+      sizeLimit: '10mb',
+    },
+  },
+};
+
+export async function POST(request: Request) {
+  const contentLength = request.headers.get('content-length');
+  const size = contentLength ? parseInt(contentLength, 10) : 0;
+  if (size > MAX_UPLOAD_SIZE) {
+    return NextResponse.json(
+      { error: `File is too large. Maximum size is ${Math.round(MAX_UPLOAD_SIZE / (1024 * 1024))} MB.` },
+      { status: 400 },
+    );
+  }
+
+  // For demonstration purposes, we simply consume the body to avoid 413 errors
+  try {
+    await request.arrayBuffer();
+  } catch (err) {
+    return NextResponse.json(
+      { error: 'Failed to read upload.' },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/assets/js/import.js
+++ b/assets/js/import.js
@@ -1,4 +1,5 @@
 const csvInput = document.getElementById("csvFile");
+const MAX_UPLOAD_SIZE = 5 * 1024 * 1024; // 5 MB limit
 const mappingDiv = document.getElementById("mapping");
 const previewDiv = document.getElementById("preview");
 const summaryDiv = document.getElementById("summary");
@@ -22,6 +23,11 @@ function slugify(text) {
 csvInput.addEventListener("change", (e) => {
   const file = e.target.files[0];
   if (!file) return;
+  if (file.size > MAX_UPLOAD_SIZE) {
+    alert(`File is too large. Maximum size is ${Math.round(MAX_UPLOAD_SIZE / (1024 * 1024))} MB.`);
+    e.target.value = "";
+    return;
+  }
   Papa.parse(file, {
     complete: (results) => {
       const isRowFilled = (row) => row.some((cell) => cell && cell.trim());

--- a/src/components/Upload.tsx
+++ b/src/components/Upload.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import React, { useState } from 'react';
+import { MAX_UPLOAD_SIZE } from '../utils/limits';
+
+const friendlySize = `${Math.round(MAX_UPLOAD_SIZE / (1024 * 1024))} MB`;
+
+/**
+ * Upload component with client-side size validation.
+ * Shows a friendly error message if the file exceeds the server limit.
+ */
+const Upload: React.FC = () => {
+  const [error, setError] = useState<string | null>(null);
+
+  const handleChange = async (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    if (file.size > MAX_UPLOAD_SIZE) {
+      setError(`File is too large. Maximum size is ${friendlySize}.`);
+      event.target.value = '';
+      return;
+    }
+
+    setError(null);
+
+    const formData = new FormData();
+    formData.append('file', file);
+
+    try {
+      const res = await fetch('/api/upload', {
+        method: 'POST',
+        body: formData,
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => null);
+        setError(data?.error || 'Upload failed.');
+      }
+    } catch (err) {
+      setError('Upload failed.');
+    }
+  };
+
+  return (
+    <div>
+      <input type="file" onChange={handleChange} />
+      {error && (
+        <p role="alert" style={{ color: 'red' }}>
+          {error}
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default Upload;

--- a/src/utils/limits.ts
+++ b/src/utils/limits.ts
@@ -1,0 +1,1 @@
+export const MAX_UPLOAD_SIZE = 5 * 1024 * 1024; // 5 MB


### PR DESCRIPTION
## Summary
- validate CSV import uploads against a 5 MB limit
- add reusable Upload component with client-side size checks
- handle oversized uploads server-side to avoid 413 responses

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b76ec3cc4c832896b01b15d0518da6