### PR TITLE
Add i18n fallback logging for missing keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/",
   "main": "script.js",
   "scripts": {
-    "test": "html-validate index.html search.html diagnostics.html import.html && node diagnostics.test.js && node tests/useCopyFormats.test.js"
+    "test": "html-validate index.html search.html diagnostics.html import.html && node diagnostics.test.js && node tests/i18n.test.js && node tests/useCopyFormats.test.js"
   },
   "keywords": [],
   "author": "",

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -1,0 +1,39 @@
+export type Locale = string;
+
+interface TranslationMap {
+  [key: string]: string;
+}
+
+const translations: Record<Locale, TranslationMap> = {
+  en: {
+    greeting: 'Hello',
+  },
+  // Other locales can be added here
+};
+
+/**
+ * Translate a key for a given locale.
+ * Falls back to English when the key is missing and logs a hint in development.
+ * Never returns undefined; falls back to the key itself if no translation exists.
+ */
+export function t(key: string, locale: Locale = 'en'): string {
+  const lang = translations[locale] || {};
+
+  if (key in lang) {
+    return lang[key];
+  }
+
+  const english = translations.en[key];
+  if (english) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn(`Missing translation for key "${key}" in locale "${locale}"`);
+    }
+    return english;
+  }
+
+  if (process.env.NODE_ENV !== 'production') {
+    console.warn(`Missing translation key "${key}" in all locales`);
+  }
+
+  return key;
+}

--- a/tests/i18n.test.js
+++ b/tests/i18n.test.js
@@ -1,0 +1,26 @@
+require('ts-node/register');
+const assert = require('assert').strict;
+
+// Ensure development mode for logging
+process.env.NODE_ENV = 'development';
+
+const { t } = require('../src/lib/i18n');
+
+let warned = '';
+const originalWarn = console.warn;
+console.warn = (msg) => { warned = msg; };
+
+// Should fall back to English and warn
+const result = t('greeting', 'es');
+assert.equal(result, 'Hello');
+assert.ok(warned.includes('Missing translation'));
+
+// Should return key when completely missing
+warned = '';
+const missing = t('unknown_key', 'es');
+assert.equal(missing, 'unknown_key');
+assert.ok(warned.includes('unknown_key'));
+
+console.warn = originalWarn;
+
+console.log('i18n tests passed');


### PR DESCRIPTION
## Summary
- add i18n helper that falls back to English and logs missing keys in dev
- ensure missing translations don't surface `undefined`
- cover translation fallback with tests and wire into `npm test`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b76eba6af88328a5295a591e02b32a