### PR TITLE
feat: manage focus for navigation and modals

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import React from "react";
+import React, { useEffect } from "react";
 import { motion } from "framer-motion";
 import Navbar from "../components/Navbar";
 import MobileTocButton from "../components/MobileTocButton";
 import { Inter } from "next/font/google";
 import useFontHinting from "../hooks/useFontHinting";
+import { usePathname } from "next/navigation";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -15,6 +16,15 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   useFontHinting();
+  const pathname = usePathname();
+
+  useEffect(() => {
+    const heading = document.querySelector("h1") as HTMLElement | null;
+    if (heading) {
+      heading.setAttribute("tabindex", "-1");
+      heading.focus();
+    }
+  }, [pathname]);
   return (
     <html lang="en" className={inter.className}>
       <body>

--- a/components/ShortcutPalette.tsx
+++ b/components/ShortcutPalette.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import useFocusTrap from '../hooks/useFocusTrap';
 
 interface Shortcut {
   keys: string;
@@ -18,6 +19,7 @@ const shortcuts: Shortcut[] = [
  */
 export default function ShortcutPalette(): JSX.Element | null {
   const [open, setOpen] = useState(false);
+  const paletteRef = useFocusTrap(open, () => setOpen(false));
 
   useEffect(() => {
     function handler(e: KeyboardEvent) {
@@ -43,7 +45,13 @@ export default function ShortcutPalette(): JSX.Element | null {
   if (!open) return null;
 
   return (
-    <div className="shortcut-palette" role="dialog" aria-modal="true">
+    <div
+      className="shortcut-palette"
+      role="dialog"
+      aria-modal="true"
+      ref={paletteRef}
+      tabIndex={-1}
+    >
       <div className="shortcut-palette__content">
         <h2>Keyboard Shortcuts</h2>
         <ul>

--- a/components/ui/Dialog.tsx
+++ b/components/ui/Dialog.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef } from "react";
+import useFocusTrap from "../../hooks/useFocusTrap";
 
 interface DialogProps {
   open: boolean;
@@ -6,53 +7,22 @@ interface DialogProps {
   children: React.ReactNode;
 }
 
-const focusableSelectors =
-  'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])';
-
 export const Dialog: React.FC<DialogProps> = ({ open, onClose, children }) => {
-  const dialogRef = useRef<HTMLDivElement>(null);
+  const dialogRef = useFocusTrap(open, onClose);
   const previouslyFocusedElement = useRef<HTMLElement | null>(null);
 
   useEffect(() => {
     if (open) {
       previouslyFocusedElement.current = document.activeElement as HTMLElement;
-      const firstFocusable =
-        dialogRef.current?.querySelector<HTMLElement>(focusableSelectors);
-      firstFocusable?.focus();
-
-      const handleKeyDown = (e: KeyboardEvent) => {
-        if (e.key === "Tab" && dialogRef.current) {
-          const focusable =
-            dialogRef.current.querySelectorAll<HTMLElement>(focusableSelectors);
-          if (!focusable.length) return;
-          const first = focusable[0];
-          const last = focusable[focusable.length - 1];
-          if (!e.shiftKey && document.activeElement === last) {
-            e.preventDefault();
-            first.focus();
-          } else if (e.shiftKey && document.activeElement === first) {
-            e.preventDefault();
-            last.focus();
-          }
-        }
-        if (e.key === "Escape") {
-          onClose();
-        }
-      };
-
-      document.addEventListener("keydown", handleKeyDown);
-      return () => {
-        document.removeEventListener("keydown", handleKeyDown);
-      };
     } else if (previouslyFocusedElement.current) {
       previouslyFocusedElement.current.focus();
     }
-  }, [open, onClose]);
+  }, [open]);
 
   if (!open) return null;
 
   return (
-    <div role="dialog" aria-modal="true" ref={dialogRef}>
+    <div role="dialog" aria-modal="true" ref={dialogRef} tabIndex={-1}>
       {children}
     </div>
   );

--- a/hooks/useFocusTrap.ts
+++ b/hooks/useFocusTrap.ts
@@ -1,0 +1,58 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * Trap keyboard focus within a container while active.
+ * The container ref should be applied to the dialog element.
+ */
+export default function useFocusTrap(
+  active: boolean,
+  onEscape?: () => void,
+) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!active) return;
+    const node = ref.current;
+    if (!node) return;
+
+    const focusableSelectors = [
+      "a[href]",
+      "area[href]",
+      "input:not([disabled])",
+      "select:not([disabled])",
+      "textarea:not([disabled])",
+      "button:not([disabled])",
+      "iframe",
+      '[tabindex]:not([tabindex="-1"])',
+      '[contenteditable="true"]',
+    ];
+    const focusable = Array.from(
+      node.querySelectorAll<HTMLElement>(focusableSelectors.join(",")),
+    );
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Tab") {
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault();
+          (last || first)?.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault();
+          (first || last)?.focus();
+        }
+      } else if (e.key === "Escape" && onEscape) {
+        onEscape();
+      }
+    };
+
+    node.addEventListener("keydown", handleKeyDown);
+    first?.focus();
+
+    return () => {
+      node.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [active, onEscape]);
+
+  return ref;
+}

--- a/src/components/ClipboardPreview.tsx
+++ b/src/components/ClipboardPreview.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useEffect, useState } from 'react';
+import useFocusTrap from '../../hooks/useFocusTrap';
 import termsData from '../../terms.json';
 
 interface Term {
@@ -17,6 +18,7 @@ const STORAGE_KEY = 'clipboardPreviewShown';
  */
 const ClipboardPreview: React.FC = () => {
   const [term, setTerm] = useState<Term | null>(null);
+  const overlayRef = useFocusTrap(Boolean(term), () => setTerm(null));
 
   useEffect(() => {
     const handleCopy = async () => {
@@ -57,6 +59,8 @@ const ClipboardPreview: React.FC = () => {
       className="clipboard-preview-overlay"
       role="dialog"
       aria-modal="true"
+      ref={overlayRef}
+      tabIndex={-1}
       style={{
         position: 'fixed',
         inset: 0,

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import useFocusTrap from "../../hooks/useFocusTrap";
 import { useNavigate } from "react-router-dom";
 
 interface Command {
@@ -25,6 +26,7 @@ const CommandPalette: React.FC<CommandPaletteProps> = ({
 }) => {
   const [visible, setVisible] = useState(false);
   const [query, setQuery] = useState("");
+  const overlayRef = useFocusTrap(visible, () => setVisible(false));
   const navigate = useNavigate();
 
   const commands: Command[] = [
@@ -70,7 +72,13 @@ const CommandPalette: React.FC<CommandPaletteProps> = ({
   if (!visible) return null;
 
   return (
-    <div className="command-palette-overlay" role="dialog" aria-modal="true">
+    <div
+      className="command-palette-overlay"
+      role="dialog"
+      aria-modal="true"
+      ref={overlayRef}
+      tabIndex={-1}
+    >
       <div className="command-palette">
         <input
           autoFocus


### PR DESCRIPTION
## Summary
- move focus to main heading after route changes
- add reusable focus trap hook for accessible modals
- apply focus trapping to command palette, shortcuts, and preview overlays

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b76ec05528832891013e66109d5095