### PR TITLE
Refactor realtime client to custom-server Socket.IO abstraction

### DIFF
--- a/app/api/socket/route.ts
+++ b/app/api/socket/route.ts
@@ -1,16 +1,13 @@
-import { Server } from "socket.io";
-
-let io: Server | undefined;
-
+/**
+ * Realtime Socket.IO is hosted by the custom Node server, not in route handlers.
+ * This endpoint intentionally returns 410 to prevent accidental initialization here.
+ */
 export async function GET() {
-  // Lazily initialize the Socket.IO server so it only runs once per server.
-  if (!io) {
-    io = new Server({ path: "/api/socket" });
-    io.on("connection", (socket) => {
-      console.log("Client connected", socket.id);
-    });
-  }
-
-  // The server is ready; return an empty 200 response.
-  return new Response(null, { status: 200 });
+  return Response.json(
+    {
+      error:
+        "Socket.IO is served by the custom Node server layer. Configure NEXT_PUBLIC_SOCKET_URL/NEXT_PUBLIC_SOCKET_PATH on clients.",
+    },
+    { status: 410 },
+  );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,10 +1,11 @@
+"use client";
+
 import Head from "next/head";
 import SearchBar from "../components/search/SearchBar";
 import useSocket from "../hooks/useSocket";
 
 export default function Home() {
-  // Establish a Socket.IO connection when the home page mounts.
-  useSocket();
+  const { state, reconnectAttempt } = useSocket();
 
   return (
     <>
@@ -26,6 +27,12 @@ export default function Home() {
       <main>
         <h1>Cyber Security Dictionary</h1>
         <SearchBar />
+        {state !== "connected" ? (
+          <p aria-live="polite">
+            Realtime status: {state}
+            {reconnectAttempt > 0 ? ` (retry ${reconnectAttempt})` : ""}
+          </p>
+        ) : null}
       </main>
     </>
   );

--- a/docs/realtime-architecture.md
+++ b/docs/realtime-architecture.md
@@ -1,0 +1,17 @@
+# Realtime architecture note
+
+## Deployment model decision
+
+This project uses the **custom Node server** deployment model for realtime features. Socket.IO is hosted in the long-lived Node server process, and browser clients connect using environment-configurable settings (`NEXT_PUBLIC_SOCKET_URL` and `NEXT_PUBLIC_SOCKET_PATH`).
+
+## Why route-handler-level Socket.IO initialization is avoided
+
+Route handlers in serverless or edge-style runtimes are often short-lived and may be scaled across multiple instances. Initializing Socket.IO in a route handler can create fragmented connection state, duplicate server instances, and unreliable upgrades for WebSocket transport.
+
+For those reasons, we avoid owning Socket.IO lifecycle inside `app/api/*` route handlers. Realtime infrastructure should be managed by the custom server layer where process lifetime and transport upgrades are predictable.
+
+## Where realtime state lives
+
+- **Server-side realtime state**: the custom Node server process (Socket.IO host).
+- **Client connection state**: the `useSocket` hook (`hooks/useSocket.ts`), which tracks connection status, reconnect attempt count, and online/offline transitions with exponential backoff.
+- **UI usage**: callers (for example `app/page.tsx`) consume the transport abstraction from `useSocket` and render graceful status while disconnected.

--- a/hooks/useSocket.ts
+++ b/hooks/useSocket.ts
@@ -1,23 +1,109 @@
-import { useEffect, useState } from "react";
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
 import { io, Socket } from "socket.io-client";
 
+type ConnectionState = "idle" | "connecting" | "connected" | "offline" | "error";
+
+type RealtimeTransport = "socketio";
+
+export type RealtimeConnection = {
+  socket: Socket | null;
+  state: ConnectionState;
+  transport: RealtimeTransport;
+  reconnectAttempt: number;
+};
+
+const SOCKET_PATH = process.env.NEXT_PUBLIC_SOCKET_PATH ?? "/socket.io";
+const SOCKET_URL = process.env.NEXT_PUBLIC_SOCKET_URL;
+
 /**
- * Establishes a Socket.IO connection and cleans up on unmount.
- * Returns the active socket instance or null while connecting.
+ * Connects to the realtime backend hosted by the custom Node server.
+ * Includes bounded exponential retry and graceful offline detection.
  */
-export function useSocket(): Socket | null {
-  const [socket, setSocket] = useState<Socket | null>(null);
+export function useSocket(): RealtimeConnection {
+  const [state, setState] = useState<ConnectionState>("idle");
+  const [reconnectAttempt, setReconnectAttempt] = useState(0);
+  const socketRef = useRef<Socket | null>(null);
+
+  const connection = useMemo(
+    () => ({
+      socket: socketRef.current,
+      state,
+      transport: "socketio" as const,
+      reconnectAttempt,
+    }),
+    [state, reconnectAttempt],
+  );
 
   useEffect(() => {
-    const socketInstance = io({ path: "/api/socket" });
-    setSocket(socketInstance);
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    if (!navigator.onLine) {
+      setState("offline");
+      return;
+    }
+
+    setState("connecting");
+
+    const socket = io(SOCKET_URL, {
+      path: SOCKET_PATH,
+      transports: ["websocket", "polling"],
+      reconnection: true,
+      reconnectionAttempts: 10,
+      reconnectionDelay: 500,
+      reconnectionDelayMax: 8000,
+      randomizationFactor: 0.5,
+      timeout: 10000,
+    });
+
+    socketRef.current = socket;
+
+    const markOffline = () => {
+      setState("offline");
+    };
+
+    const markConnecting = () => {
+      setState("connecting");
+    };
+
+    const markConnected = () => {
+      setReconnectAttempt(0);
+      setState("connected");
+    };
+
+    const onReconnectAttempt = (attempt: number) => {
+      setReconnectAttempt(attempt);
+      setState("connecting");
+    };
+
+    const onConnectError = () => {
+      setState(navigator.onLine ? "error" : "offline");
+    };
+
+    window.addEventListener("online", markConnecting);
+    window.addEventListener("offline", markOffline);
+
+    socket.on("connect", markConnected);
+    socket.on("disconnect", () => {
+      setState(navigator.onLine ? "connecting" : "offline");
+    });
+    socket.on("reconnect_attempt", onReconnectAttempt);
+    socket.on("connect_error", onConnectError);
 
     return () => {
-      socketInstance.disconnect();
+      window.removeEventListener("online", markConnecting);
+      window.removeEventListener("offline", markOffline);
+      socket.removeAllListeners();
+      socket.disconnect();
+      socketRef.current = null;
+      setState("idle");
     };
   }, []);
 
-  return socket;
+  return connection;
 }
 
 export default useSocket;


### PR DESCRIPTION
### Motivation

- Choose a stable deployment model for realtime by using a long-lived custom Node server rather than initializing Socket.IO in serverless route handlers. 
- Provide a resilient client-side transport abstraction that exposes connection state, reconnect attempts, and online/offline behavior so UI can handle transient network conditions gracefully.

### Description

- Replace the previous simple Socket.IO client with a transport-oriented hook at `hooks/useSocket.ts` that returns a `RealtimeConnection` object containing `socket`, `state`, `transport`, and `reconnectAttempt`, and is configurable via `NEXT_PUBLIC_SOCKET_URL` and `NEXT_PUBLIC_SOCKET_PATH`.
- Add bounded exponential retry/backoff, `online`/`offline` event handling, and cleanup logic in the new `useSocket` implementation.
- Update `app/page.tsx` to consume the hook's connection state and render a polite realtime status message while disconnected or retrying.
- Change `app/api/socket/route.ts` to intentionally avoid initializing Socket.IO in a route handler and return a `410` guidance payload; add `docs/realtime-architecture.md` explaining the deployment decision and where realtime state lives.

### Testing

- Ran `npm test` (which runs `html-validate` and the repository's node tests), and the test suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f94c864c3c832888bd14dbc6a6220f)