### PR TITLE
Use safe URL helper in search routines

### DIFF
--- a/api/suggest/route.ts
+++ b/api/suggest/route.ts
@@ -1,10 +1,11 @@
 import { chipsForTags } from '../../lib/prompts';
+import safeUrl from '../../src/utils/safeUrl';
 
 /**
  * Return prompt chips for the provided comma separated `tags` query parameter.
  */
 export async function GET(request: Request): Promise<Response> {
-  const url = new URL(request.url);
+  const url = safeUrl(request.url);
   const tagsParam = url.searchParams.get('tags') || '';
   const tags = tagsParam.split(',').map((t) => t.trim()).filter(Boolean);
   const suggestions = chipsForTags(tags);

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import data from "../../../terms.json";
+import safeUrl from "../../../src/utils/safeUrl";
 
 interface Term {
   term: string;
@@ -40,7 +41,7 @@ function levenshtein(a: string, b: string): number {
 }
 
 export async function GET(request: Request) {
-  const { searchParams } = new URL(request.url);
+  const { searchParams } = safeUrl(request.url);
   const query = searchParams.get("q")?.trim().toLowerCase() ?? "";
 
   const terms: Term[] = (data as any).terms || [];

--- a/app/components/SearchInput.tsx
+++ b/app/components/SearchInput.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { searchPersonalTerms, PersonalTerm } from "../../lib/personalTerms";
+import safeUrl from "../../src/utils/safeUrl";
 
 interface Term {
   term: string;
@@ -24,7 +25,9 @@ export default function SearchInput() {
     const value = e.target.value;
     setQuery(value);
 
-    const res = await fetch(`/api/search?q=${encodeURIComponent(value)}`);
+    const res = await fetch(
+      safeUrl(`/api/search?q=${encodeURIComponent(value)}`).toString(),
+    );
     if (res.ok) {
       const data: SearchResponse = await res.json();
       setResults(data.results);

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import { searchPersonalTerms, PersonalTerm } from '../../lib/personalTerms';
+import safeUrl from '../../src/utils/safeUrl';
 
 interface Term {
   term: string;
@@ -25,7 +26,7 @@ export default function SearchPage() {
 
   useEffect(() => {
     if (!query) return;
-    fetch(`/api/search?q=${encodeURIComponent(query)}`)
+    fetch(safeUrl(`/api/search?q=${encodeURIComponent(query)}`).toString())
       .then((res) => res.json())
       .then(setData)
       .catch(() => setData({ results: [], suggestions: [] }));

--- a/components/SearchBox.tsx
+++ b/components/SearchBox.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react';
 import AutocompleteList from './AutocompleteList';
+import safeUrl from '../src/utils/safeUrl';
 
 const SearchBox: React.FC = () => {
   const [value, setValue] = useState('');
@@ -14,7 +15,7 @@ const SearchBox: React.FC = () => {
       setShowSuggestions(false);
       return;
     }
-    fetch(`/api/suggest?q=${encodeURIComponent(value)}`)
+    fetch(safeUrl(`/api/suggest?q=${encodeURIComponent(value)}`).toString())
       .then((r) => (r.ok ? r.json() : Promise.reject(r.statusText)))
       .then((data: string[]) => {
         setSuggestions(data);

--- a/components/search/Autocomplete.tsx
+++ b/components/search/Autocomplete.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
+import safeUrl from '../../src/utils/safeUrl';
 
 interface AutocompleteProps {
   /**
@@ -26,9 +27,12 @@ const Autocomplete: React.FC<AutocompleteProps> = ({ onCommit, pinned = [] }) =>
     }
 
     const controller = new AbortController();
-    fetch(`/api/suggestions?q=${encodeURIComponent(query)}`, {
-      signal: controller.signal,
-    })
+    fetch(
+      safeUrl(`/api/suggestions?q=${encodeURIComponent(query)}`).toString(),
+      {
+        signal: controller.signal,
+      },
+    )
       .then((res) => (res.ok ? res.json() : []))
       .then((data: string[]) => {
         setSuggestions(data);

--- a/src/hooks/useSearch.tsx
+++ b/src/hooks/useSearch.tsx
@@ -5,6 +5,7 @@ import {
   useEffect,
   useState,
 } from "react";
+import safeUrl from "../utils/safeUrl";
 
 interface SearchResult {
   term: string;
@@ -50,7 +51,11 @@ export const SearchProvider: React.FC<{ children: React.ReactNode }> = ({
       setResults([]);
       return;
     }
-    fetch(`/api/search?q=${encodeURIComponent(query)}&fuzziness=${fuzziness}`)
+    fetch(
+      safeUrl(
+        `/api/search?q=${encodeURIComponent(query)}&fuzziness=${fuzziness}`,
+      ).toString(),
+    )
       .then((res) => (res.ok ? res.json() : { results: [] }))
       .then((data) => setResults(data.results || []))
       .catch(() => setResults([]));

--- a/src/utils/safeUrl.ts
+++ b/src/utils/safeUrl.ts
@@ -1,0 +1,16 @@
+export function safeUrl(path: string, base?: string | URL): URL {
+  if (base) {
+    return new URL(path, base);
+  }
+  try {
+    return new URL(path);
+  } catch {
+    const origin =
+      typeof window !== 'undefined' && window.location
+        ? window.location.href
+        : 'http://localhost';
+    return new URL(path, origin);
+  }
+}
+
+export default safeUrl;


### PR DESCRIPTION
## Summary
- add a `safeUrl` utility that normalizes relative paths with an optional base
- refactor search APIs and components to build requests using `safeUrl` instead of `new URL`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b76eb8f3188328b980c88253ffae9a