### PR TITLE
Add hydration regression test with Playwright

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,13 @@ jobs:
           cache: npm
       - name: Install
         run: npm ci
+      - name: Install Playwright
+        run: npx playwright install --with-deps
       - name: Lint
         run: npm run lint
       - name: Test
-        run: npm test
+        run: |
+          npm test
+          npx playwright test
       - name: Build
         run: npm run build

--- a/tests/hydration.spec.ts
+++ b/tests/hydration.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect } from "@playwright/test";
+import path from "path";
+
+// Pages to verify hydration: route is for test name only
+const pages = [
+  { route: "/", file: "index.html" },
+  { route: "/search", file: "search.html" },
+  { route: "/term/cidr", file: "cidr.html" },
+  { route: "/chat", file: "chat.html" },
+];
+
+for (const { route, file } of pages) {
+  test(`hydration markup for ${route} matches server output`, async ({
+    browser,
+  }) => {
+    const filePath = path.join(__dirname, "..", file);
+    const url = "file://" + filePath;
+
+    // Helper to grab comparable HTML while ignoring dynamic-only sections
+    const getSanitizedHTML = async (p: import("@playwright/test").Page) => {
+      return await p.evaluate(() => {
+        const body = document.body.cloneNode(true) as HTMLElement;
+        body.querySelectorAll("[data-pro-only]").forEach((el) => el.remove());
+        body.querySelectorAll("#search-help").forEach((el) => el.remove());
+        body.querySelectorAll(".skeleton").forEach((el) => el.remove());
+        const searchWrapper = body.querySelector("#search-wrapper");
+        if (searchWrapper) {
+          const searchInput = searchWrapper.querySelector("#search");
+          searchWrapper.replaceWith(searchInput as Node);
+        }
+        const searchInput = body.querySelector("#search");
+        if (searchInput) {
+          searchInput.removeAttribute("style");
+        }
+        body
+          .querySelectorAll("#search-token-overlay")
+          .forEach((el) => el.remove());
+        body
+          .querySelectorAll("#definition-container")
+          .forEach((el) => el.remove());
+        return body.innerHTML;
+      });
+    };
+
+    // Get server-rendered HTML with JS disabled
+    const staticContext = await browser.newContext({
+      javaScriptEnabled: false,
+    });
+    const staticPage = await staticContext.newPage();
+    await staticPage.goto(url);
+    const serverHTML = await getSanitizedHTML(staticPage);
+    await staticContext.close();
+
+    // Get hydrated HTML with JS enabled
+    const hydratedContext = await browser.newContext();
+    const hydratedPage = await hydratedContext.newPage();
+    await hydratedPage.goto(url);
+    await hydratedPage.waitForLoadState("networkidle");
+    const hydratedHTML = await getSanitizedHTML(hydratedPage);
+    await hydratedContext.close();
+
+    expect(hydratedHTML).toBe(serverHTML);
+  });
+}


### PR DESCRIPTION
## Summary
- add Playwright spec checking server vs hydrated HTML for key pages
- run Playwright in CI with browsers installed

## Testing
- `npm test`
- `npx playwright test tests/hydration.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b76ea9fecc8328a783a4c88d5650b4