### PR TITLE
Broaden TypeScript coverage and add CI typecheck baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
         run: npm ci
       - name: Lint
         run: npm run lint
+      - name: Typecheck
+        run: npm run typecheck
       - name: Test
         run: npm test
       - name: Build

--- a/docs/typecheck-baseline.md
+++ b/docs/typecheck-baseline.md
@@ -1,0 +1,28 @@
+# Typecheck Baseline (Stage 1)
+
+This baseline was captured with `npm run typecheck` on April 26, 2026 after widening TypeScript coverage and enabling `strict` + `noImplicitAny`.
+
+## Error categories
+
+- **Import / module-resolution errors (TS2307, TS7016, TS2503, TS2304):** Missing framework or package types (for example `next/*`, `contentlayer/generated`, `react-router-dom`, `@types/*` for some packages, and browser globals). This is currently the largest error group.
+- **Nullability / optionality errors (TS18047, TS18048, TS2322 where `undefined`/`null` appears):** Accessing maybe-undefined objects without guards and assigning nullable values into strict non-null types.
+- **Boundary / API contract errors (TS2322, TS2345, TS2769):** Mismatched data at boundaries (URLSearchParams construction, crypto BufferSource expectations, ref target typing, external callback/status enums).
+- **Typing gaps / implicit `any` errors (TS7006):** Unannotated callback params revealed by `noImplicitAny` through `strict`.
+
+## Staged strictness rollout
+
+1. **Stage 1 (this change):**
+   - Expand `tsconfig` include to project globs.
+   - Enable `strict` and `noImplicitAny`.
+   - Keep `noUncheckedIndexedAccess` explicitly disabled while resolving baseline errors.
+   - Add `npm run typecheck` and enforce it in CI.
+2. **Stage 2 (next PR):**
+   - Resolve import/module gaps by installing missing runtime/type dependencies and adding targeted module declarations where unavoidable.
+   - Fix top-priority nullability and boundary errors in `app/**` and shared components.
+3. **Stage 3 (follow-up PR):**
+   - Turn on `noUncheckedIndexedAccess`.
+   - Address indexed access fallout with guards, defaults, and narrowed helper types.
+
+## Note on `next/server` and `next/image`
+
+Custom `paths` aliases were removed. Local compatibility shims now use ambient module declarations in `types/` so TypeScript does not redirect imports through path mapping that can hide real resolution behavior.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/",
   "main": "script.js",
   "scripts": {
-    "test": "html-validate index.html search.html diagnostics.html import.html && node diagnostics.test.js && node tests/useCopyFormats.test.js"
+    "test": "html-validate index.html search.html diagnostics.html import.html && node diagnostics.test.js && node tests/useCopyFormats.test.js",
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [],
   "author": "",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,20 +5,21 @@
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
-    "strict": false,
+    "strict": true,
+    "noImplicitAny": true,
+    "noUncheckedIndexedAccess": false,
     "skipLibCheck": true,
     "resolveJsonModule": true,
     "jsx": "react-jsx",
     "baseUrl": ".",
-    "paths": {
-      "next/server": ["types/next-server"],
-      "next/image": ["types/next-image"]
-    },
     "types": ["undici-types"]
   },
   "include": [
-    "lib/settings.tsx",
-    "src/features/linkPreview/index.tsx",
-    "src/components/LinkPreviewCard.tsx"
+    "app/**/*",
+    "components/**/*",
+    "lib/**/*",
+    "hooks/**/*",
+    "src/**/*",
+    "types/**/*"
   ]
 }

--- a/types/next-image.d.ts
+++ b/types/next-image.d.ts
@@ -1,2 +1,8 @@
-declare const Image: React.ComponentType<any>;
-export default Image;
+declare module 'next/image' {
+  import * as React from 'react';
+
+  export type ImageProps = React.ImgHTMLAttributes<HTMLImageElement>;
+
+  const Image: React.ComponentType<ImageProps>;
+  export default Image;
+}

--- a/types/next-server.d.ts
+++ b/types/next-server.d.ts
@@ -1,8 +1,11 @@
-export class NextResponse extends Response {
-  constructor(body?: BodyInit | null, init?: ResponseInit);
-  static json(data: any, init?: ResponseInit): NextResponse;
-  static next(): NextResponse;
-}
-export interface NextRequest extends Request {
-  nextUrl: URL;
+declare module 'next/server' {
+  export class NextResponse extends Response {
+    constructor(body?: BodyInit | null, init?: ResponseInit);
+    static json(data: unknown, init?: ResponseInit): NextResponse;
+    static next(): NextResponse;
+  }
+
+  export interface NextRequest extends Request {
+    nextUrl: URL;
+  }
 }


### PR DESCRIPTION
### Motivation

- Increase TypeScript coverage across the project so compiler checks apply to all app, component and shared code rather than a tiny file set. 
- Surface real type issues (module resolution, nullability, boundary mismatches) by removing path aliases that masked failures and starting a staged strictness rollout. 
- Add an automated gate so type regressions are caught in CI early as stricter checks are introduced.

### Description

- Replaced the narrow `tsconfig.json` `include` list with repo globs: `app/**/*`, `components/**/*`, `lib/**/*`, `hooks/**/*`, `src/**/*`, and `types/**/*`.
- Enabled stricter compiler options for stage 1 by setting `strict: true` and `noImplicitAny: true`, while keeping `noUncheckedIndexedAccess: false` for incremental rollout.
- Removed `paths` overrides for `next/server` and `next/image` and added ambient module shims under `types/` (`types/next-server.d.ts`, `types/next-image.d.ts`) to avoid hiding resolution issues.
- Added `npm run typecheck` (`tsc --noEmit`), inserted a `Typecheck` step into `.github/workflows/ci.yml`, and added `docs/typecheck-baseline.md` documenting error categories and a staged remediation plan.

### Testing

- Ran `npm run typecheck`; the typecheck run produced a baseline list of errors (import/module-resolution, nullability, boundary/API, and implicit `any`) and therefore failed as expected to capture current issues.
- Ran `npm test`; the existing test suite completed successfully and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ede6dfadd0832880a5f13dde993ff9)