### PR TITLE
Sanitize HTML rendering and add DOMPurify tests

### DIFF
--- a/__tests__/sanitize.test.ts
+++ b/__tests__/sanitize.test.ts
@@ -1,0 +1,12 @@
+const assert = require("assert");
+const sanitize = require("../src/utils/sanitize").default;
+
+const dirty =
+  '<img src="x" onerror="alert(1)"><p>Hello</p><script>alert(1)</script>';
+const clean = sanitize(dirty);
+
+assert(!clean.includes("<script"), "script tags should be removed");
+assert(!clean.includes("onerror"), "event handlers should be stripped");
+assert(clean.includes("<p>Hello</p>"), "safe content should remain");
+
+console.log("Sanitization test passed");

--- a/app/components/FAQBlock.tsx
+++ b/app/components/FAQBlock.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import sanitize from "../../src/utils/sanitize";
 
 interface FAQItem {
   question: string;
@@ -23,6 +24,8 @@ export function FAQBlock({ items }: FAQBlockProps) {
     })),
   };
 
+  const jsonLdString = sanitize(JSON.stringify(jsonLd));
+
   return (
     <section>
       <h2>FAQ</h2>
@@ -34,7 +37,7 @@ export function FAQBlock({ items }: FAQBlockProps) {
       ))}
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        dangerouslySetInnerHTML={{ __html: jsonLdString }}
       />
     </section>
   );

--- a/app/terms/[slug]/page.tsx
+++ b/app/terms/[slug]/page.tsx
@@ -3,6 +3,7 @@ import fs from "fs";
 import path from "path";
 import yaml from "js-yaml";
 import { FAQBlock } from "../../components/FAQBlock";
+import sanitize from "../../../src/utils/sanitize";
 
 interface Term {
   name: string;
@@ -43,6 +44,8 @@ export default function TermPage({ params }: { params: { slug: string } }) {
     },
   ];
 
+  const termJsonLdString = sanitize(JSON.stringify(termJsonLd));
+
   return (
     <main>
       <h1>{term.name}</h1>
@@ -55,7 +58,7 @@ export default function TermPage({ params }: { params: { slug: string } }) {
       <FAQBlock items={faqItems} />
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(termJsonLd) }}
+        dangerouslySetInnerHTML={{ __html: termJsonLdString }}
       />
     </main>
   );

--- a/components/results/DefinitionItem.tsx
+++ b/components/results/DefinitionItem.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import highlight from "../../lib/highlight";
+import sanitize from "../../src/utils/sanitize";
 
 interface DefinitionItemProps {
   term: string;
@@ -12,8 +13,8 @@ export default function DefinitionItem({
   definition,
   match,
 }: DefinitionItemProps) {
-  const title = match ? highlight(term, match) : term;
-  const body = match ? highlight(definition, match) : definition;
+  const title = sanitize(match ? highlight(term, match) : term);
+  const body = sanitize(match ? highlight(definition, match) : definition);
 
   return (
     <div className="definition-item">

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "dompurify": "^3.2.6",
         "framer-motion": "^12.23.12",
         "hammerjs": "^2.0.8",
         "idb": "^7.1.1",
@@ -360,6 +361,13 @@
       "dependencies": {
         "csstype": "^3.0.2"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -920,6 +928,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
+      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/",
   "main": "script.js",
   "scripts": {
-    "test": "html-validate index.html search.html diagnostics.html import.html && node diagnostics.test.js && node tests/useCopyFormats.test.js"
+    "test": "html-validate index.html search.html diagnostics.html import.html && node diagnostics.test.js && node tests/useCopyFormats.test.js && ts-node --compiler-options '{\"module\":\"CommonJS\"}' --transpile-only __tests__/sanitize.test.ts"
   },
   "keywords": [],
   "author": "",
@@ -21,6 +21,7 @@
     "typescript": "^5.9.2"
   },
   "dependencies": {
+    "dompurify": "^3.2.6",
     "framer-motion": "^12.23.12",
     "hammerjs": "^2.0.8",
     "idb": "^7.1.1",

--- a/src/playgrounds/regex/RegexSandbox.tsx
+++ b/src/playgrounds/regex/RegexSandbox.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import sanitize from "../../utils/sanitize";
 
 const FLAG_OPTIONS = ["g", "i", "m", "s", "u", "y"] as const;
 type Flag = (typeof FLAG_OPTIONS)[number];
@@ -110,7 +111,9 @@ export default function RegexSandbox() {
       <div>
         {results.map((res, idx) => (
           <div key={idx} style={{ color: res.match ? "inherit" : "red" }}>
-            <div dangerouslySetInnerHTML={{ __html: res.highlighted }} />
+            <div
+              dangerouslySetInnerHTML={{ __html: sanitize(res.highlighted) }}
+            />
             {!res.match && res.error && <small>{res.error}</small>}
           </div>
         ))}

--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -1,0 +1,12 @@
+import createDOMPurify from "dompurify";
+import { JSDOM } from "jsdom";
+
+const windowRef: any =
+  typeof (globalThis as any).window === "undefined"
+    ? new JSDOM("").window
+    : (globalThis as any).window;
+const DOMPurify = createDOMPurify(windowRef);
+
+export default function sanitize(dirty: string): string {
+  return DOMPurify.sanitize(dirty);
+}


### PR DESCRIPTION
## Summary
- add DOMPurify-based sanitize utility
- sanitize all dangerouslySetInnerHTML usages
- add unit test for sanitizer and wire into test script

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b76eb1ba70832895ac36a3fe37bbb3