### PR TITLE
Harden API mutations with storage layer, auth, validation, rate limits, and audit logs

### DIFF
--- a/app/api/feedback/route.ts
+++ b/app/api/feedback/route.ts
@@ -1,54 +1,30 @@
 import { NextResponse } from 'next/server';
-import fs from 'node:fs/promises';
-import path from 'node:path';
+import type { NextRequest } from 'next/server';
+import { errorResponse } from '../../../lib/api/errors';
+import { feedbackSchema } from '../../../lib/schemas/api-schemas';
+import { appendAuditLog } from '../../../lib/storage/audit-storage';
+import { addFeedback } from '../../../lib/storage/feedback-storage';
 
-interface Feedback {
-  message: string;
-  email?: string;
-  timestamp: string;
-}
-
-const feedbackFile = path.join(process.cwd(), 'feedback.json');
-
-export async function POST(request: Request) {
+export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
-    const message: string | undefined = body.message?.trim();
-    const email: string | undefined = body.email?.trim();
-
-    if (!message) {
-      return NextResponse.json(
-        { success: false, error: 'Message is required' },
-        { status: 400 }
-      );
+    const parsed = feedbackSchema.safeParse(await request.json());
+    if (!parsed.success) {
+      return errorResponse(400, 'VALIDATION_ERROR', 'Invalid feedback payload.', parsed.error.flatten());
     }
 
-    let feedback: Feedback[] = [];
-    try {
-      const existing = await fs.readFile(feedbackFile, 'utf8');
-      feedback = JSON.parse(existing);
-    } catch (err: any) {
-      if (err.code !== 'ENOENT') {
-        throw err;
-      }
-    }
+    const saved = await addFeedback(parsed.data);
+    const actor = request.headers.get('x-actor') || 'anonymous';
 
-    const entry: Feedback = {
-      message,
-      email,
-      timestamp: new Date().toISOString(),
-    };
+    await appendAuditLog({
+      actor,
+      action: 'feedback.create',
+      target: 'feedback',
+      details: { hasEmail: Boolean(parsed.data.email) },
+    });
 
-    feedback.push(entry);
-    await fs.writeFile(feedbackFile, JSON.stringify(feedback, null, 2));
-
-    return NextResponse.json({ success: true });
+    return NextResponse.json({ success: true, data: saved });
   } catch (error) {
     console.error('Failed to save feedback', error);
-    return NextResponse.json(
-      { success: false, error: 'Internal server error' },
-      { status: 500 }
-    );
+    return errorResponse(500, 'INTERNAL_ERROR', 'Internal server error');
   }
 }
-

--- a/app/api/terms/[term]/route.ts
+++ b/app/api/terms/[term]/route.ts
@@ -1,50 +1,66 @@
 import { NextResponse } from "next/server";
-import { promises as fs } from "fs";
-import path from "path";
-
-const dataFile = path.join(process.cwd(), "terms.json");
-
-interface Term {
-  term: string;
-  definition: string;
-}
-
-async function readTerms(): Promise<Term[]> {
-  const data = await fs.readFile(dataFile, "utf8");
-  const parsed = JSON.parse(data);
-  return parsed.terms || [];
-}
-
-async function writeTerms(terms: Term[]): Promise<void> {
-  const data = JSON.stringify({ terms }, null, 2);
-  await fs.writeFile(dataFile, data);
-}
+import { errorResponse } from "../../../../lib/api/errors";
+import { termUpdateSchema } from "../../../../lib/schemas/api-schemas";
+import { appendAuditLog } from "../../../../lib/storage/audit-storage";
+import { deleteTerm, updateTerm } from "../../../../lib/storage/terms-storage";
+import type { NextRequest } from "next/server";
 
 export async function PUT(
-  request: Request,
+  request: NextRequest,
   { params }: { params: { term: string } }
 ) {
-  const { definition } = await request.json();
-  const terms = await readTerms();
-  const idx = terms.findIndex((t) => t.term === params.term);
-  if (idx === -1) {
-    return NextResponse.json({ error: "not found" }, { status: 404 });
+  const parsed = termUpdateSchema.safeParse(await request.json());
+  if (!parsed.success) {
+    return errorResponse(400, "VALIDATION_ERROR", "Invalid term update payload.", parsed.error.flatten());
   }
-  terms[idx].definition = definition;
-  await writeTerms(terms);
-  return NextResponse.json(terms[idx]);
+
+  const headerVersion = request.headers.get("if-match");
+  const expectedVersion = parsed.data.expectedVersion ?? (headerVersion ? Number(headerVersion) : undefined);
+
+  try {
+    const updated = await updateTerm(params.term, {
+      definition: parsed.data.definition,
+      expectedVersion,
+    });
+    await appendAuditLog({
+      actor: request.headers.get("x-actor") || "api-key-client",
+      action: "term.update",
+      target: params.term,
+      details: { previousExpectedVersion: expectedVersion, newVersion: updated.version },
+    });
+
+    return NextResponse.json(updated);
+  } catch (error: any) {
+    if (error?.message === "TERM_NOT_FOUND") {
+      return errorResponse(404, "NOT_FOUND", "Term not found.");
+    }
+    if (error?.message === "VERSION_CONFLICT") {
+      return errorResponse(409, "VERSION_CONFLICT", "Version mismatch. Refresh and retry with the latest version.");
+    }
+
+    console.error("Failed to update term", error);
+    return errorResponse(500, "INTERNAL_ERROR", "Internal server error");
+  }
 }
 
 export async function DELETE(
-  request: Request,
+  request: NextRequest,
   { params }: { params: { term: string } }
 ) {
-  const terms = await readTerms();
-  const idx = terms.findIndex((t) => t.term === params.term);
-  if (idx === -1) {
-    return NextResponse.json({ error: "not found" }, { status: 404 });
+  try {
+    const removed = await deleteTerm(params.term);
+    await appendAuditLog({
+      actor: request.headers.get("x-actor") || "api-key-client",
+      action: "term.delete",
+      target: params.term,
+      details: { removedVersion: removed.version },
+    });
+    return NextResponse.json(removed);
+  } catch (error: any) {
+    if (error?.message === "TERM_NOT_FOUND") {
+      return errorResponse(404, "NOT_FOUND", "Term not found.");
+    }
+    console.error("Failed to delete term", error);
+    return errorResponse(500, "INTERNAL_ERROR", "Internal server error");
   }
-  const removed = terms.splice(idx, 1)[0];
-  await writeTerms(terms);
-  return NextResponse.json(removed);
 }

--- a/app/api/terms/route.ts
+++ b/app/api/terms/route.ts
@@ -1,48 +1,37 @@
 import { NextResponse } from "next/server";
-import { promises as fs } from "fs";
-import path from "path";
-
-const dataFile = path.join(process.cwd(), "terms.json");
-
-interface Term {
-  term: string;
-  definition: string;
-}
-
-async function readTerms(): Promise<Term[]> {
-  const data = await fs.readFile(dataFile, "utf8");
-  const parsed = JSON.parse(data);
-  return parsed.terms || [];
-}
-
-async function writeTerms(terms: Term[]): Promise<void> {
-  const data = JSON.stringify({ terms }, null, 2);
-  await fs.writeFile(dataFile, data);
-}
+import { errorResponse } from "../../../lib/api/errors";
+import { termCreateSchema } from "../../../lib/schemas/api-schemas";
+import { appendAuditLog } from "../../../lib/storage/audit-storage";
+import { createTerm, listTerms } from "../../../lib/storage/terms-storage";
+import type { NextRequest } from "next/server";
 
 export async function GET() {
-  const terms = await readTerms();
+  const terms = await listTerms();
   return NextResponse.json(terms);
 }
 
-export async function POST(request: Request) {
-  const { term, definition } = await request.json();
-  if (!term || !definition) {
-    return NextResponse.json(
-      { error: "term and definition are required" },
-      { status: 400 }
-    );
+export async function POST(request: NextRequest) {
+  const parsed = termCreateSchema.safeParse(await request.json());
+  if (!parsed.success) {
+    return errorResponse(400, "VALIDATION_ERROR", "Invalid term payload.", parsed.error.flatten());
   }
 
-  const terms = await readTerms();
-  if (terms.some((t) => t.term === term)) {
-    return NextResponse.json(
-      { error: "term already exists" },
-      { status: 409 }
-    );
-  }
+  try {
+    const created = await createTerm(parsed.data);
+    await appendAuditLog({
+      actor: request.headers.get("x-actor") || "api-key-client",
+      action: "term.create",
+      target: parsed.data.term,
+      details: { version: created.version },
+    });
 
-  terms.push({ term, definition });
-  await writeTerms(terms);
-  return NextResponse.json({ term, definition }, { status: 201 });
+    return NextResponse.json(created, { status: 201 });
+  } catch (error: any) {
+    if (error?.message === "TERM_EXISTS") {
+      return errorResponse(409, "TERM_EXISTS", "A term with this name already exists.");
+    }
+
+    console.error("Failed to create term", error);
+    return errorResponse(500, "INTERNAL_ERROR", "Internal server error");
+  }
 }

--- a/lib/api/auth.ts
+++ b/lib/api/auth.ts
@@ -1,0 +1,48 @@
+import { NextRequest } from 'next/server';
+import { errorResponse } from './errors';
+
+const mutatingMethods = new Set(['POST', 'PUT', 'DELETE', 'PATCH']);
+
+export interface AuthContext {
+  actor: string;
+  role: string;
+}
+
+export function authorizeMutation(request: NextRequest): { ok: true; auth: AuthContext } | { ok: false; response: Response } {
+  if (!mutatingMethods.has(request.method)) {
+    return { ok: true, auth: { actor: 'anonymous', role: 'viewer' } };
+  }
+
+  const apiKey = request.headers.get('x-api-key');
+  const configuredKey = process.env.API_WRITE_TOKEN;
+
+  if (!configuredKey) {
+    return {
+      ok: false,
+      response: errorResponse(503, 'AUTH_NOT_CONFIGURED', 'Mutation auth is not configured on the server.'),
+    };
+  }
+
+  if (!apiKey || apiKey !== configuredKey) {
+    return {
+      ok: false,
+      response: errorResponse(401, 'UNAUTHORIZED', 'A valid x-api-key is required for mutating routes.'),
+    };
+  }
+
+  const role = request.headers.get('x-role') || 'editor';
+  if (!['admin', 'editor'].includes(role)) {
+    return {
+      ok: false,
+      response: errorResponse(403, 'FORBIDDEN', 'Insufficient role to modify resources.'),
+    };
+  }
+
+  return {
+    ok: true,
+    auth: {
+      actor: request.headers.get('x-actor') || 'api-key-client',
+      role,
+    },
+  };
+}

--- a/lib/api/errors.ts
+++ b/lib/api/errors.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server';
+
+export function errorResponse(status: number, code: string, message: string, details?: unknown) {
+  return NextResponse.json(
+    {
+      success: false,
+      error: {
+        code,
+        message,
+        details,
+      },
+    },
+    { status }
+  );
+}

--- a/lib/api/rate-limit.ts
+++ b/lib/api/rate-limit.ts
@@ -1,0 +1,50 @@
+import { NextRequest } from 'next/server';
+
+interface Bucket {
+  count: number;
+  resetAt: number;
+}
+
+const buckets = new Map<string, Bucket>();
+
+function getClientId(request: NextRequest): string {
+  const fwd = request.headers.get('x-forwarded-for');
+  if (fwd) {
+    return fwd.split(',')[0].trim();
+  }
+
+  return request.headers.get('x-real-ip') || 'unknown-client';
+}
+
+export function consumeRateLimit(
+  request: NextRequest,
+  options: { routeKey: string; limit: number; windowMs: number }
+): { allowed: true; remaining: number; resetAt: number } | { allowed: false; retryAfterSec: number } {
+  const now = Date.now();
+  const key = `${options.routeKey}:${getClientId(request)}`;
+  const bucket = buckets.get(key);
+
+  if (!bucket || bucket.resetAt <= now) {
+    buckets.set(key, { count: 1, resetAt: now + options.windowMs });
+    return {
+      allowed: true,
+      remaining: options.limit - 1,
+      resetAt: now + options.windowMs,
+    };
+  }
+
+  if (bucket.count >= options.limit) {
+    return {
+      allowed: false,
+      retryAfterSec: Math.max(1, Math.ceil((bucket.resetAt - now) / 1000)),
+    };
+  }
+
+  bucket.count += 1;
+  buckets.set(key, bucket);
+  return {
+    allowed: true,
+    remaining: options.limit - bucket.count,
+    resetAt: bucket.resetAt,
+  };
+}

--- a/lib/schemas/api-schemas.ts
+++ b/lib/schemas/api-schemas.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+
+export const feedbackSchema = z.object({
+  message: z.string().trim().min(1, 'Message is required').max(5000, 'Message is too long'),
+  email: z.string().trim().email('Email must be valid').optional(),
+});
+
+export const termCreateSchema = z.object({
+  term: z.string().trim().min(1, 'Term is required').max(200, 'Term is too long'),
+  definition: z.string().trim().min(1, 'Definition is required').max(10000, 'Definition is too long'),
+});
+
+export const termUpdateSchema = z.object({
+  definition: z.string().trim().min(1, 'Definition is required').max(10000, 'Definition is too long'),
+  expectedVersion: z.number().int().positive().optional(),
+});

--- a/lib/storage/audit-storage.ts
+++ b/lib/storage/audit-storage.ts
@@ -1,0 +1,17 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import { AuditLogEntry } from './types';
+
+const auditFile = path.join(process.cwd(), 'audit-log.jsonl');
+
+export async function appendAuditLog(entry: Omit<AuditLogEntry, 'id' | 'timestamp'>): Promise<AuditLogEntry> {
+  const complete: AuditLogEntry = {
+    id: crypto.randomUUID(),
+    timestamp: new Date().toISOString(),
+    ...entry,
+  };
+
+  await fs.appendFile(auditFile, `${JSON.stringify(complete)}\n`, 'utf8');
+  return complete;
+}

--- a/lib/storage/feedback-storage.ts
+++ b/lib/storage/feedback-storage.ts
@@ -1,0 +1,32 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { FeedbackRecord } from './types';
+
+const feedbackFile = path.join(process.cwd(), 'feedback.json');
+
+export async function listFeedback(): Promise<FeedbackRecord[]> {
+  try {
+    const raw = await fs.readFile(feedbackFile, 'utf8');
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (error: any) {
+    if (error?.code === 'ENOENT') {
+      return [];
+    }
+
+    throw error;
+  }
+}
+
+export async function addFeedback(input: { message: string; email?: string }): Promise<FeedbackRecord> {
+  const feedback = await listFeedback();
+  const created: FeedbackRecord = {
+    message: input.message,
+    email: input.email,
+    timestamp: new Date().toISOString(),
+  };
+
+  feedback.push(created);
+  await fs.writeFile(feedbackFile, JSON.stringify(feedback, null, 2), 'utf8');
+  return created;
+}

--- a/lib/storage/terms-storage.ts
+++ b/lib/storage/terms-storage.ts
@@ -1,0 +1,93 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { TermRecord } from './types';
+
+interface TermsFile {
+  terms: Array<Partial<TermRecord> & { term: string; definition: string }>;
+}
+
+const termsFile = path.join(process.cwd(), 'terms.json');
+
+function normalizeTerm(term: Partial<TermRecord> & { term: string; definition: string }): TermRecord {
+  return {
+    term: term.term,
+    definition: term.definition,
+    version: Number.isFinite(term.version) ? Number(term.version) : 1,
+    updatedAt: term.updatedAt || new Date().toISOString(),
+  };
+}
+
+async function readTermsFile(): Promise<TermRecord[]> {
+  const raw = await fs.readFile(termsFile, 'utf8');
+  const parsed: TermsFile = JSON.parse(raw);
+  return (parsed.terms || []).map(normalizeTerm);
+}
+
+async function writeTermsFile(terms: TermRecord[]): Promise<void> {
+  await fs.writeFile(termsFile, JSON.stringify({ terms }, null, 2), 'utf8');
+}
+
+export async function listTerms(): Promise<TermRecord[]> {
+  return readTermsFile();
+}
+
+export async function createTerm(input: { term: string; definition: string }): Promise<TermRecord> {
+  const terms = await readTermsFile();
+  if (terms.some((item) => item.term === input.term)) {
+    throw new Error('TERM_EXISTS');
+  }
+
+  const created: TermRecord = {
+    term: input.term,
+    definition: input.definition,
+    version: 1,
+    updatedAt: new Date().toISOString(),
+  };
+
+  terms.push(created);
+  await writeTermsFile(terms);
+  return created;
+}
+
+export async function updateTerm(
+  termName: string,
+  input: { definition: string; expectedVersion?: number }
+): Promise<TermRecord> {
+  const terms = await readTermsFile();
+  const idx = terms.findIndex((item) => item.term === termName);
+  if (idx < 0) {
+    throw new Error('TERM_NOT_FOUND');
+  }
+
+  const current = terms[idx];
+  if (
+    typeof input.expectedVersion === 'number' &&
+    Number.isFinite(input.expectedVersion) &&
+    current.version !== input.expectedVersion
+  ) {
+    throw new Error('VERSION_CONFLICT');
+  }
+
+  const updated: TermRecord = {
+    ...current,
+    definition: input.definition,
+    version: current.version + 1,
+    updatedAt: new Date().toISOString(),
+  };
+
+  terms[idx] = updated;
+  await writeTermsFile(terms);
+  return updated;
+}
+
+export async function deleteTerm(termName: string): Promise<TermRecord> {
+  const terms = await readTermsFile();
+  const idx = terms.findIndex((item) => item.term === termName);
+  if (idx < 0) {
+    throw new Error('TERM_NOT_FOUND');
+  }
+
+  const [removed] = terms.splice(idx, 1);
+  await writeTermsFile(terms);
+  return removed;
+}

--- a/lib/storage/types.ts
+++ b/lib/storage/types.ts
@@ -1,0 +1,21 @@
+export interface TermRecord {
+  term: string;
+  definition: string;
+  version: number;
+  updatedAt: string;
+}
+
+export interface FeedbackRecord {
+  message: string;
+  email?: string;
+  timestamp: string;
+}
+
+export interface AuditLogEntry {
+  id: string;
+  actor: string;
+  action: string;
+  target: string;
+  timestamp: string;
+  details?: Record<string, unknown>;
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
+import { authorizeMutation } from './lib/api/auth';
+import { consumeRateLimit } from './lib/api/rate-limit';
 
 // Define the allowed origin for CORS
 const allowedOrigin = process.env.ALLOWED_ORIGIN || 'https://alex-unnippillil.github.io';
@@ -17,6 +19,41 @@ export function middleware(request: NextRequest) {
     }
 
     const response = NextResponse.next();
+
+    if (pathname === '/api/feedback') {
+      const limit = consumeRateLimit(request, {
+        routeKey: 'feedback',
+        limit: 10,
+        windowMs: 60_000,
+      });
+      if (!limit.allowed) {
+        return NextResponse.json(
+          { success: false, error: { code: 'RATE_LIMITED', message: 'Too many feedback requests.' } },
+          { status: 429, headers: { 'Retry-After': String(limit.retryAfterSec) } }
+        );
+      }
+    }
+
+    if (pathname.startsWith('/api/terms')) {
+      const limit = consumeRateLimit(request, {
+        routeKey: pathname.startsWith('/api/terms/') ? 'terms-item' : 'terms-collection',
+        limit: 30,
+        windowMs: 60_000,
+      });
+      if (!limit.allowed) {
+        return NextResponse.json(
+          { success: false, error: { code: 'RATE_LIMITED', message: 'Too many term requests.' } },
+          { status: 429, headers: { 'Retry-After': String(limit.retryAfterSec) } }
+        );
+      }
+    }
+
+    if (pathname === '/api/feedback' || pathname.startsWith('/api/terms')) {
+      const auth = authorizeMutation(request);
+      if (!auth.ok) {
+        return auth.response;
+      }
+    }
 
     response.headers.set('Strict-Transport-Security', 'max-age=63072000; includeSubDomains; preload');
     response.headers.set('X-DNS-Prefetch-Control', 'off');

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "react-dom": "^18.3.1",
         "react-joyride": "^2.9.3",
         "socket.io": "^4.8.1",
-        "socket.io-client": "^4.8.1"
+        "socket.io-client": "^4.8.1",
+        "zod": "^3.24.1"
       },
       "devDependencies": {
         "@playwright/test": "^1.55.0",
@@ -3375,6 +3376,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "react-dom": "^18.3.1",
     "react-joyride": "^2.9.3",
     "socket.io": "^4.8.1",
-    "socket.io-client": "^4.8.1"
+    "socket.io-client": "^4.8.1",
+    "zod": "^3.24.1"
   }
 }


### PR DESCRIPTION
### Motivation
- Centralize persistence and stop ad-hoc direct writes to repo-root JSON files by introducing a storage abstraction to reduce duplication and normalize records.
- Prevent unauthorized or abusive changes to content by enforcing authentication/authorization and rate limiting for mutating routes.
- Improve data integrity for concurrent updates and provide traceability via optimistic concurrency checks and audit logging.

### Description
- Introduces a storage abstraction under `lib/storage/*` with `terms-storage.ts`, `feedback-storage.ts`, `audit-storage.ts`, and typed records in `lib/storage/types.ts`, and updates routes to use `listTerms`, `createTerm`, `updateTerm`, `deleteTerm`, and `addFeedback` instead of direct `fs` writes.
- Adds authz helpers in `lib/api/auth.ts` and wires enforcement into `middleware.ts` so mutating HTTP methods require a valid `x-api-key` (`API_WRITE_TOKEN`) and role header (`x-role`) for `/api/feedback` and `/api/terms*`.
- Adds request schema validation using Zod in `lib/schemas/api-schemas.ts` and structured error responses via `lib/api/errors.ts`, and integrates validation in `app/api/feedback/route.ts`, `app/api/terms/route.ts`, and `app/api/terms/[term]/route.ts`.
- Implements per-route in-memory rate limiting in `lib/api/rate-limit.ts` with gating in `middleware.ts` for `/api/feedback` and `/api/terms*`, optimistic concurrency via `expectedVersion`/`If-Match` in `terms-storage.ts`, and audit logging of mutation events to `audit-log.jsonl` via `appendAuditLog`.
- Adds `zod` to `package.json` dependencies for runtime schema checks and normalizes term records to include `version` and `updatedAt`.

### Testing
- Ran `npm install --package-lock-only` to update lock metadata successfully.
- Ran the project test suite with `npm test`, which completed successfully (diagnostics and `useCopyFormats` tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ede6e1162083288a3946887c3448a8)