### PR TITLE
feat: add safe JSON parsing utility

### DIFF
--- a/SearchResultCard.tsx
+++ b/SearchResultCard.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { safeParse } from "./src/utils/safeJson";
 
 interface SearchResultCardProps {
   /** Term to display in the result */
@@ -19,8 +20,9 @@ export default function SearchResultCard({
   const [timer, setTimer] = useState<ReturnType<typeof setTimeout> | null>(null);
 
   const addToCollection = () => {
-    const collection: string[] = JSON.parse(
-      localStorage.getItem("collection") || "[]",
+    const collection: string[] = safeParse(
+      localStorage.getItem("collection"),
+      [],
     );
     if (!collection.includes(term)) {
       collection.push(term);
@@ -32,8 +34,9 @@ export default function SearchResultCard({
   };
 
   const undo = () => {
-    const collection: string[] = JSON.parse(
-      localStorage.getItem("collection") || "[]",
+    const collection: string[] = safeParse(
+      localStorage.getItem("collection"),
+      [],
     );
     const idx = collection.indexOf(term);
     if (idx !== -1) {

--- a/app/api/feedback/route.ts
+++ b/app/api/feedback/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import { safeParse } from '../../src/utils/safeJson';
 
 interface Feedback {
   message: string;
@@ -26,7 +27,7 @@ export async function POST(request: Request) {
     let feedback: Feedback[] = [];
     try {
       const existing = await fs.readFile(feedbackFile, 'utf8');
-      feedback = JSON.parse(existing);
+      feedback = safeParse<Feedback[]>(existing, []);
     } catch (err: any) {
       if (err.code !== 'ENOENT') {
         throw err;

--- a/app/api/terms/[term]/route.ts
+++ b/app/api/terms/[term]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { promises as fs } from "fs";
 import path from "path";
+import { safeParse } from "../../../../src/utils/safeJson";
 
 const dataFile = path.join(process.cwd(), "terms.json");
 
@@ -11,7 +12,7 @@ interface Term {
 
 async function readTerms(): Promise<Term[]> {
   const data = await fs.readFile(dataFile, "utf8");
-  const parsed = JSON.parse(data);
+  const parsed = safeParse<{ terms?: Term[] }>(data, { terms: [] });
   return parsed.terms || [];
 }
 

--- a/app/api/terms/route.ts
+++ b/app/api/terms/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { promises as fs } from "fs";
 import path from "path";
+import { safeParse } from "../../../src/utils/safeJson";
 
 const dataFile = path.join(process.cwd(), "terms.json");
 
@@ -11,7 +12,7 @@ interface Term {
 
 async function readTerms(): Promise<Term[]> {
   const data = await fs.readFile(dataFile, "utf8");
-  const parsed = JSON.parse(data);
+  const parsed = safeParse<{ terms?: Term[] }>(data, { terms: [] });
   return parsed.terms || [];
 }
 

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import PersonalTermsManager from "../../components/PersonalTermsManager";
+import { safeParse } from "../../src/utils/safeJson";
 
 export default function SettingsPage() {
   const [darkMode, setDarkMode] = useState(false);
@@ -12,18 +13,12 @@ export default function SettingsPage() {
 
   useEffect(() => {
     const saved = localStorage.getItem("settings");
-    if (saved) {
-      try {
-        const parsed = JSON.parse(saved);
-        setDarkMode(parsed.darkMode ?? false);
-        setFontSize(parsed.fontSize ?? "medium");
-        setDensity(parsed.density ?? "comfortable");
-        setPreferredSources(parsed.preferredSources ?? []);
-        setEnhancedHinting(parsed.enhancedHinting ?? true);
-      } catch {
-        // ignore parse errors
-      }
-    }
+    const parsed = safeParse<any>(saved, {});
+    setDarkMode(parsed.darkMode ?? false);
+    setFontSize(parsed.fontSize ?? "medium");
+    setDensity(parsed.density ?? "comfortable");
+    setPreferredSources(parsed.preferredSources ?? []);
+    setEnhancedHinting(parsed.enhancedHinting ?? true);
   }, []);
 
   useEffect(() => {

--- a/components/PersonalTermsManager.tsx
+++ b/components/PersonalTermsManager.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { safeParse } from "../src/utils/safeJson";
 
 interface PersonalTerm {
   slug: string;
@@ -26,12 +27,8 @@ export default function PersonalTermsManager() {
 
   // Load stored personal terms on first render
   useEffect(() => {
-    try {
-      const raw = localStorage.getItem("personalTerms");
-      if (raw) setTerms(JSON.parse(raw));
-    } catch {
-      // ignore invalid data
-    }
+    const raw = localStorage.getItem("personalTerms");
+    setTerms(safeParse<PersonalTerm[]>(raw, []));
   }, []);
 
   // Helper to persist changes
@@ -57,7 +54,7 @@ export default function PersonalTermsManager() {
     if (!file) return;
     try {
       const text = await file.text();
-      const incoming = JSON.parse(text) as PersonalTerm[];
+      const incoming = safeParse<PersonalTerm[]>(text, []);
       const map = new Map(terms.map((t) => [t.slug, t]));
       const duplicates: ImportPreview["duplicates"] = [];
       const newTerms: PersonalTerm[] = [];

--- a/components/RecentMenu.tsx
+++ b/components/RecentMenu.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { usePathname, useRouter } from "next/navigation";
+import { safeParse } from "../src/utils/safeJson";
 
 interface RecentItem {
   term: string;
@@ -11,18 +12,9 @@ interface RecentItem {
 const STORAGE_KEY = "recentTerms";
 
 function loadFromStorage(): RecentItem[] {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (raw) {
-      const parsed = JSON.parse(raw);
-      if (Array.isArray(parsed)) {
-        return parsed;
-      }
-    }
-  } catch {
-    /* ignore */
-  }
-  return [];
+  const raw = localStorage.getItem(STORAGE_KEY);
+  const parsed = safeParse<unknown>(raw, []);
+  return Array.isArray(parsed) ? (parsed as RecentItem[]) : [];
 }
 
 export default function RecentMenu() {

--- a/components/ShortcutManager.tsx
+++ b/components/ShortcutManager.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { safeParse } from "../src/utils/safeJson";
 
 interface ShortcutManagerProps {
   /** The term this manager controls a shortcut for */
@@ -14,12 +15,8 @@ interface TermHotkeys {
 const STORAGE_KEY = "term-hotkeys";
 
 function loadHotkeys(): TermHotkeys {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    return raw ? (JSON.parse(raw) as TermHotkeys) : {};
-  } catch {
-    return {};
-  }
+  const raw = localStorage.getItem(STORAGE_KEY);
+  return safeParse<TermHotkeys>(raw, {});
 }
 
 function saveHotkeys(hotkeys: TermHotkeys) {

--- a/components/SideDrawer.tsx
+++ b/components/SideDrawer.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { safeParse } from "../src/utils/safeJson";
 
 interface SideDrawerProps {
   /** Word currently selected; when null the drawer is hidden */
@@ -43,16 +44,12 @@ const SideDrawer: React.FC<SideDrawerProps> = ({ word, onClose }) => {
       } catch {
         if (!cancelled) {
           const cached = localStorage.getItem(storageKey);
-          if (cached) {
-            try {
-              const data = JSON.parse(cached);
-              setDefinition(
-                data.summary || data.definition || "No definition available.",
-              );
-              return;
-            } catch {
-              /* ignore parse errors */
-            }
+          const data = safeParse<any>(cached, null);
+          if (data) {
+            setDefinition(
+              data.summary || data.definition || "No definition available.",
+            );
+            return;
           }
           setDefinition("Failed to fetch definition.");
         }

--- a/components/WordOfDay.tsx
+++ b/components/WordOfDay.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { safeParse } from "../src/utils/safeJson";
 
 interface Entry {
   id: string;
@@ -30,13 +31,10 @@ const WordOfDay: React.FC = () => {
     } catch (err) {
       console.error(err);
       const cached = localStorage.getItem(storageKey);
-      if (cached) {
-        try {
-          setEntry(JSON.parse(cached));
-          return;
-        } catch {
-          /* ignore parse errors */
-        }
+      const parsed = safeParse<Entry | null>(cached, null);
+      if (parsed) {
+        setEntry(parsed);
+        return;
       }
       setEntry(null);
     }
@@ -51,8 +49,9 @@ const WordOfDay: React.FC = () => {
 
   const handleSave = () => {
     if (!entry) return;
-    const saved: Entry[] = JSON.parse(
-      localStorage.getItem("savedWords") || "[]",
+    const saved: Entry[] = safeParse(
+      localStorage.getItem("savedWords"),
+      [],
     );
     if (!saved.find((e) => e.id === entry.id)) {
       saved.push(entry);

--- a/components/term/FavoriteButton.tsx
+++ b/components/term/FavoriteButton.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { safeParse } from "../../src/utils/safeJson";
 
 interface FavoriteButtonProps {
   term: string;
@@ -27,8 +28,9 @@ export default function FavoriteButton({ term }: FavoriteButtonProps) {
   };
 
   const addToFavorites = () => {
-    const favorites: string[] = JSON.parse(
-      localStorage.getItem("favorites") || "[]",
+    const favorites: string[] = safeParse(
+      localStorage.getItem("favorites"),
+      [],
     );
     if (!favorites.includes(term)) {
       favorites.push(term);

--- a/hooks/useFontHinting.ts
+++ b/hooks/useFontHinting.ts
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import { safeParse } from "../src/utils/safeJson";
 
 function detectOS(): "mac" | "windows" | "linux" | "other" {
   const ua = navigator.userAgent.toLowerCase();
@@ -25,14 +26,10 @@ export function useFontHinting() {
   useEffect(() => {
     const apply = () => {
       let features = "";
-      try {
-        const raw = localStorage.getItem("settings");
-        const disabled = raw && JSON.parse(raw).enhancedHinting === false;
-        if (!disabled) {
-          features = featureSettings(detectOS());
-        }
-      } catch {
-        /* ignore */
+      const raw = localStorage.getItem("settings");
+      const settings = safeParse<any>(raw, {});
+      if (settings.enhancedHinting !== false) {
+        features = featureSettings(detectOS());
       }
       document.documentElement.style.fontFeatureSettings = features;
     };

--- a/hooks/useSearchHistory.ts
+++ b/hooks/useSearchHistory.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { safeParse } from "../src/utils/safeJson";
 
 const STORAGE_KEY = "searchHistory";
 
@@ -11,16 +12,10 @@ export function useSearchHistory(authenticated: boolean = false) {
 
   // Load from localStorage on first mount
   useEffect(() => {
-    try {
-      const raw = localStorage.getItem(STORAGE_KEY);
-      if (raw) {
-        const parsed = JSON.parse(raw);
-        if (Array.isArray(parsed)) {
-          setHistory(parsed);
-        }
-      }
-    } catch {
-      /* ignore */
+    const raw = localStorage.getItem(STORAGE_KEY);
+    const parsed = safeParse<unknown>(raw, []);
+    if (Array.isArray(parsed)) {
+      setHistory(parsed as string[]);
     }
   }, []);
 

--- a/lib/search/runtime.ts
+++ b/lib/search/runtime.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from "fs";
 import path from "path";
+import { safeParse } from "../../src/utils/safeJson";
 
 interface TermEntry {
   term?: string;
@@ -15,7 +16,7 @@ function loadIndex(): TermEntry[] {
   if (!cache) {
     const indexPath = path.resolve(__dirname, "../../index.json");
     const raw = readFileSync(indexPath, "utf8");
-    const data = JSON.parse(raw);
+    const data = safeParse<any>(raw, []);
     cache = Array.isArray(data) ? data : data.terms || [];
   }
   return cache;

--- a/lib/settings.ts
+++ b/lib/settings.ts
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
 import useBatterySaver from '../hooks/useBatterySaver';
+import { safeParse } from '../src/utils/safeJson';
 
 export type Settings = {
   darkMode: boolean;
@@ -45,12 +46,10 @@ const SettingsContext = createContext<SettingsContextValue>({
 function useLocalStorageSettings(): [Settings, React.Dispatch<React.SetStateAction<Settings>>] {
   const [settings, setSettings] = useState<Settings>(() => {
     if (typeof window === 'undefined') return defaultSettings;
-    try {
-      const raw = localStorage.getItem('settings');
-      return raw ? { ...defaultSettings, ...JSON.parse(raw) } : defaultSettings;
-    } catch {
-      return defaultSettings;
-    }
+    const raw = localStorage.getItem('settings');
+    return raw
+      ? { ...defaultSettings, ...safeParse<Partial<Settings>>(raw, {}) }
+      : defaultSettings;
   });
 
   useEffect(() => {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,6 +1,7 @@
 import { GetStaticProps } from 'next';
 import path from 'path';
 import { promises as fs } from 'fs';
+import { safeParse } from '../src/utils/safeJson';
 
 interface Term {
   term: string;
@@ -27,7 +28,7 @@ export default function HomePage({ terms }: HomePageProps) {
 export const getStaticProps: GetStaticProps<HomePageProps> = async () => {
   const filePath = path.join(process.cwd(), 'terms.json');
   const json = await fs.readFile(filePath, 'utf-8');
-  const data = JSON.parse(json);
+  const data = safeParse<{ terms?: Term[] }>(json, { terms: [] });
   const terms: Term[] = data.terms || [];
   return {
     props: {

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,9 +1,11 @@
 const fs = require('fs');
 const path = require('path');
+const { safeParse } = require('../src/utils/safeJson.js');
 
 // Paths are resolved relative to the repository root
 const dataPath = path.join(__dirname, '..', 'terms.json');
-const data = JSON.parse(fs.readFileSync(dataPath, 'utf8'));
+const raw = fs.readFileSync(dataPath, 'utf8');
+const data = safeParse(raw, { terms: [] });
 
 const termsDir = path.join(__dirname, '..', 'terms');
 fs.mkdirSync(termsDir, { recursive: true });

--- a/src/components/ClipboardHistory.tsx
+++ b/src/components/ClipboardHistory.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useEffect, useState } from 'react';
+import { safeParse } from '../utils/safeJson';
 
 interface HistoryItem {
   text: string;
@@ -25,13 +26,7 @@ const ClipboardHistory: React.FC = () => {
   // Load existing history on mount
   useEffect(() => {
     const stored = localStorage.getItem(STORAGE_KEY);
-    if (stored) {
-      try {
-        setHistory(JSON.parse(stored));
-      } catch {
-        /* ignore malformed storage */
-      }
-    }
+    setHistory(safeParse<HistoryItem[]>(stored, []));
   }, []);
 
   const addItem = React.useCallback((text: string) => {

--- a/src/components/ClipboardPreview.tsx
+++ b/src/components/ClipboardPreview.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useState } from 'react';
 import termsData from '../../terms.json';
+import { safeParse } from '../utils/safeJson';
 
 interface Term {
   term: string;
@@ -31,8 +32,9 @@ const ClipboardPreview: React.FC = () => {
         );
         if (!match) return;
 
-        const shown: string[] = JSON.parse(
-          sessionStorage.getItem(STORAGE_KEY) || '[]',
+        const shown: string[] = safeParse(
+          sessionStorage.getItem(STORAGE_KEY),
+          [],
         );
         if (shown.includes(match.term)) return;
 

--- a/src/components/StandardsTable.tsx
+++ b/src/components/StandardsTable.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { safeParse } from '../utils/safeJson';
 
 interface Column<T> {
   key: keyof T;
@@ -44,22 +45,16 @@ export function StandardsTable<T extends Record<string, any>>({
   // Load preferences on mount
   useEffect(() => {
     if (typeof window === 'undefined') return;
-    try {
-      const saved = window.localStorage.getItem(storageKey);
-      if (saved) {
-        const parsed = JSON.parse(saved);
-        if (Array.isArray(parsed.visibleColumns)) {
-          const valid = parsed.visibleColumns.filter((k: keyof T) =>
-            columnKeys.includes(k)
-          );
-          if (valid.length) setVisibleColumns(valid);
-        }
-        if (parsed.sortConfig && columnKeys.includes(parsed.sortConfig.key)) {
-          setSortConfig(parsed.sortConfig);
-        }
-      }
-    } catch {
-      // ignore malformed data
+    const saved = window.localStorage.getItem(storageKey);
+    const parsed = safeParse<any>(saved, {});
+    if (Array.isArray(parsed.visibleColumns)) {
+      const valid = parsed.visibleColumns.filter((k: keyof T) =>
+        columnKeys.includes(k)
+      );
+      if (valid.length) setVisibleColumns(valid);
+    }
+    if (parsed.sortConfig && columnKeys.includes(parsed.sortConfig.key)) {
+      setSortConfig(parsed.sortConfig);
     }
   }, [storageKey, columnKeys]);
 

--- a/src/features/history/UndoManager.ts
+++ b/src/features/history/UndoManager.ts
@@ -6,6 +6,8 @@ export type State = unknown;
 
 type ApplyFn<T> = (id: string, state: T) => void;
 
+import { safeParse } from '../../utils/safeJson';
+
 export class UndoManager<T = State> {
   private states: Map<string, T> = new Map();
   private order: string[] = [];
@@ -21,7 +23,7 @@ export class UndoManager<T = State> {
   private clone(state: T): T {
     return typeof structuredClone === "function"
       ? structuredClone(state)
-      : JSON.parse(JSON.stringify(state));
+      : safeParse(JSON.stringify(state), state);
   }
 
   private onKeyDown(e: KeyboardEvent) {

--- a/src/features/notes/Encryption.ts
+++ b/src/features/notes/Encryption.ts
@@ -1,3 +1,5 @@
+import { safeParse } from '../../utils/safeJson';
+
 // Utilities for encoding/decoding text when working with the Web Crypto API.
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
@@ -91,7 +93,8 @@ export async function loadEncryptedNote(id: string): Promise<string | null> {
   }
 
   try {
-    const payload: EncryptedPayload = JSON.parse(stored);
+    const payload = safeParse<EncryptedPayload | null>(stored, null);
+    if (!payload) throw new Error('Invalid payload');
     const passphrase = await promptPassphrase(
       "Enter passphrase to decrypt note",
     );

--- a/src/features/onboarding/Checklist.tsx
+++ b/src/features/onboarding/Checklist.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { safeParse } from '../../utils/safeJson';
 
 /** Structure of a checklist task. If `event` is provided the checklist
  * will listen for that custom event on the window object and
@@ -35,15 +36,8 @@ interface Props {
 const Checklist: React.FC<Props> = ({ tasks = DEFAULT_TASKS }) => {
   // Load completion information from localStorage on first render
   const [completed, setCompleted] = useState<Record<string, boolean>>(() => {
-    try {
-      const raw = localStorage.getItem(STORAGE_KEY);
-      if (raw) {
-        return JSON.parse(raw);
-      }
-    } catch {
-      // ignore parsing/storage issues
-    }
-    return {};
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return safeParse<Record<string, boolean>>(raw, {});
   });
 
   // Persist completion state whenever it changes

--- a/src/features/selection/SelectionContext.tsx
+++ b/src/features/selection/SelectionContext.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, useEffect, useRef, useState } from 'react';
+import { safeParse } from '../../utils/safeJson';
 
 type SelectionEntry = { id: string; timestamp: number };
 
@@ -16,18 +17,16 @@ const STORAGE_KEY = 'selection';
 const EXPIRY_MS = 5 * 60 * 1000; // 5 minutes
 
 function loadFromStorage(): SelectionEntry[] {
-  try {
-    const raw = sessionStorage.getItem(STORAGE_KEY);
-    if (!raw) return [];
-    const data = JSON.parse(raw);
-    if (data.expires && Date.now() > data.expires) {
-      sessionStorage.removeItem(STORAGE_KEY);
-      return [];
-    }
-    return data.items ?? [];
-  } catch {
+  const raw = sessionStorage.getItem(STORAGE_KEY);
+  const data = safeParse<{ items?: SelectionEntry[]; expires?: number }>(raw, {
+    items: [],
+    expires: 0,
+  });
+  if (data.expires && Date.now() > data.expires) {
+    sessionStorage.removeItem(STORAGE_KEY);
     return [];
   }
+  return data.items ?? [];
 }
 
 export const SelectionProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {

--- a/src/hooks/useSearchHistory.ts
+++ b/src/hooks/useSearchHistory.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
+import { safeParse } from "../utils/safeJson";
 
 export interface SearchEntry {
   query: string;
@@ -11,19 +12,16 @@ const LIMIT = 20;
 
 function load(): SearchEntry[] {
   if (typeof window === "undefined") return [];
-  try {
-    const raw = window.localStorage.getItem(STORAGE_KEY);
-    if (!raw) return [];
-    const parsed = JSON.parse(raw);
-    if (Array.isArray(parsed)) {
-      return parsed.filter((e) => typeof e.query === "string").map((e) => ({
+  const raw = window.localStorage.getItem(STORAGE_KEY);
+  const parsed = safeParse<unknown>(raw, []);
+  if (Array.isArray(parsed)) {
+    return parsed
+      .filter((e: any) => typeof e.query === "string")
+      .map((e: any) => ({
         query: e.query,
         timestamp: typeof e.timestamp === "number" ? e.timestamp : Date.now(),
         pinned: !!e.pinned,
       }));
-    }
-  } catch {
-    /* ignore */
   }
   return [];
 }

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -1,4 +1,5 @@
 import { useState, useCallback } from "react";
+import { safeParse } from "../utils/safeJson";
 
 export type SettingKey = "darkMode" | "showFavorites";
 
@@ -19,14 +20,10 @@ export function useSettings() {
     if (typeof window === "undefined") {
       return DEFAULT_SETTINGS;
     }
-    try {
-      const raw = window.localStorage.getItem(STORAGE_KEY);
-      return raw
-        ? { ...DEFAULT_SETTINGS, ...JSON.parse(raw) }
-        : DEFAULT_SETTINGS;
-    } catch {
-      return DEFAULT_SETTINGS;
-    }
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    return raw
+      ? { ...DEFAULT_SETTINGS, ...safeParse<Partial<Settings>>(raw, {}) }
+      : DEFAULT_SETTINGS;
   });
 
   const updateSetting = useCallback(

--- a/src/layout/WorkbenchLayout.tsx
+++ b/src/layout/WorkbenchLayout.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
+import { safeParse } from "../utils/safeJson";
 
 /**
  * WorkbenchLayout provides a simple two-pane workbench with a resizable divider.
@@ -25,12 +26,7 @@ const WorkbenchLayout: React.FC<WorkbenchLayoutProps> = ({ left, right }) => {
   // Load presets from localStorage on mount
   useEffect(() => {
     const raw = localStorage.getItem(LOCAL_STORAGE_KEY);
-    if (!raw) return;
-    try {
-      setPresets(JSON.parse(raw));
-    } catch {
-      // ignore parse errors
-    }
+    setPresets(safeParse<Record<string, number>>(raw, {}));
   }, []);
 
   // Persist presets on change

--- a/src/utils/exportImport.ts
+++ b/src/utils/exportImport.ts
@@ -1,3 +1,5 @@
+import { safeParse } from './safeJson';
+
 export interface BackupData {
   settings: Record<string, string>;
   notes: Record<string, string>;
@@ -36,5 +38,5 @@ export function importData(data: BackupData): void {
 }
 
 export function parseBackup(json: string): BackupData {
-  return JSON.parse(json) as BackupData;
+  return safeParse<BackupData>(json, { settings: {}, notes: {} });
 }

--- a/src/utils/safeJson.js
+++ b/src/utils/safeJson.js
@@ -1,0 +1,17 @@
+function safeParse(raw, fallback, onError) {
+  if (raw === null || raw === undefined) {
+    return fallback;
+  }
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    if (typeof onError === 'function') {
+      onError(error);
+    } else {
+      console.warn('Failed to parse JSON', error);
+    }
+    return fallback;
+  }
+}
+
+module.exports = { safeParse };

--- a/src/utils/safeJson.ts
+++ b/src/utils/safeJson.ts
@@ -1,0 +1,15 @@
+export function safeParse<T>(raw: string | null, fallback: T, onError?: (error: unknown) => void): T {
+  if (raw === null || raw === undefined) {
+    return fallback;
+  }
+  try {
+    return JSON.parse(raw) as T;
+  } catch (error) {
+    if (onError) {
+      onError(error);
+    } else {
+      console.warn('Failed to parse JSON', error);
+    }
+    return fallback;
+  }
+}


### PR DESCRIPTION
## Summary
- add `safeParse` helper to wrap JSON.parse with try/catch and fallback
- replace direct JSON.parse calls across app with safeParse for resilience
- handle parsing failures gracefully with defaults

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b76ecc19fc83289552ede6e2400911