### PR TITLE
Integrate React Hook Form and Zod for personal term form

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,17 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@hookform/resolvers": "^3.10.0",
         "framer-motion": "^12.23.12",
         "hammerjs": "^2.0.8",
         "idb": "^7.1.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-hook-form": "^7.62.0",
         "react-joyride": "^2.9.3",
         "socket.io": "^4.8.1",
-        "socket.io-client": "^4.8.1"
+        "socket.io-client": "^4.8.1",
+        "zod": "^4.1.5"
       },
       "devDependencies": {
         "@playwright/test": "^1.55.0",
@@ -184,6 +187,15 @@
       "resolved": "https://registry.npmjs.org/@gilbarbara/deep-equal/-/deep-equal-0.3.1.tgz",
       "integrity": "sha512-I7xWjLs2YSVMc5gGx1Z3ZG1lgFpITPndpi8Ku55GeEIKpACCPQNS/OTqQbxgTCfq0Ncvcc+CrFov96itVh6Qvw==",
       "license": "MIT"
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.10.0.tgz",
+      "integrity": "sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react-hook-form": "^7.0.0"
+      }
     },
     "node_modules/@html-validate/stylish": {
       "version": "4.3.0",
@@ -2300,6 +2312,22 @@
         "is-lite": "^0.8.2"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.62.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.62.0.tgz",
+      "integrity": "sha512-7KWFejc98xqG/F4bAxpL41NB3o1nnvQO1RWZT3TqRZYL8RryQETGfEdVnJN2fy1crCiBLLjkRBVK05j24FxJGA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-innertext": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/react-innertext/-/react-innertext-1.1.5.tgz",
@@ -3367,6 +3395,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.5.tgz",
+      "integrity": "sha512-rcUUZqlLJgBC33IT3PNMgsCq6TzLQEG/Ei/KTCU0PedSWRMAXoOUN+4t/0H+Q8bdnLPdqUYnvboJT0bn/229qg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -21,13 +21,16 @@
     "typescript": "^5.9.2"
   },
   "dependencies": {
+    "@hookform/resolvers": "^3.10.0",
     "framer-motion": "^12.23.12",
     "hammerjs": "^2.0.8",
     "idb": "^7.1.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-hook-form": "^7.62.0",
     "react-joyride": "^2.9.3",
     "socket.io": "^4.8.1",
-    "socket.io-client": "^4.8.1"
+    "socket.io-client": "^4.8.1",
+    "zod": "^4.1.5"
   }
 }


### PR DESCRIPTION
## Summary
- add react-hook-form, zod, and @hookform/resolvers
- refactor PersonalTermForm to use RHF with Zod schema validation and inline errors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b76ebef9d483289dba09bb424eb716