### PR TITLE
chore: restrict image domains

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -5,6 +5,18 @@ const nextConfig = {
   images: {
     loader: "cloudinary",
     path: `https://res.cloudinary.com/${cloudName}/image/upload/`,
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "res.cloudinary.com",
+        pathname: `/${cloudName}/image/upload/**`,
+      },
+      {
+        protocol: "https",
+        hostname: "www.google.com",
+        pathname: "/s2/favicons",
+      },
+    ],
   },
   async headers() {
     const csp = [

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -17,7 +17,23 @@ const securityHeaders = [
   },
 ];
 
+const cloudName = process.env.CLOUDINARY_CLOUD_NAME || "demo";
+
 const nextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "res.cloudinary.com",
+        pathname: `/${cloudName}/image/upload/**`,
+      },
+      {
+        protocol: "https",
+        hostname: "www.google.com",
+        pathname: "/s2/favicons",
+      },
+    ],
+  },
   async headers() {
     return [
       {


### PR DESCRIPTION
## Summary
- restrict remote images to res.cloudinary.com and Google favicon service
- share same restrictions with ESM config

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b76eb21c00832886a822a13b11775c