### PR TITLE
Refactor App Router layout/page metadata and isolate client islands

### DIFF
--- a/app/ClientShell.tsx
+++ b/app/ClientShell.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import React from "react";
+import { motion } from "framer-motion";
+import Navbar from "../components/Navbar";
+import MobileTocButton from "../components/MobileTocButton";
+import useFontHinting from "../hooks/useFontHinting";
+
+export default function ClientShell({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  useFontHinting();
+
+  return (
+    <>
+      <Navbar />
+      <motion.div
+        initial={{ opacity: 0, y: 10 }}
+        animate={{ opacity: 1, y: 0 }}
+        exit={{ opacity: 0, y: -10 }}
+        transition={{ duration: 0.3 }}
+      >
+        {children}
+      </motion.div>
+      <MobileTocButton />
+    </>
+  );
+}

--- a/app/HomeClientEffects.tsx
+++ b/app/HomeClientEffects.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import useSocket from "../hooks/useSocket";
+
+export default function HomeClientEffects() {
+  useSocket();
+  return null;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,11 +1,6 @@
-"use client";
-
 import React from "react";
-import { motion } from "framer-motion";
-import Navbar from "../components/Navbar";
-import MobileTocButton from "../components/MobileTocButton";
 import { Inter } from "next/font/google";
-import useFontHinting from "../hooks/useFontHinting";
+import ClientShell from "./ClientShell";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -14,20 +9,10 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
-  useFontHinting();
   return (
     <html lang="en" className={inter.className}>
       <body>
-        <Navbar />
-        <motion.div
-          initial={{ opacity: 0, y: 10 }}
-          animate={{ opacity: 1, y: 0 }}
-          exit={{ opacity: 0, y: -10 }}
-          transition={{ duration: 0.3 }}
-        >
-          {children}
-        </motion.div>
-        <MobileTocButton />
+        <ClientShell>{children}</ClientShell>
       </body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,32 +1,22 @@
-import Head from "next/head";
+import type { Metadata } from "next";
 import SearchBar from "../components/search/SearchBar";
-import useSocket from "../hooks/useSocket";
+import HomeClientEffects from "./HomeClientEffects";
+
+export const metadata: Metadata = {
+  title: "Cyber Security Dictionary",
+  description: "Look up cybersecurity terms and definitions.",
+  openGraph: {
+    title: "Cyber Security Dictionary",
+    description: "Look up cybersecurity terms and definitions.",
+  },
+};
 
 export default function Home() {
-  // Establish a Socket.IO connection when the home page mounts.
-  useSocket();
-
   return (
-    <>
-      <Head>
-        <title>Cyber Security Dictionary</title>
-        <meta
-          name="description"
-          content="Look up cybersecurity terms and definitions."
-        />
-        <meta
-          property="og:title"
-          content="Cyber Security Dictionary"
-        />
-        <meta
-          property="og:description"
-          content="Look up cybersecurity terms and definitions."
-        />
-      </Head>
-      <main>
-        <h1>Cyber Security Dictionary</h1>
-        <SearchBar />
-      </main>
-    </>
+    <main>
+      <HomeClientEffects />
+      <h1>Cyber Security Dictionary</h1>
+      <SearchBar />
+    </main>
   );
 }

--- a/app/search/SearchPageClient.tsx
+++ b/app/search/SearchPageClient.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useSearchParams } from 'next/navigation';
+import { searchPersonalTerms, PersonalTerm } from '../../lib/personalTerms';
+
+interface Term {
+  term: string;
+  definition: string;
+}
+
+interface SearchResponse {
+  results: Term[];
+  suggestions: string[];
+}
+
+export default function SearchPageClient() {
+  const searchParams = useSearchParams();
+  const query = searchParams.get('q') || '';
+  const [data, setData] = useState<SearchResponse | null>(null);
+  const [personal, setPersonal] = useState<PersonalTerm[]>([]);
+
+  useEffect(() => {
+    if (!query) return;
+    fetch(`/api/search?q=${encodeURIComponent(query)}`)
+      .then((res) => res.json())
+      .then(setData)
+      .catch(() => setData({ results: [], suggestions: [] }));
+    searchPersonalTerms(query).then(setPersonal);
+  }, [query]);
+
+  const results = data?.results || [];
+  const combined = [
+    ...personal.map((p) => ({ term: p.slug, definition: p.definition, personal: true })),
+    ...results.map((r) => ({ ...r, personal: false })),
+  ];
+  const suggestions = data?.suggestions || [];
+
+  return (
+    <div>
+      {suggestions.length > 0 && (
+        <div className="suggestions">
+          <p>Did you mean:</p>
+          <ul>
+            {suggestions.map((s) => (
+              <li key={s}>
+                <Link href={`/search?q=${encodeURIComponent(s)}`}>{s}</Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      <ul>
+        {combined.map((r) => (
+          <li key={r.term}>
+            <strong>{r.term}</strong>
+            {r.personal && <span className="badge"> Personal</span>}: {r.definition}
+          </li>
+        ))}
+        {combined.length === 0 && <li>No results found.</li>}
+      </ul>
+    </div>
+  );
+}

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -1,85 +1,15 @@
-'use client';
+import type { Metadata } from 'next';
+import SearchPageClient from './SearchPageClient';
 
-import Head from 'next/head';
-import { useEffect, useState } from 'react';
-import Link from 'next/link';
-import { useSearchParams } from 'next/navigation';
-import { searchPersonalTerms, PersonalTerm } from '../../lib/personalTerms';
-
-interface Term {
-  term: string;
-  definition: string;
-}
-
-interface SearchResponse {
-  results: Term[];
-  suggestions: string[];
-}
-
+export const metadata: Metadata = {
+  title: 'Search – Cyber Security Dictionary',
+  description: 'Search cybersecurity terms in the dictionary.',
+  openGraph: {
+    title: 'Search – Cyber Security Dictionary',
+    description: 'Search cybersecurity terms in the dictionary.',
+  },
+};
 
 export default function SearchPage() {
-  const searchParams = useSearchParams();
-  const query = searchParams.get('q') || '';
-  const [data, setData] = useState<SearchResponse | null>(null);
-  const [personal, setPersonal] = useState<PersonalTerm[]>([]);
-
-  useEffect(() => {
-    if (!query) return;
-    fetch(`/api/search?q=${encodeURIComponent(query)}`)
-      .then((res) => res.json())
-      .then(setData)
-      .catch(() => setData({ results: [], suggestions: [] }));
-    searchPersonalTerms(query).then(setPersonal);
-  }, [query]);
-
-  const results = data?.results || [];
-  const combined = [
-    ...personal.map((p) => ({ term: p.slug, definition: p.definition, personal: true })),
-    ...results.map((r) => ({ ...r, personal: false })),
-  ];
-  const suggestions = data?.suggestions || [];
-
-  return (
-    <>
-      <Head>
-        <title>Search – Cyber Security Dictionary</title>
-        <meta
-          name="description"
-          content="Search cybersecurity terms in the dictionary."
-        />
-        <meta
-          property="og:title"
-          content="Search – Cyber Security Dictionary"
-        />
-        <meta
-          property="og:description"
-          content="Search cybersecurity terms in the dictionary."
-        />
-      </Head>
-      <div>
-        {suggestions.length > 0 && (
-          <div className="suggestions">
-            <p>Did you mean:</p>
-            <ul>
-              {suggestions.map((s) => (
-                <li key={s}>
-                  <Link href={`/search?q=${encodeURIComponent(s)}`}>{s}</Link>
-                </li>
-              ))}
-            </ul>
-          </div>
-        )}
-        <ul>
-          {combined.map((r) => (
-            <li key={r.term}>
-              <strong>{r.term}</strong>
-              {r.personal && <span className="badge"> Personal</span>}: {r.definition}
-            </li>
-          ))}
-          {combined.length === 0 && <li>No results found.</li>}
-        </ul>
-      </div>
-    </>
-  );
+  return <SearchPageClient />;
 }
-

--- a/components/MobileTocButton.tsx
+++ b/components/MobileTocButton.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useEffect, useState } from "react";
 import TOC from "./TOC";
 


### PR DESCRIPTION
### Motivation
- Reduce client-side hydration surface by keeping the root layout server-rendered and confining interactive behavior to client islands. 
- Adopt App Router metadata APIs instead of `next/head` so page metadata is expressed at the route level. 
- Ensure only truly interactive pieces (navigation, mobile TOC, socket effects, animations) hydrate on the client to lower bundle and runtime cost. 

### Description
- Converted `app/layout.tsx` into a server component by removing the root `"use client"` directive and rendering `<html>`/`<body>` on the server. 
- Introduced `app/ClientShell.tsx` as a client component to host `Navbar`, `MobileTocButton`, `useFontHinting()`, and the `framer-motion` wrapper so animations and navigation are isolated from the root layout. 
- Replaced `next/head` usage in `app/page.tsx` with `export const metadata` and moved socket initialization into a minimal client island `app/HomeClientEffects.tsx`. 
- Reworked `app/search/page.tsx` to use `export const metadata` and split the interactive logic into `app/search/SearchPageClient.tsx` (now a client component). 
- Marked `components/MobileTocButton.tsx` as a client component by adding `"use client";` to ensure it remains an interactive island. 

### Testing
- Ran `npm test` (which executes `html-validate` and project node tests) and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f94c85763083289682cdd9576e6b5b)