### PR TITLE
feat: restore scroll position between routes

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import Navbar from "../components/Navbar";
 import MobileTocButton from "../components/MobileTocButton";
 import { Inter } from "next/font/google";
 import useFontHinting from "../hooks/useFontHinting";
+import useScrollRestoration from "../src/hooks/useScrollRestoration";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -15,6 +16,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   useFontHinting();
+  useScrollRestoration();
   return (
     <html lang="en" className={inter.className}>
       <body>

--- a/src/hooks/useScrollRestoration.ts
+++ b/src/hooks/useScrollRestoration.ts
@@ -1,0 +1,53 @@
+import { useEffect, useRef } from "react";
+import { usePathname } from "next/navigation";
+
+const STORAGE_KEY = "scroll-positions";
+
+function readPositions(): Record<string, number> {
+  if (typeof window === "undefined") return {};
+  try {
+    const raw = window.sessionStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : {};
+  } catch {
+    return {};
+  }
+}
+
+function writePositions(pos: Record<string, number>) {
+  try {
+    window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify(pos));
+  } catch {
+    /* ignore */
+  }
+}
+
+/**
+ * Persists scroll positions per route and restores them on navigation.
+ * Useful when custom transitions or manual router usage disable the
+ * browser's default scroll restoration.
+ */
+export function useScrollRestoration() {
+  const pathname = usePathname();
+  const positions = useRef<Record<string, number>>(readPositions());
+
+  useEffect(() => {
+    const stored = positions.current[pathname];
+    if (typeof stored === "number") {
+      window.scrollTo(0, stored);
+    }
+
+    const save = () => {
+      positions.current[pathname] = window.scrollY;
+      writePositions(positions.current);
+    };
+
+    window.addEventListener("beforeunload", save);
+    return () => {
+      save();
+      window.removeEventListener("beforeunload", save);
+    };
+  }, [pathname]);
+}
+
+export default useScrollRestoration;
+


### PR DESCRIPTION
## Summary
- add `useScrollRestoration` hook to persist scroll per route
- wire hook into root layout so navigation keeps position

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b76ec1a06c832882ab770dc82d4644