### PR TITLE
refactor: isolate env vars in API routes

### DIFF
--- a/api/expand/route.ts
+++ b/api/expand/route.ts
@@ -1,4 +1,4 @@
-import { expandTopic } from '../../lib/ai';
+import { expandTopic, AIProvider } from '../../lib/ai';
 
 /**
  * API route that expands a topic using the configured AI provider.
@@ -7,7 +7,20 @@ import { expandTopic } from '../../lib/ai';
 export async function POST(request: Request): Promise<Response> {
   const { topic, prompt = '', provider } = await request.json();
   const combined = prompt ? `${topic}\n\n${prompt}` : topic;
-  const expansion = await expandTopic(combined, provider);
+
+  const resolvedProvider: AIProvider =
+    (provider as AIProvider) ||
+    ((process.env.AI_PROVIDER as AIProvider) || 'openai');
+  const apiKey =
+    resolvedProvider === 'openai'
+      ? process.env.OPENAI_API_KEY
+      : process.env.ANTHROPIC_API_KEY;
+
+  if (!apiKey) {
+    return new Response('Missing API key', { status: 500 });
+  }
+
+  const expansion = await expandTopic(combined, resolvedProvider, apiKey);
   return new Response(JSON.stringify({ expansion }), {
     headers: { 'Content-Type': 'application/json' }
   });

--- a/lib/ai.ts
+++ b/lib/ai.ts
@@ -6,20 +6,20 @@ export type AIProvider = 'openai' | 'anthropic';
  */
 export async function expandTopic(
   topic: string,
-  provider: AIProvider = (process.env.AI_PROVIDER as AIProvider) || 'openai'
+  provider: AIProvider,
+  apiKey: string
 ): Promise<string> {
   switch (provider) {
     case 'openai':
-      return openAIExpand(topic);
+      return openAIExpand(topic, apiKey);
     case 'anthropic':
-      return anthropicExpand(topic);
+      return anthropicExpand(topic, apiKey);
     default:
       throw new Error(`Unsupported AI provider: ${provider}`);
   }
 }
 
-async function openAIExpand(topic: string): Promise<string> {
-  const apiKey = process.env.OPENAI_API_KEY;
+async function openAIExpand(topic: string, apiKey: string): Promise<string> {
   if (!apiKey) throw new Error('Missing OPENAI_API_KEY');
 
   const res = await fetch('https://api.openai.com/v1/chat/completions', {
@@ -39,8 +39,7 @@ async function openAIExpand(topic: string): Promise<string> {
   return typeof text === 'string' ? text.trim() : '';
 }
 
-async function anthropicExpand(topic: string): Promise<string> {
-  const apiKey = process.env.ANTHROPIC_API_KEY;
+async function anthropicExpand(topic: string, apiKey: string): Promise<string> {
   if (!apiKey) throw new Error('Missing ANTHROPIC_API_KEY');
 
   const res = await fetch('https://api.anthropic.com/v1/messages', {


### PR DESCRIPTION
## Summary
- avoid referencing environment variables directly in `lib/ai`
- resolve AI provider and API keys inside API route

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b76ebce814832880cb962cf48daffb