### PR TITLE
Unify term loaders on canonical MDX content model

### DIFF
--- a/app/[category]/page.tsx
+++ b/app/[category]/page.tsx
@@ -1,14 +1,5 @@
 import React from "react";
-import fs from "fs";
-import path from "path";
-import yaml from "js-yaml";
-
-interface Term {
-  name: string;
-  slug?: string;
-  definition: string;
-  category?: string;
-}
+import { getAllTerms } from "@/lib/content/api";
 
 function slugify(value: string) {
   return value
@@ -17,17 +8,9 @@ function slugify(value: string) {
     .replace(/^-+|-+$/g, "");
 }
 
-function getTerms(): Term[] {
-  const filePath = path.join(process.cwd(), "data", "terms.yaml");
-  const file = fs.readFileSync(filePath, "utf8");
-  return yaml.load(file) as Term[];
-}
-
 export async function generateStaticParams() {
-  const terms = getTerms();
-  const categories = Array.from(
-    new Set(terms.map((t) => t.category).filter(Boolean)),
-  );
+  const terms = getAllTerms();
+  const categories = Array.from(new Set(terms.map((t) => t.category).filter(Boolean)));
   return categories.map((category) => ({
     category: slugify(category as string),
   }));
@@ -38,7 +21,7 @@ export default function CategoryPage({
 }: {
   params: { category: string };
 }) {
-  const terms = getTerms();
+  const terms = getAllTerms();
   const categoryTerms = terms.filter(
     (t) => t.category && slugify(t.category) === params.category,
   );
@@ -54,8 +37,8 @@ export default function CategoryPage({
       <h1>{categoryName}</h1>
       <ul>
         {categoryTerms.map((term) => (
-          <li key={term.slug || slugify(term.name)}>
-            <strong>{term.name}</strong>: {term.definition}
+          <li key={term.slug}>
+            <strong>{term.title}</strong>: {term.definition}
           </li>
         ))}
       </ul>

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -1,9 +1,11 @@
 import { NextResponse } from "next/server";
-import data from "../../../terms.json";
+import { getSearchIndex } from "@/lib/content/api";
 
 interface Term {
   term: string;
   definition: string;
+  slug: string;
+  synonyms?: string[];
 }
 
 interface SearchResponse {
@@ -43,7 +45,7 @@ export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const query = searchParams.get("q")?.trim().toLowerCase() ?? "";
 
-  const terms: Term[] = (data as any).terms || [];
+  const terms: Term[] = getSearchIndex();
 
   if (!query) {
     return NextResponse.json({ results: [], suggestions: [] } as SearchResponse);
@@ -52,7 +54,8 @@ export async function GET(request: Request) {
   const results = terms.filter(
     (t) =>
       t.term.toLowerCase().includes(query) ||
-      t.definition.toLowerCase().includes(query)
+      t.definition.toLowerCase().includes(query) ||
+      (t.synonyms || []).some((s) => s.toLowerCase().includes(query))
   );
   const exact = terms.find((t) => t.term.toLowerCase() === query);
 

--- a/app/term/[slug]/page.tsx
+++ b/app/term/[slug]/page.tsx
@@ -1,29 +1,21 @@
-import fs from 'node:fs/promises';
-import path from 'node:path';
 import { notFound } from 'next/navigation';
-import matter from 'gray-matter';
 import TermPage from '@/components/term/TermPage';
+import { getAllTerms, getTermBySlug } from '@/lib/content/api';
 
 interface PageProps {
   params: { slug: string };
 }
 
 export default async function Page({ params }: PageProps) {
-  const filePath = path.join(process.cwd(), 'terms', `${params.slug}.mdx`);
-  let file: string;
-  try {
-    file = await fs.readFile(filePath, 'utf8');
-  } catch {
+  const term = getTermBySlug(params.slug);
+
+  if (!term) {
     notFound();
   }
-  const { content, data } = matter(file!);
-  return <TermPage title={data.title ?? params.slug} body={content} sources={data.sources} />;
+
+  return <TermPage title={term.title} body={term.body} />;
 }
 
 export async function generateStaticParams() {
-  const dir = path.join(process.cwd(), 'terms');
-  const entries = await fs.readdir(dir, { withFileTypes: true });
-  return entries
-    .filter((e) => e.isFile() && e.name.endsWith('.mdx'))
-    .map((e) => ({ slug: e.name.replace(/\.mdx$/, '') }));
+  return getAllTerms().map((term) => ({ slug: term.slug }));
 }

--- a/app/terms/[slug]/page.tsx
+++ b/app/terms/[slug]/page.tsx
@@ -1,28 +1,13 @@
 import React from "react";
-import fs from "fs";
-import path from "path";
-import yaml from "js-yaml";
 import { FAQBlock } from "../../components/FAQBlock";
-
-interface Term {
-  name: string;
-  slug: string;
-  definition: string;
-  synonyms?: string[];
-}
-
-function loadTerms(): Term[] {
-  const filePath = path.join(process.cwd(), "data", "terms.yaml");
-  const file = fs.readFileSync(filePath, "utf8");
-  return yaml.load(file) as Term[];
-}
+import { getAllTerms, getTermBySlug } from "@/lib/content/api";
 
 export async function generateStaticParams() {
-  return loadTerms().map((term) => ({ slug: term.slug }));
+  return getAllTerms().map((term) => ({ slug: term.slug }));
 }
 
 export default function TermPage({ params }: { params: { slug: string } }) {
-  const term = loadTerms().find((t) => t.slug === params.slug);
+  const term = getTermBySlug(params.slug);
 
   if (!term) {
     return <div>Term not found</div>;
@@ -31,21 +16,21 @@ export default function TermPage({ params }: { params: { slug: string } }) {
   const termJsonLd = {
     "@context": "https://schema.org",
     "@type": "DefinedTerm",
-    name: term.name,
+    name: term.title,
     description: term.definition,
     url: `https://example.com/terms/${params.slug}`,
   };
 
   const faqItems = [
     {
-      question: `What is ${term.name}?`,
+      question: `What is ${term.title}?`,
       answer: term.definition,
     },
   ];
 
   return (
     <main>
-      <h1>{term.name}</h1>
+      <h1>{term.title}</h1>
       <p>{term.definition}</p>
       {term.synonyms && term.synonyms.length > 0 && (
         <p>

--- a/docs/content-model.md
+++ b/docs/content-model.md
@@ -1,0 +1,55 @@
+# Content Model
+
+This project uses **`content/terms/*.mdx`** as the canonical source of truth for term content.
+
+## Canonical folder layout
+
+```text
+content/
+  terms/
+    <slug>.mdx
+    sql-injection.mdx
+    zero-trust.mdx
+    ...
+```
+
+- Each file name should be the canonical slug (kebab-case).
+- Each term should live in exactly one MDX file under `content/terms`.
+- Runtime loaders and search indexing read from this directory via `lib/content/api.ts`.
+
+## Expected frontmatter schema
+
+Recommended frontmatter:
+
+```yaml
+---
+title: "SQL Injection"          # string, recommended
+slug: sql-injection              # string, optional if filename matches
+shortDefinition: "..."          # string, optional summary used in some views
+category: "Application Security"# string, optional
+tags:                            # string[], optional
+  - owasp
+  - injection
+synonyms:                        # string[], optional
+  - SQLi
+see_also:                        # string[], optional slugs
+  - injection
+sources:                         # string[], optional canonical source URLs
+  - https://owasp.org/Top10/A03_2021-Injection/
+---
+```
+
+Notes:
+- `title` is strongly recommended. If omitted, loaders may fall back to first markdown heading (`# Heading`) or a titleized slug.
+- `slug` should match the filename when provided.
+- Prefer stable, canonical URLs in `sources`.
+
+## Validation behavior
+
+At startup/build time, the content loader validates that `content/terms` exists and is a directory.
+If it is missing, the app throws an error and fails fast.
+
+## YAML loader status
+
+Legacy YAML-based loading (`data/terms.yaml`) has been removed from runtime loaders.
+All term reads should go through the canonical MDX loader in `lib/content/api.ts`.

--- a/lib/content/api.ts
+++ b/lib/content/api.ts
@@ -1,12 +1,63 @@
-import * as fs from 'fs';
-import * as path from 'path';
-import { load } from 'js-yaml';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import matter from 'gray-matter';
+
+const CANONICAL_TERMS_DIR = path.join(process.cwd(), 'content', 'terms');
+
+function slugToTitle(slug: string): string {
+  return slug
+    .split('-')
+    .filter(Boolean)
+    .map((part) => part[0].toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+function extractHeading(content: string): string | undefined {
+  const heading = content.match(/^#\s+(.+)$/m);
+  return heading?.[1]?.trim();
+}
+
+function markdownToPlainText(markdown: string): string {
+  return markdown
+    .replace(/```[\s\S]*?```/g, ' ')
+    .replace(/`[^`]+`/g, ' ')
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, ' ')
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+    .replace(/^#{1,6}\s+/gm, '')
+    .replace(/\[\^\d+\]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function firstSentence(text: string): string {
+  if (!text) return '';
+  const sentence = text.match(/[^.!?]+[.!?]/)?.[0]?.trim();
+  return sentence || text;
+}
+
+function assertCanonicalTermsDirectoryExists(): void {
+  if (!fs.existsSync(CANONICAL_TERMS_DIR)) {
+    throw new Error(
+      `Canonical terms directory is missing: ${CANONICAL_TERMS_DIR}. Expected content under content/terms/*.mdx.`
+    );
+  }
+
+  const stats = fs.statSync(CANONICAL_TERMS_DIR);
+  if (!stats.isDirectory()) {
+    throw new Error(
+      `Canonical terms path is not a directory: ${CANONICAL_TERMS_DIR}. Expected content under content/terms/*.mdx.`
+    );
+  }
+}
 
 export interface Term {
   name: string;
+  title: string;
   slug: string;
   definition: string;
+  body: string;
   category?: string;
+  tags?: string[];
   synonyms?: string[];
   see_also?: string[];
   sources?: string[];
@@ -14,16 +65,48 @@ export interface Term {
 
 let cachedTerms: Term[] | null = null;
 
+function parseTermFile(filePath: string): Term {
+  const file = fs.readFileSync(filePath, 'utf8');
+  const { content, data } = matter(file);
+  const fallbackSlug = path.basename(filePath, '.mdx');
+  const slug = String(data.slug || fallbackSlug);
+  const title = String(data.title || extractHeading(content) || slugToTitle(slug));
+  const plainText = markdownToPlainText(content);
+
+  return {
+    name: title,
+    title,
+    slug,
+    definition: String(data.shortDefinition || firstSentence(plainText) || title),
+    body: content,
+    category: typeof data.category === 'string' ? data.category : undefined,
+    tags: Array.isArray(data.tags) ? data.tags.filter((t): t is string => typeof t === 'string') : undefined,
+    synonyms: Array.isArray(data.synonyms)
+      ? data.synonyms.filter((s): s is string => typeof s === 'string')
+      : undefined,
+    see_also: Array.isArray(data.see_also)
+      ? data.see_also.filter((s): s is string => typeof s === 'string')
+      : undefined,
+    sources: Array.isArray(data.sources)
+      ? data.sources.filter((s): s is string => typeof s === 'string')
+      : undefined,
+  };
+}
+
 function loadTerms(): Term[] {
   if (cachedTerms) {
     return cachedTerms;
   }
-  const filePath = path.join(__dirname, '../../data/terms.yaml');
-  const file = fs.readFileSync(filePath, 'utf8');
-  const loaded = load(file) as Term[] | { terms: Term[] };
-  const terms = Array.isArray(loaded) ? loaded : (loaded as { terms: Term[] }).terms;
-  cachedTerms = terms;
-  return terms;
+
+  assertCanonicalTermsDirectoryExists();
+
+  const entries = fs
+    .readdirSync(CANONICAL_TERMS_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.mdx'))
+    .map((entry) => path.join(CANONICAL_TERMS_DIR, entry.name));
+
+  cachedTerms = entries.map(parseTermFile).sort((a, b) => a.title.localeCompare(b.title));
+  return cachedTerms;
 }
 
 export function getAllTerms(): Term[] {
@@ -33,3 +116,18 @@ export function getAllTerms(): Term[] {
 export function getTermBySlug(slug: string): Term | undefined {
   return loadTerms().find((t) => t.slug === slug);
 }
+
+export function getSearchIndex(): Array<{ term: string; definition: string; slug: string; synonyms: string[] }> {
+  return loadTerms().map((term) => ({
+    term: term.title,
+    definition: term.definition,
+    slug: term.slug,
+    synonyms: term.synonyms || [],
+  }));
+}
+
+export function validateContentModel(): void {
+  assertCanonicalTermsDirectoryExists();
+}
+
+validateContentModel();

--- a/lib/search/runtime.ts
+++ b/lib/search/runtime.ts
@@ -1,10 +1,9 @@
-import { readFileSync } from "fs";
-import path from "path";
+import { getSearchIndex } from "@/lib/content/api";
 
 interface TermEntry {
-  term?: string;
-  name?: string;
-  definition?: string;
+  term: string;
+  definition: string;
+  slug: string;
   synonyms?: string[];
   [key: string]: any;
 }
@@ -13,10 +12,7 @@ let cache: TermEntry[] | null = null;
 
 function loadIndex(): TermEntry[] {
   if (!cache) {
-    const indexPath = path.resolve(__dirname, "../../index.json");
-    const raw = readFileSync(indexPath, "utf8");
-    const data = JSON.parse(raw);
-    cache = Array.isArray(data) ? data : data.terms || [];
+    cache = getSearchIndex();
   }
   return cache;
 }
@@ -25,12 +21,10 @@ export function search(query: string): TermEntry[] {
   if (!query) return [];
   const q = query.toLowerCase();
   return loadIndex().filter((entry) => {
-    const term = (entry.term || entry.name || "").toLowerCase();
+    const term = (entry.term || "").toLowerCase();
     const def = (entry.definition || "").toLowerCase();
     const syns = (entry.synonyms || []).map((s) => s.toLowerCase());
-    return (
-      term.includes(q) || def.includes(q) || syns.some((s) => s.includes(q))
-    );
+    return term.includes(q) || def.includes(q) || syns.some((s) => s.includes(q));
   });
 }
 
@@ -39,9 +33,9 @@ export function suggest(query: string): string[] {
   const q = query.toLowerCase();
   const suggestions: string[] = [];
   for (const entry of loadIndex()) {
-    const term = (entry.term || entry.name || "").toLowerCase();
+    const term = (entry.term || "").toLowerCase();
     if (term.startsWith(q)) {
-      suggestions.push(entry.term || entry.name || "");
+      suggestions.push(entry.term || "");
     }
   }
   return suggestions.slice(0, 10);


### PR DESCRIPTION
### Motivation
- Centralize term content on a single canonical source (`content/terms/*.mdx`) so all runtime loaders and search use the same MDX frontmatter and body data. 
- Remove scattered YAML/JSON runtime loading to simplify maintenance and avoid duplicate sources of truth. 
- Fail fast at startup/build time when the canonical content directory is missing to surface configuration errors early.

### Description
- Added a canonical MDX loader `lib/content/api.ts` that parses `content/terms/*.mdx` with `gray-matter`, normalizes frontmatter, extracts title/definition/body, exposes `getAllTerms`, `getTermBySlug`, and `getSearchIndex`, and runs `validateContentModel()` at load time. 
- Updated route loaders to use the shared API: `app/term/[slug]/page.tsx`, `app/terms/[slug]/page.tsx`, and `app/[category]/page.tsx` now call `getAllTerms` / `getTermBySlug` instead of reading YAML/JSON or ad-hoc files. 
- Reworked search plumbing to use the canonical index by changing `app/api/search/route.ts` and `lib/search/runtime.ts` to call `getSearchIndex()` and include `synonyms` and `slug` in the index. 
- Removed legacy runtime YAML loader logic and documented the new model in `docs/content-model.md`, including expected frontmatter fields and folder layout.

### Testing
- Ran the repository test script via `npm test`, which completed successfully and reported: `Diagnostics render test passed` and `useCopyFormats tests passed`.
- The content loader performs startup/build-time validation and will throw if `content/terms` is missing, which was exercised during the module import in the updated runtime.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ede6dbaa188328a1a1032f6f7a3652)