### PR TITLE
Add environment-based logger and remove console.log usage

### DIFF
--- a/app/api/socket/route.ts
+++ b/app/api/socket/route.ts
@@ -1,4 +1,5 @@
 import { Server } from "socket.io";
+import logger from "../../../src/utils/logger";
 
 let io: Server | undefined;
 
@@ -7,7 +8,7 @@ export async function GET() {
   if (!io) {
     io = new Server({ path: "/api/socket" });
     io.on("connection", (socket) => {
-      console.log("Client connected", socket.id);
+      logger.info("Client connected", socket.id);
     });
   }
 

--- a/assets/js/preconnect.js
+++ b/assets/js/preconnect.js
@@ -1,4 +1,5 @@
 (function () {
+  const logger = (typeof window !== "undefined" && window.logger) || console;
   const STORAGE_KEY = "host-usage";
   const MAX_PRECONNECTS = 5;
 
@@ -37,7 +38,7 @@
       link.crossOrigin = "";
       document.head.appendChild(link);
       preconnected.push(host);
-      console.log("preconnecting to", host);
+      logger.debug("preconnecting to", host);
     });
     return preconnected;
   }
@@ -76,7 +77,7 @@
     const totalPreconnects = totals.wins + totals.losses;
     if (totalPreconnects > 0) {
       const efficiency = (totals.wins / totalPreconnects).toFixed(2);
-      console.log(
+      logger.info(
         `Preconnect efficiency: ${efficiency} (wins: ${totals.wins}, losses: ${totals.losses})`,
       );
     }

--- a/diagnostics.html
+++ b/diagnostics.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Diagnostics</title>
+  <script src="src/utils/logger.js"></script>
   <script src="assets/js/preconnect.js"></script>
   <link rel="stylesheet" href="styles.css">
 </head>

--- a/diagnostics.test.js
+++ b/diagnostics.test.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const { JSDOM } = require('jsdom');
+const logger = require('./src/utils/logger');
 
 const html = fs.readFileSync('diagnostics.html', 'utf8');
 const dom = new JSDOM(html, { runScripts: 'dangerously', url: 'https://example.com' });
@@ -35,4 +36,4 @@ if (hiddenRows.length !== 2) {
   process.exit(1);
 }
 
-console.log('Diagnostics render test passed');
+logger.info('Diagnostics render test passed');

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Cyber Security Dictionary</title>
+  <script src="src/utils/logger.js"></script>
   <script src="assets/js/preconnect.js"></script>
   <link rel="stylesheet" href="styles.css">
   <link rel="stylesheet" href="src/styles/print.css" media="print">

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,11 +1,12 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
+import logger from './src/utils/logger';
 
 // Define the allowed origin for CORS
 const allowedOrigin = process.env.ALLOWED_ORIGIN || 'https://alex-unnippillil.github.io';
 
 export function middleware(request: NextRequest) {
-  console.log(`Incoming request: ${request.method} ${request.url}`);
+  logger.info(`Incoming request: ${request.method} ${request.url}`);
   const { pathname } = request.nextUrl;
   const origin = request.headers.get('origin');
 

--- a/search.html
+++ b/search.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Search</title>
+  <script src="src/utils/logger.js"></script>
   <script src="assets/js/preconnect.js"></script>
   <link rel="stylesheet" href="styles.css">
 </head>

--- a/server.js
+++ b/server.js
@@ -1,6 +1,7 @@
 const http = require('http');
 const path = require('path');
 const fs = require('fs');
+const logger = require('./src/utils/logger');
 
 // In-memory token buckets keyed by IP
 const buckets = new Map();
@@ -23,7 +24,7 @@ function rateLimit(req, res) {
   }
 
   if (bucket.tokens < 1) {
-    console.log(`Rate limit exceeded for IP ${ip}`);
+    logger.warn(`Rate limit exceeded for IP ${ip}`);
     res.writeHead(429, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify({ error: 'Too Many Requests' }));
     return false;
@@ -55,5 +56,5 @@ const server = http.createServer((req, res) => {
 
 const PORT = process.env.PORT || 3000;
 server.listen(PORT, () => {
-  console.log(`Server running on port ${PORT}`);
+  logger.info(`Server running on port ${PORT}`);
 });

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,0 +1,37 @@
+// Basic logger with environment-based log levels
+// Suppresses debug and info in production
+
+const levels = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3,
+};
+
+const env =
+  (typeof process !== 'undefined' && process.env && process.env.NODE_ENV) ||
+  'development';
+const currentLevel = env === 'production' ? levels.warn : levels.debug;
+
+function log(level, ...args) {
+  if (levels[level] < currentLevel) return;
+  const method = level === 'debug' ? 'log' : level;
+  if (typeof console !== 'undefined' && console[method]) {
+    console[method](...args);
+  }
+}
+
+const logger = {
+  debug: (...args) => log('debug', ...args),
+  info: (...args) => log('info', ...args),
+  warn: (...args) => log('warn', ...args),
+  error: (...args) => log('error', ...args),
+};
+
+if (typeof window !== 'undefined') {
+  window.logger = logger;
+} else if (typeof global !== 'undefined') {
+  global.logger = logger;
+}
+
+module.exports = logger;

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,49 @@
+// Basic logger with environment-based log levels
+// Suppresses debug and info in production
+
+type Level = 'debug' | 'info' | 'warn' | 'error';
+
+const levels: Record<Level, number> = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3,
+};
+
+const env =
+  (typeof process !== 'undefined' && process.env && process.env.NODE_ENV) ||
+  'development';
+const currentLevel = env === 'production' ? levels.warn : levels.debug;
+
+function log(level: Level, ...args: unknown[]): void {
+  if (levels[level] < currentLevel) return;
+  const method = level === 'debug' ? 'log' : level;
+  if (typeof console !== 'undefined' && (console as any)[method]) {
+    (console as any)[method](...args);
+  }
+}
+
+const logger = {
+  debug: (...args: unknown[]) => log('debug', ...args),
+  info: (...args: unknown[]) => log('info', ...args),
+  warn: (...args: unknown[]) => log('warn', ...args),
+  error: (...args: unknown[]) => log('error', ...args),
+};
+
+export default logger;
+
+// Attach to global scope for non-module scripts
+declare global {
+  // eslint-disable-next-line no-unused-vars
+  interface Window {
+    logger: typeof logger;
+  }
+}
+
+if (typeof window !== 'undefined') {
+  window.logger = logger;
+} else if (typeof global !== 'undefined') {
+  (global as any).logger = logger;
+}
+
+export { logger };

--- a/tests/useCopyFormats.test.js
+++ b/tests/useCopyFormats.test.js
@@ -1,5 +1,6 @@
 require("ts-node/register");
 const assert = require("assert").strict;
+const logger = require("../src/utils/logger");
 const useCopyFormats =
   require("../src/features/selection/useCopyFormats").default;
 
@@ -23,4 +24,4 @@ assert.equal(
   '<blockquote>Example text</blockquote><p><a href="https://example.com/page#heading">Heading</a></p>',
 );
 
-console.log("useCopyFormats tests passed");
+logger.info("useCopyFormats tests passed");


### PR DESCRIPTION
## Summary
- add reusable logger utility with environment-driven levels
- replace `console.log` calls with logger across server, middleware, tests, and client script
- expose logger globally for browser scripts and load it in HTML

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b76ec20588832897019f23626ff2a0