### PR TITLE
feat: add route error boundaries

### DIFF
--- a/app/(site)/a-z/error.tsx
+++ b/app/(site)/a-z/error.tsx
@@ -1,0 +1,15 @@
+'use client';
+import { useEffect } from 'react';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="p-6">
+      <h2>Something went wrong</h2>
+      <button onClick={() => reset()}>Try again</button>
+    </div>
+  );
+}

--- a/app/(site)/a-z/not-found.tsx
+++ b/app/(site)/a-z/not-found.tsx
@@ -1,0 +1,10 @@
+import Link from 'next/link';
+
+export default function NotFound() {
+  return (
+    <div className="p-6">
+      <h2>Page not found</h2>
+      <Link href="/">Go home</Link>
+    </div>
+  );
+}

--- a/app/(site)/error.tsx
+++ b/app/(site)/error.tsx
@@ -1,0 +1,15 @@
+'use client';
+import { useEffect } from 'react';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="p-6">
+      <h2>Something went wrong</h2>
+      <button onClick={() => reset()}>Try again</button>
+    </div>
+  );
+}

--- a/app/(site)/not-found.tsx
+++ b/app/(site)/not-found.tsx
@@ -1,0 +1,10 @@
+import Link from 'next/link';
+
+export default function NotFound() {
+  return (
+    <div className="p-6">
+      <h2>Page not found</h2>
+      <Link href="/">Go home</Link>
+    </div>
+  );
+}

--- a/app/(site)/settings/error.tsx
+++ b/app/(site)/settings/error.tsx
@@ -1,0 +1,15 @@
+'use client';
+import { useEffect } from 'react';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="p-6">
+      <h2>Something went wrong</h2>
+      <button onClick={() => reset()}>Try again</button>
+    </div>
+  );
+}

--- a/app/(site)/settings/not-found.tsx
+++ b/app/(site)/settings/not-found.tsx
@@ -1,0 +1,10 @@
+import Link from 'next/link';
+
+export default function NotFound() {
+  return (
+    <div className="p-6">
+      <h2>Page not found</h2>
+      <Link href="/">Go home</Link>
+    </div>
+  );
+}

--- a/app/(site)/term/[slug]/error.tsx
+++ b/app/(site)/term/[slug]/error.tsx
@@ -1,0 +1,15 @@
+'use client';
+import { useEffect } from 'react';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="p-6">
+      <h2>Something went wrong</h2>
+      <button onClick={() => reset()}>Try again</button>
+    </div>
+  );
+}

--- a/app/(site)/term/[slug]/not-found.tsx
+++ b/app/(site)/term/[slug]/not-found.tsx
@@ -1,0 +1,10 @@
+import Link from 'next/link';
+
+export default function NotFound() {
+  return (
+    <div className="p-6">
+      <h2>Page not found</h2>
+      <Link href="/">Go home</Link>
+    </div>
+  );
+}

--- a/app/(site)/term/error.tsx
+++ b/app/(site)/term/error.tsx
@@ -1,0 +1,15 @@
+'use client';
+import { useEffect } from 'react';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="p-6">
+      <h2>Something went wrong</h2>
+      <button onClick={() => reset()}>Try again</button>
+    </div>
+  );
+}

--- a/app/(site)/term/not-found.tsx
+++ b/app/(site)/term/not-found.tsx
@@ -1,0 +1,10 @@
+import Link from 'next/link';
+
+export default function NotFound() {
+  return (
+    <div className="p-6">
+      <h2>Page not found</h2>
+      <Link href="/">Go home</Link>
+    </div>
+  );
+}

--- a/app/[category]/error.tsx
+++ b/app/[category]/error.tsx
@@ -1,0 +1,15 @@
+'use client';
+import { useEffect } from 'react';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="p-6">
+      <h2>Something went wrong</h2>
+      <button onClick={() => reset()}>Try again</button>
+    </div>
+  );
+}

--- a/app/[category]/not-found.tsx
+++ b/app/[category]/not-found.tsx
@@ -1,0 +1,10 @@
+import Link from 'next/link';
+
+export default function NotFound() {
+  return (
+    <div className="p-6">
+      <h2>Page not found</h2>
+      <Link href="/">Go home</Link>
+    </div>
+  );
+}

--- a/app/[term]/error.tsx
+++ b/app/[term]/error.tsx
@@ -1,0 +1,15 @@
+'use client';
+import { useEffect } from 'react';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="p-6">
+      <h2>Something went wrong</h2>
+      <button onClick={() => reset()}>Try again</button>
+    </div>
+  );
+}

--- a/app/[term]/not-found.tsx
+++ b/app/[term]/not-found.tsx
@@ -1,0 +1,10 @@
+import Link from 'next/link';
+
+export default function NotFound() {
+  return (
+    <div className="p-6">
+      <h2>Page not found</h2>
+      <Link href="/">Go home</Link>
+    </div>
+  );
+}

--- a/app/a-z/error.tsx
+++ b/app/a-z/error.tsx
@@ -1,0 +1,15 @@
+'use client';
+import { useEffect } from 'react';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="p-6">
+      <h2>Something went wrong</h2>
+      <button onClick={() => reset()}>Try again</button>
+    </div>
+  );
+}

--- a/app/a-z/not-found.tsx
+++ b/app/a-z/not-found.tsx
@@ -1,0 +1,10 @@
+import Link from 'next/link';
+
+export default function NotFound() {
+  return (
+    <div className="p-6">
+      <h2>Page not found</h2>
+      <Link href="/">Go home</Link>
+    </div>
+  );
+}

--- a/app/admin/error.tsx
+++ b/app/admin/error.tsx
@@ -1,0 +1,15 @@
+'use client';
+import { useEffect } from 'react';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="p-6">
+      <h2>Something went wrong</h2>
+      <button onClick={() => reset()}>Try again</button>
+    </div>
+  );
+}

--- a/app/admin/not-found.tsx
+++ b/app/admin/not-found.tsx
@@ -1,0 +1,10 @@
+import Link from 'next/link';
+
+export default function NotFound() {
+  return (
+    <div className="p-6">
+      <h2>Page not found</h2>
+      <Link href="/">Go home</Link>
+    </div>
+  );
+}

--- a/app/compare/[a]-vs-[b]/error.tsx
+++ b/app/compare/[a]-vs-[b]/error.tsx
@@ -1,0 +1,15 @@
+'use client';
+import { useEffect } from 'react';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="p-6">
+      <h2>Something went wrong</h2>
+      <button onClick={() => reset()}>Try again</button>
+    </div>
+  );
+}

--- a/app/compare/[a]-vs-[b]/not-found.tsx
+++ b/app/compare/[a]-vs-[b]/not-found.tsx
@@ -1,0 +1,10 @@
+import Link from 'next/link';
+
+export default function NotFound() {
+  return (
+    <div className="p-6">
+      <h2>Page not found</h2>
+      <Link href="/">Go home</Link>
+    </div>
+  );
+}

--- a/app/compare/error.tsx
+++ b/app/compare/error.tsx
@@ -1,0 +1,15 @@
+'use client';
+import { useEffect } from 'react';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="p-6">
+      <h2>Something went wrong</h2>
+      <button onClick={() => reset()}>Try again</button>
+    </div>
+  );
+}

--- a/app/compare/not-found.tsx
+++ b/app/compare/not-found.tsx
@@ -1,0 +1,10 @@
+import Link from 'next/link';
+
+export default function NotFound() {
+  return (
+    <div className="p-6">
+      <h2>Page not found</h2>
+      <Link href="/">Go home</Link>
+    </div>
+  );
+}

--- a/app/search/error.tsx
+++ b/app/search/error.tsx
@@ -1,0 +1,15 @@
+'use client';
+import { useEffect } from 'react';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="p-6">
+      <h2>Something went wrong</h2>
+      <button onClick={() => reset()}>Try again</button>
+    </div>
+  );
+}

--- a/app/search/not-found.tsx
+++ b/app/search/not-found.tsx
@@ -1,0 +1,10 @@
+import Link from 'next/link';
+
+export default function NotFound() {
+  return (
+    <div className="p-6">
+      <h2>Page not found</h2>
+      <Link href="/">Go home</Link>
+    </div>
+  );
+}

--- a/app/settings/error.tsx
+++ b/app/settings/error.tsx
@@ -1,0 +1,15 @@
+'use client';
+import { useEffect } from 'react';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="p-6">
+      <h2>Something went wrong</h2>
+      <button onClick={() => reset()}>Try again</button>
+    </div>
+  );
+}

--- a/app/settings/not-found.tsx
+++ b/app/settings/not-found.tsx
@@ -1,0 +1,10 @@
+import Link from 'next/link';
+
+export default function NotFound() {
+  return (
+    <div className="p-6">
+      <h2>Page not found</h2>
+      <Link href="/">Go home</Link>
+    </div>
+  );
+}

--- a/app/term/[slug]/error.tsx
+++ b/app/term/[slug]/error.tsx
@@ -1,0 +1,15 @@
+'use client';
+import { useEffect } from 'react';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="p-6">
+      <h2>Something went wrong</h2>
+      <button onClick={() => reset()}>Try again</button>
+    </div>
+  );
+}

--- a/app/term/[slug]/not-found.tsx
+++ b/app/term/[slug]/not-found.tsx
@@ -1,0 +1,10 @@
+import Link from 'next/link';
+
+export default function NotFound() {
+  return (
+    <div className="p-6">
+      <h2>Page not found</h2>
+      <Link href="/">Go home</Link>
+    </div>
+  );
+}

--- a/app/term/error.tsx
+++ b/app/term/error.tsx
@@ -1,0 +1,15 @@
+'use client';
+import { useEffect } from 'react';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="p-6">
+      <h2>Something went wrong</h2>
+      <button onClick={() => reset()}>Try again</button>
+    </div>
+  );
+}

--- a/app/term/not-found.tsx
+++ b/app/term/not-found.tsx
@@ -1,0 +1,10 @@
+import Link from 'next/link';
+
+export default function NotFound() {
+  return (
+    <div className="p-6">
+      <h2>Page not found</h2>
+      <Link href="/">Go home</Link>
+    </div>
+  );
+}

--- a/app/terms/[slug]/error.tsx
+++ b/app/terms/[slug]/error.tsx
@@ -1,0 +1,15 @@
+'use client';
+import { useEffect } from 'react';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="p-6">
+      <h2>Something went wrong</h2>
+      <button onClick={() => reset()}>Try again</button>
+    </div>
+  );
+}

--- a/app/terms/[slug]/not-found.tsx
+++ b/app/terms/[slug]/not-found.tsx
@@ -1,0 +1,10 @@
+import Link from 'next/link';
+
+export default function NotFound() {
+  return (
+    <div className="p-6">
+      <h2>Page not found</h2>
+      <Link href="/">Go home</Link>
+    </div>
+  );
+}

--- a/app/terms/error.tsx
+++ b/app/terms/error.tsx
@@ -1,0 +1,15 @@
+'use client';
+import { useEffect } from 'react';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="p-6">
+      <h2>Something went wrong</h2>
+      <button onClick={() => reset()}>Try again</button>
+    </div>
+  );
+}

--- a/app/terms/not-found.tsx
+++ b/app/terms/not-found.tsx
@@ -1,0 +1,10 @@
+import Link from 'next/link';
+
+export default function NotFound() {
+  return (
+    <div className="p-6">
+      <h2>Page not found</h2>
+      <Link href="/">Go home</Link>
+    </div>
+  );
+}

--- a/app/word/[slug]/error.tsx
+++ b/app/word/[slug]/error.tsx
@@ -1,0 +1,15 @@
+'use client';
+import { useEffect } from 'react';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="p-6">
+      <h2>Something went wrong</h2>
+      <button onClick={() => reset()}>Try again</button>
+    </div>
+  );
+}

--- a/app/word/[slug]/not-found.tsx
+++ b/app/word/[slug]/not-found.tsx
@@ -1,0 +1,10 @@
+import Link from 'next/link';
+
+export default function NotFound() {
+  return (
+    <div className="p-6">
+      <h2>Page not found</h2>
+      <Link href="/">Go home</Link>
+    </div>
+  );
+}

--- a/app/word/error.tsx
+++ b/app/word/error.tsx
@@ -1,0 +1,15 @@
+'use client';
+import { useEffect } from 'react';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="p-6">
+      <h2>Something went wrong</h2>
+      <button onClick={() => reset()}>Try again</button>
+    </div>
+  );
+}

--- a/app/word/not-found.tsx
+++ b/app/word/not-found.tsx
@@ -1,0 +1,10 @@
+import Link from 'next/link';
+
+export default function NotFound() {
+  return (
+    <div className="p-6">
+      <h2>Page not found</h2>
+      <Link href="/">Go home</Link>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `error.tsx` with retry button for each app route
- add `not-found.tsx` linking back home for each route

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b76eade0148328a81cfa50f9ec305a