### PR TITLE
Specify runtimes for API and sitemap routes

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,9 +1,11 @@
-import { streamText } from 'ai';
-import { createOpenAI } from '@ai-sdk/openai';
+import { streamText } from "ai";
+import { createOpenAI } from "@ai-sdk/openai";
+
+export const runtime = "edge";
 
 // Initialize OpenAI client using the API key from environment variables.
 const openai = createOpenAI({
-  apiKey: process.env.OPENAI_API_KEY || ''
+  apiKey: process.env.OPENAI_API_KEY || "",
 });
 
 // Handle POST requests to the chat endpoint. This uses the `streamText`
@@ -14,7 +16,7 @@ export async function POST(req: Request): Promise<Response> {
     const { messages } = await req.json();
 
     const result = await streamText({
-      model: openai('gpt-4o-mini'),
+      model: openai("gpt-4o-mini"),
       messages,
     });
 
@@ -23,7 +25,7 @@ export async function POST(req: Request): Promise<Response> {
     // render tokens incrementally.
     return result.toDataStreamResponse();
   } catch (error) {
-    console.error('Chat streaming failed', error);
-    return new Response('Failed to generate chat response', { status: 500 });
+    console.error("Chat streaming failed", error);
+    return new Response("Failed to generate chat response", { status: 500 });
   }
 }

--- a/app/api/feedback/route.ts
+++ b/app/api/feedback/route.ts
@@ -1,6 +1,8 @@
-import { NextResponse } from 'next/server';
-import fs from 'node:fs/promises';
-import path from 'node:path';
+import { NextResponse } from "next/server";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+export const runtime = "node";
 
 interface Feedback {
   message: string;
@@ -8,7 +10,7 @@ interface Feedback {
   timestamp: string;
 }
 
-const feedbackFile = path.join(process.cwd(), 'feedback.json');
+const feedbackFile = path.join(process.cwd(), "feedback.json");
 
 export async function POST(request: Request) {
   try {
@@ -18,17 +20,17 @@ export async function POST(request: Request) {
 
     if (!message) {
       return NextResponse.json(
-        { success: false, error: 'Message is required' },
-        { status: 400 }
+        { success: false, error: "Message is required" },
+        { status: 400 },
       );
     }
 
     let feedback: Feedback[] = [];
     try {
-      const existing = await fs.readFile(feedbackFile, 'utf8');
+      const existing = await fs.readFile(feedbackFile, "utf8");
       feedback = JSON.parse(existing);
     } catch (err: any) {
-      if (err.code !== 'ENOENT') {
+      if (err.code !== "ENOENT") {
         throw err;
       }
     }
@@ -44,11 +46,10 @@ export async function POST(request: Request) {
 
     return NextResponse.json({ success: true });
   } catch (error) {
-    console.error('Failed to save feedback', error);
+    console.error("Failed to save feedback", error);
     return NextResponse.json(
-      { success: false, error: 'Internal server error' },
-      { status: 500 }
+      { success: false, error: "Internal server error" },
+      { status: 500 },
     );
   }
 }
-

--- a/app/api/socket/route.ts
+++ b/app/api/socket/route.ts
@@ -1,5 +1,7 @@
 import { Server } from "socket.io";
 
+export const runtime = "node";
+
 let io: Server | undefined;
 
 export async function GET() {

--- a/app/api/terms/[term]/route.ts
+++ b/app/api/terms/[term]/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from "next/server";
 import { promises as fs } from "fs";
 import path from "path";
 
+export const runtime = "node";
+
 const dataFile = path.join(process.cwd(), "terms.json");
 
 interface Term {
@@ -22,7 +24,7 @@ async function writeTerms(terms: Term[]): Promise<void> {
 
 export async function PUT(
   request: Request,
-  { params }: { params: { term: string } }
+  { params }: { params: { term: string } },
 ) {
   const { definition } = await request.json();
   const terms = await readTerms();
@@ -37,7 +39,7 @@ export async function PUT(
 
 export async function DELETE(
   request: Request,
-  { params }: { params: { term: string } }
+  { params }: { params: { term: string } },
 ) {
   const terms = await readTerms();
   const idx = terms.findIndex((t) => t.term === params.term);

--- a/app/api/terms/route.ts
+++ b/app/api/terms/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from "next/server";
 import { promises as fs } from "fs";
 import path from "path";
 
+export const runtime = "node";
+
 const dataFile = path.join(process.cwd(), "terms.json");
 
 interface Term {
@@ -30,16 +32,13 @@ export async function POST(request: Request) {
   if (!term || !definition) {
     return NextResponse.json(
       { error: "term and definition are required" },
-      { status: 400 }
+      { status: 400 },
     );
   }
 
   const terms = await readTerms();
   if (terms.some((t) => t.term === term)) {
-    return NextResponse.json(
-      { error: "term already exists" },
-      { status: 409 }
-    );
+    return NextResponse.json({ error: "term already exists" }, { status: 409 });
   }
 
   terms.push({ term, definition });

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,25 +1,23 @@
-import type { MetadataRoute } from 'next';
-import termsData from '../terms.json' assert { type: 'json' };
-import siteConfig from '../site.config.json' assert { type: 'json' };
+import type { MetadataRoute } from "next";
+import termsData from "../terms.json" assert { type: "json" };
+import siteConfig from "../site.config.json" assert { type: "json" };
+
+export const runtime = "edge";
 
 function slugify(term: string): string {
   return term
     .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
 }
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const baseUrl = (siteConfig.siteUrl || '').replace(/\/$/, '');
+  const baseUrl = (siteConfig.siteUrl || "").replace(/\/$/, "");
 
   const termEntries = (termsData.terms || []).map((t: { term: string }) => ({
     url: `${baseUrl}/terms/${slugify(t.term)}`,
     lastModified: new Date(),
   }));
 
-  return [
-    { url: baseUrl, lastModified: new Date() },
-    ...termEntries,
-  ];
+  return [{ url: baseUrl, lastModified: new Date() }, ...termEntries];
 }
-


### PR DESCRIPTION
## Summary
- declare appropriate runtime (edge or node) for each API route and sitemap
- ensure edge routes avoid Node-only dependencies

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b76ebc3f148328bff1104ae44a027c