### PR TITLE
Guard useEffect side effects

### DIFF
--- a/app/admin/AdminPanel.tsx
+++ b/app/admin/AdminPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 interface Term {
   term: string;
@@ -14,7 +14,10 @@ export default function AdminPanel() {
   const [editing, setEditing] = useState<string | null>(null);
   const [editingDefinition, setEditingDefinition] = useState("");
 
+  const hasFetchedRef = useRef(false);
   useEffect(() => {
+    if (hasFetchedRef.current) return;
+    hasFetchedRef.current = true;
     fetchTerms();
   }, []);
 

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Head from 'next/head';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import { searchPersonalTerms, PersonalTerm } from '../../lib/personalTerms';
@@ -23,8 +23,10 @@ export default function SearchPage() {
   const [data, setData] = useState<SearchResponse | null>(null);
   const [personal, setPersonal] = useState<PersonalTerm[]>([]);
 
+  const prevQueryRef = useRef<string | null>(null);
   useEffect(() => {
-    if (!query) return;
+    if (!query || prevQueryRef.current === query) return;
+    prevQueryRef.current = query;
     fetch(`/api/search?q=${encodeURIComponent(query)}`)
       .then((res) => res.json())
       .then(setData)

--- a/components/FrequencyMeter.tsx
+++ b/components/FrequencyMeter.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { ResponsiveContainer, LineChart, Line } from "recharts";
 
 interface FrequencyMeterProps {
@@ -8,7 +8,10 @@ interface FrequencyMeterProps {
 const FrequencyMeter: React.FC<FrequencyMeterProps> = ({ term }) => {
   const [data, setData] = useState<number[]>([]);
 
+  const prevTermRef = useRef<string | null>(null);
   useEffect(() => {
+    if (prevTermRef.current === term) return;
+    prevTermRef.current = term;
     async function fetchFrequency() {
       try {
         const response = await fetch(

--- a/components/WordOfDay.tsx
+++ b/components/WordOfDay.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 
 interface Entry {
   id: string;
@@ -42,7 +42,10 @@ const WordOfDay: React.FC = () => {
     }
   };
 
+  const prevOffsetRef = useRef<number | null>(null);
   useEffect(() => {
+    if (prevOffsetRef.current === offset) return;
+    prevOffsetRef.current = offset;
     fetchEntry(offset);
   }, [offset]);
 

--- a/components/search/RandomTerm.tsx
+++ b/components/search/RandomTerm.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 type Term = {
   term?: string;
@@ -11,7 +11,10 @@ type Term = {
 const RandomTerm: React.FC = () => {
   const [terms, setTerms] = useState<Term[]>([]);
 
+  const hasFetchedRef = useRef(false);
   useEffect(() => {
+    if (hasFetchedRef.current) return;
+    hasFetchedRef.current = true;
     fetch('/terms.json')
       .then(res => res.json())
       .then(data => {

--- a/hooks/useSearchHistory.ts
+++ b/hooks/useSearchHistory.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 const STORAGE_KEY = "searchHistory";
 
@@ -8,6 +8,7 @@ function unique(arr: string[]): string[] {
 
 export function useSearchHistory(authenticated: boolean = false) {
   const [history, setHistory] = useState<string[]>([]);
+  const hasFetchedRef = useRef(false);
 
   // Load from localStorage on first mount
   useEffect(() => {
@@ -26,7 +27,8 @@ export function useSearchHistory(authenticated: boolean = false) {
 
   // If authenticated, merge server history
   useEffect(() => {
-    if (!authenticated) return;
+    if (!authenticated || hasFetchedRef.current) return;
+    hasFetchedRef.current = true;
     fetch("/api/history")
       .then((res) => (res.ok ? res.json() : null))
       .then((data) => {


### PR DESCRIPTION
## Summary
- prevent repeated history merge fetch with ref tracking
- avoid duplicate WordOfDay fetches by caching last offset
- guard one-time fetches in admin and random term components
- suppress repeated searches and frequency requests for the same query

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b76ebd236c8328b977b633ad0a94f7