### PR TITLE
Harden TypeScript config, enable strict mode, and add `typecheck` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "https://alex-unnippillil.github.io/CyberSecuirtyDictionary/",
   "main": "script.js",
   "scripts": {
-    "test": "html-validate index.html search.html diagnostics.html import.html && node diagnostics.test.js && node tests/useCopyFormats.test.js"
+    "test": "html-validate index.html search.html diagnostics.html import.html && node diagnostics.test.js && node tests/useCopyFormats.test.js",
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [],
   "author": "",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,20 +5,21 @@
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
-    "strict": false,
+    "strict": true,
     "skipLibCheck": true,
     "resolveJsonModule": true,
     "jsx": "react-jsx",
     "baseUrl": ".",
-    "paths": {
-      "next/server": ["types/next-server"],
-      "next/image": ["types/next-image"]
-    },
     "types": ["undici-types"]
   },
   "include": [
-    "lib/settings.tsx",
-    "src/features/linkPreview/index.tsx",
-    "src/components/LinkPreviewCard.tsx"
-  ]
+    "app/**/*",
+    "src/**/*",
+    "components/**/*",
+    "lib/**/*",
+    "types/**/*",
+    "tests/**/*",
+    "middleware.ts"
+  ],
+  "exclude": ["node_modules", "dist", "build", ".next", "out", "coverage"]
 }

--- a/types/next-image.d.ts
+++ b/types/next-image.d.ts
@@ -1,2 +1,12 @@
-declare const Image: React.ComponentType<any>;
-export default Image;
+import type { ComponentType, ImgHTMLAttributes } from "react";
+
+/**
+ * Local compatibility shim for non-Next.js tooling.
+ * Required because this repository type-checks React components importing
+ * `next/image`, while `next` is not installed in this package.
+ */
+declare module "next/image" {
+  export type ImageProps = ImgHTMLAttributes<HTMLImageElement>;
+  const Image: ComponentType<ImageProps>;
+  export default Image;
+}

--- a/types/next-server.d.ts
+++ b/types/next-server.d.ts
@@ -1,8 +1,16 @@
-export class NextResponse extends Response {
-  constructor(body?: BodyInit | null, init?: ResponseInit);
-  static json(data: any, init?: ResponseInit): NextResponse;
-  static next(): NextResponse;
-}
-export interface NextRequest extends Request {
-  nextUrl: URL;
+/**
+ * Local compatibility shim for non-Next.js tooling.
+ * Required because this repository type-checks API route modules that import
+ * `next/server`, while `next` is not installed in this package.
+ */
+declare module "next/server" {
+  export class NextResponse extends Response {
+    constructor(body?: BodyInit | null, init?: ResponseInit);
+    static json(data: unknown, init?: ResponseInit): NextResponse;
+    static next(init?: ResponseInit): NextResponse;
+  }
+
+  export interface NextRequest extends Request {
+    nextUrl: URL;
+  }
 }


### PR DESCRIPTION
### Motivation
- Improve type-safety project-wide by running the TypeScript checker across the real codebase instead of a small subset. 
- Make CI/local type-checking consistent by providing a dedicated entrypoint for `tsc` so type regressions are caught reliably. 

### Description
- Turned on `strict` in `tsconfig.json` and broadened `include` to `app/**/*`, `src/**/*`, `components/**/*`, `lib/**/*`, `types/**/*`, `tests/**/*`, and `middleware.ts`. 
- Added `exclude` entries targeting generated/build folders: `node_modules`, `dist`, `build`, `.next`, `out`, and `coverage`. 
- Removed `tsconfig` path overrides that masked framework resolution and replaced them with documented ambient shims in `types/next-server.d.ts` and `types/next-image.d.ts` which declare minimal `next/*` modules required for local type-checking. 
- Added a `typecheck` script in `package.json` with `tsc --noEmit` so CI and contributors can run `npm run typecheck`. 

### Testing
- Ran `npm test` and it succeeded. 
- Ran `npm run typecheck` and it failed with existing repository typing/dependency diagnostics (missing framework/@types and strictness issues), which is expected now that strict mode and broader includes surface prior issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f94c834dc88328849544a6c049b9fd)