### PR TITLE
Handle unhandled rejections and improve API error handling

### DIFF
--- a/api/expand/route.ts
+++ b/api/expand/route.ts
@@ -1,14 +1,21 @@
 import { expandTopic } from '../../lib/ai';
+import { NextResponse } from 'next/server';
 
 /**
  * API route that expands a topic using the configured AI provider.
  * Expects a JSON body: `{ topic: string, prompt?: string, provider?: string }`.
  */
 export async function POST(request: Request): Promise<Response> {
-  const { topic, prompt = '', provider } = await request.json();
-  const combined = prompt ? `${topic}\n\n${prompt}` : topic;
-  const expansion = await expandTopic(combined, provider);
-  return new Response(JSON.stringify({ expansion }), {
-    headers: { 'Content-Type': 'application/json' }
-  });
+  try {
+    const { topic, prompt = '', provider } = await request.json();
+    const combined = prompt ? `${topic}\n\n${prompt}` : topic;
+    const expansion = await expandTopic(combined, provider);
+    return NextResponse.json({ expansion });
+  } catch (error) {
+    console.error('Failed to expand topic', error);
+    return NextResponse.json(
+      { error: 'Failed to expand topic' },
+      { status: 500 }
+    );
+  }
 }

--- a/api/suggest/route.ts
+++ b/api/suggest/route.ts
@@ -1,14 +1,21 @@
 import { chipsForTags } from '../../lib/prompts';
+import { NextResponse } from 'next/server';
 
 /**
  * Return prompt chips for the provided comma separated `tags` query parameter.
  */
 export async function GET(request: Request): Promise<Response> {
-  const url = new URL(request.url);
-  const tagsParam = url.searchParams.get('tags') || '';
-  const tags = tagsParam.split(',').map((t) => t.trim()).filter(Boolean);
-  const suggestions = chipsForTags(tags);
-  return new Response(JSON.stringify({ suggestions }), {
-    headers: { 'Content-Type': 'application/json' }
-  });
+  try {
+    const url = new URL(request.url);
+    const tagsParam = url.searchParams.get('tags') || '';
+    const tags = tagsParam.split(',').map((t) => t.trim()).filter(Boolean);
+    const suggestions = chipsForTags(tags);
+    return NextResponse.json({ suggestions });
+  } catch (error) {
+    console.error('Failed to generate suggestions', error);
+    return NextResponse.json(
+      { error: 'Failed to generate suggestions' },
+      { status: 500 }
+    );
+  }
 }

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,5 +1,6 @@
 import { streamText } from 'ai';
 import { createOpenAI } from '@ai-sdk/openai';
+import { NextResponse } from 'next/server';
 
 // Initialize OpenAI client using the API key from environment variables.
 const openai = createOpenAI({
@@ -24,6 +25,9 @@ export async function POST(req: Request): Promise<Response> {
     return result.toDataStreamResponse();
   } catch (error) {
     console.error('Chat streaming failed', error);
-    return new Response('Failed to generate chat response', { status: 500 });
+    return NextResponse.json(
+      { error: 'Failed to generate chat response' },
+      { status: 500 }
+    );
   }
 }

--- a/app/api/socket/route.ts
+++ b/app/api/socket/route.ts
@@ -1,16 +1,25 @@
 import { Server } from "socket.io";
+import { NextResponse } from 'next/server';
 
 let io: Server | undefined;
 
 export async function GET() {
-  // Lazily initialize the Socket.IO server so it only runs once per server.
-  if (!io) {
-    io = new Server({ path: "/api/socket" });
-    io.on("connection", (socket) => {
-      console.log("Client connected", socket.id);
-    });
-  }
+  try {
+    // Lazily initialize the Socket.IO server so it only runs once per server.
+    if (!io) {
+      io = new Server({ path: '/api/socket' });
+      io.on('connection', (socket) => {
+        console.log('Client connected', socket.id);
+      });
+    }
 
-  // The server is ready; return an empty 200 response.
-  return new Response(null, { status: 200 });
+    // The server is ready; return an empty 200 response.
+    return new Response(null, { status: 200 });
+  } catch (error) {
+    console.error('Socket initialization failed', error);
+    return NextResponse.json(
+      { error: 'Socket initialization failed' },
+      { status: 500 }
+    );
+  }
 }

--- a/app/api/terms/[term]/route.ts
+++ b/app/api/terms/[term]/route.ts
@@ -24,27 +24,37 @@ export async function PUT(
   request: Request,
   { params }: { params: { term: string } }
 ) {
-  const { definition } = await request.json();
-  const terms = await readTerms();
-  const idx = terms.findIndex((t) => t.term === params.term);
-  if (idx === -1) {
-    return NextResponse.json({ error: "not found" }, { status: 404 });
+  try {
+    const { definition } = await request.json();
+    const terms = await readTerms();
+    const idx = terms.findIndex((t) => t.term === params.term);
+    if (idx === -1) {
+      return NextResponse.json({ error: 'not found' }, { status: 404 });
+    }
+    terms[idx].definition = definition;
+    await writeTerms(terms);
+    return NextResponse.json(terms[idx]);
+  } catch (error) {
+    console.error('Failed to update term', error);
+    return NextResponse.json({ error: 'Failed to update term' }, { status: 500 });
   }
-  terms[idx].definition = definition;
-  await writeTerms(terms);
-  return NextResponse.json(terms[idx]);
 }
 
 export async function DELETE(
   request: Request,
   { params }: { params: { term: string } }
 ) {
-  const terms = await readTerms();
-  const idx = terms.findIndex((t) => t.term === params.term);
-  if (idx === -1) {
-    return NextResponse.json({ error: "not found" }, { status: 404 });
+  try {
+    const terms = await readTerms();
+    const idx = terms.findIndex((t) => t.term === params.term);
+    if (idx === -1) {
+      return NextResponse.json({ error: 'not found' }, { status: 404 });
+    }
+    const removed = terms.splice(idx, 1)[0];
+    await writeTerms(terms);
+    return NextResponse.json(removed);
+  } catch (error) {
+    console.error('Failed to delete term', error);
+    return NextResponse.json({ error: 'Failed to delete term' }, { status: 500 });
   }
-  const removed = terms.splice(idx, 1)[0];
-  await writeTerms(terms);
-  return NextResponse.json(removed);
 }

--- a/app/api/terms/route.ts
+++ b/app/api/terms/route.ts
@@ -21,28 +21,38 @@ async function writeTerms(terms: Term[]): Promise<void> {
 }
 
 export async function GET() {
-  const terms = await readTerms();
-  return NextResponse.json(terms);
+  try {
+    const terms = await readTerms();
+    return NextResponse.json(terms);
+  } catch (error) {
+    console.error('Failed to load terms', error);
+    return NextResponse.json({ error: 'Failed to load terms' }, { status: 500 });
+  }
 }
 
 export async function POST(request: Request) {
-  const { term, definition } = await request.json();
-  if (!term || !definition) {
-    return NextResponse.json(
-      { error: "term and definition are required" },
-      { status: 400 }
-    );
-  }
+  try {
+    const { term, definition } = await request.json();
+    if (!term || !definition) {
+      return NextResponse.json(
+        { error: 'term and definition are required' },
+        { status: 400 }
+      );
+    }
 
-  const terms = await readTerms();
-  if (terms.some((t) => t.term === term)) {
-    return NextResponse.json(
-      { error: "term already exists" },
-      { status: 409 }
-    );
-  }
+    const terms = await readTerms();
+    if (terms.some((t) => t.term === term)) {
+      return NextResponse.json(
+        { error: 'term already exists' },
+        { status: 409 }
+      );
+    }
 
-  terms.push({ term, definition });
-  await writeTerms(terms);
-  return NextResponse.json({ term, definition }, { status: 201 });
+    terms.push({ term, definition });
+    await writeTerms(terms);
+    return NextResponse.json({ term, definition }, { status: 201 });
+  } catch (error) {
+    console.error('Failed to create term', error);
+    return NextResponse.json({ error: 'Failed to create term' }, { status: 500 });
+  }
 }

--- a/lib/ai.ts
+++ b/lib/ai.ts
@@ -21,42 +21,50 @@ export async function expandTopic(
 async function openAIExpand(topic: string): Promise<string> {
   const apiKey = process.env.OPENAI_API_KEY;
   if (!apiKey) throw new Error('Missing OPENAI_API_KEY');
-
-  const res = await fetch('https://api.openai.com/v1/chat/completions', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${apiKey}`
-    },
-    body: JSON.stringify({
-      model: 'gpt-4o-mini',
-      messages: [{ role: 'user', content: `Expand on: ${topic}` }]
-    })
-  });
-  const data = await res.json();
-  // OpenAI responses may vary in structure; attempt to retrieve the text safely.
-  const text = data?.choices?.[0]?.message?.content;
-  return typeof text === 'string' ? text.trim() : '';
+  try {
+    const res = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`
+      },
+      body: JSON.stringify({
+        model: 'gpt-4o-mini',
+        messages: [{ role: 'user', content: `Expand on: ${topic}` }]
+      })
+    });
+    const data = await res.json();
+    // OpenAI responses may vary in structure; attempt to retrieve the text safely.
+    const text = data?.choices?.[0]?.message?.content;
+    return typeof text === 'string' ? text.trim() : '';
+  } catch (error) {
+    console.error('OpenAI expansion failed', error);
+    throw new Error('OpenAI expansion failed');
+  }
 }
 
 async function anthropicExpand(topic: string): Promise<string> {
   const apiKey = process.env.ANTHROPIC_API_KEY;
   if (!apiKey) throw new Error('Missing ANTHROPIC_API_KEY');
-
-  const res = await fetch('https://api.anthropic.com/v1/messages', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'x-api-key': apiKey,
-      'anthropic-version': '2023-06-01'
-    },
-    body: JSON.stringify({
-      model: 'claude-3-haiku-20240307',
-      max_tokens: 256,
-      messages: [{ role: 'user', content: `Expand on: ${topic}` }]
-    })
-  });
-  const data = await res.json();
-  const text = data?.content?.[0]?.text;
-  return typeof text === 'string' ? text.trim() : '';
+  try {
+    const res = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': apiKey,
+        'anthropic-version': '2023-06-01'
+      },
+      body: JSON.stringify({
+        model: 'claude-3-haiku-20240307',
+        max_tokens: 256,
+        messages: [{ role: 'user', content: `Expand on: ${topic}` }]
+      })
+    });
+    const data = await res.json();
+    const text = data?.content?.[0]?.text;
+    return typeof text === 'string' ? text.trim() : '';
+  } catch (error) {
+    console.error('Anthropic expansion failed', error);
+    throw new Error('Anthropic expansion failed');
+  }
 }

--- a/server.js
+++ b/server.js
@@ -2,6 +2,13 @@ const http = require('http');
 const path = require('path');
 const fs = require('fs');
 
+// Log unhandled promise rejections during development to aid debugging
+if (process.env.NODE_ENV !== 'production') {
+  process.on('unhandledRejection', (reason, promise) => {
+    console.error('Unhandled Rejection at:', promise, 'reason:', reason);
+  });
+}
+
 // In-memory token buckets keyed by IP
 const buckets = new Map();
 const MAX_TOKENS = 100; // max requests per interval


### PR DESCRIPTION
## Summary
- log unhandled promise rejections in development
- add try/catch and NextResponse error handling across API routes
- wrap AI expansion utilities with error handling

## Testing
- `npm test`
- `node server.js & sleep 1; kill $!`

------
https://chatgpt.com/codex/tasks/task_e_68b76eac88fc83288698bce1089e6208