### PR TITLE
Canonicalize term rendering routes and redirect legacy term URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,7 @@ The project is a static site published with GitHub Pages. After updating content
 
 For information on reporting vulnerabilities, please see our [Security Policy](SECURITY.md).
 
+
+## Routing
+
+- Canonical term route and migration notes: `docs/term-routing-migration.md`.

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -13,7 +13,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
   const baseUrl = (siteConfig.siteUrl || '').replace(/\/$/, '');
 
   const termEntries = (termsData.terms || []).map((t: { term: string }) => ({
-    url: `${baseUrl}/terms/${slugify(t.term)}`,
+    url: `${baseUrl}/term/${slugify(t.term)}`,
     lastModified: new Date(),
   }));
 

--- a/app/terms/[slug]/page.tsx
+++ b/app/terms/[slug]/page.tsx
@@ -1,62 +1,9 @@
-import React from "react";
-import fs from "fs";
-import path from "path";
-import yaml from "js-yaml";
-import { FAQBlock } from "../../components/FAQBlock";
+import { redirect } from "next/navigation";
 
-interface Term {
-  name: string;
-  slug: string;
-  definition: string;
-  synonyms?: string[];
+interface PageProps {
+  params: { slug: string };
 }
 
-function loadTerms(): Term[] {
-  const filePath = path.join(process.cwd(), "data", "terms.yaml");
-  const file = fs.readFileSync(filePath, "utf8");
-  return yaml.load(file) as Term[];
-}
-
-export async function generateStaticParams() {
-  return loadTerms().map((term) => ({ slug: term.slug }));
-}
-
-export default function TermPage({ params }: { params: { slug: string } }) {
-  const term = loadTerms().find((t) => t.slug === params.slug);
-
-  if (!term) {
-    return <div>Term not found</div>;
-  }
-
-  const termJsonLd = {
-    "@context": "https://schema.org",
-    "@type": "DefinedTerm",
-    name: term.name,
-    description: term.definition,
-    url: `https://example.com/terms/${params.slug}`,
-  };
-
-  const faqItems = [
-    {
-      question: `What is ${term.name}?`,
-      answer: term.definition,
-    },
-  ];
-
-  return (
-    <main>
-      <h1>{term.name}</h1>
-      <p>{term.definition}</p>
-      {term.synonyms && term.synonyms.length > 0 && (
-        <p>
-          <strong>Synonyms:</strong> {term.synonyms.join(", ")}
-        </p>
-      )}
-      <FAQBlock items={faqItems} />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(termJsonLd) }}
-      />
-    </main>
-  );
+export default function DeprecatedTermsRoute({ params }: PageProps) {
+  redirect(`/term/${params.slug}`);
 }

--- a/app/word/[slug]/page.tsx
+++ b/app/word/[slug]/page.tsx
@@ -1,54 +1,9 @@
-import { notFound } from "next/navigation";
+import { redirect } from "next/navigation";
 
-interface Phonetic {
-  text?: string;
-  audio?: string;
-}
-
-interface Entry {
-  word: string;
-  phonetics?: Phonetic[];
-}
-
-function syllabify(word: string): string {
-  return word
-    .toLowerCase()
-    .split(/(?<=[aeiouy])/)
-    .join("·");
-}
-
-export const revalidate = 0;
-
-export default async function EntryPage({
+export default function DeprecatedWordRoute({
   params,
 }: {
   params: { slug: string };
 }) {
-  const res = await fetch(
-    `https://api.dictionaryapi.dev/api/v2/entries/en/${params.slug}`,
-    { cache: "no-store" }
-  );
-
-  if (!res.ok) {
-    notFound();
-  }
-
-  const data = await res.json();
-  const entry: Entry = data[0];
-
-  const ipa = entry.phonetics?.find((p) => p.text)?.text || "";
-  const audio = entry.phonetics?.find((p) => p.audio)?.audio || "";
-  const syllables = syllabify(entry.word);
-
-  return (
-    <div>
-      <header style={{ display: "flex", alignItems: "center", gap: "1rem" }}>
-        <h1>{entry.word}</h1>
-        <span>{syllables}</span>
-        {ipa && <span>{ipa}</span>}
-        {audio && <audio controls src={audio}></audio>}
-      </header>
-    </div>
-  );
+  redirect(`/term/${params.slug}`);
 }
-

--- a/docs/term-routing-migration.md
+++ b/docs/term-routing-migration.md
@@ -1,0 +1,42 @@
+# Term Route Canonicalization Plan
+
+## Canonical Rendering Stack
+
+The canonical term-rendering stack is now:
+
+- Route: `/term/[slug]`
+- Renderer: `app/(site)/term/[slug]/page.tsx`
+- Related/backlinks: `app/(site)/term/[slug]/RelatedTerms.tsx` (links to `/term/[slug]`)
+- Sitemap source: `app/sitemap.ts` (emits `/term/[slug]` URLs)
+
+This keeps a single source of truth for rendering MDX term content and related-term navigation.
+
+## Overlapping Entry Points Inventory
+
+The repository had multiple overlapping paths for term-like content:
+
+- `index.html` + `script.js` (legacy static browser runtime)
+- `app/term/[slug]/...`
+- `app/(site)/term/[slug]/...`
+- `app/terms/[slug]/...`
+- `app/word/[slug]/...`
+- `word/[slug]/...` (legacy non-App-Router tree)
+
+## Deprecations and Redirects
+
+The following routes now redirect to canonical URLs:
+
+- `/terms/[slug]` → `/term/[slug]`
+- `/word/[slug]` → `/term/[slug]`
+
+## Migration Steps
+
+1. Update any internal links that still point to `/terms/*` or `/word/*` so they point to `/term/*`.
+2. Update automated backlink generation to emit `/term/[slug]` only.
+3. Regenerate and verify sitemap entries use `/term/[slug]` only.
+4. Remove remaining legacy renderers after downstream consumers are migrated.
+
+## Follow-up Cleanup (Recommended)
+
+- Consolidate the duplicate `/term/[slug]` renderers (`app/term/[slug]` vs `app/(site)/term/[slug]`) so only one implementation remains in the tree.
+- Remove or archive the legacy static runtime (`index.html` / `script.js`) once Next.js routes are the only supported entry point.


### PR DESCRIPTION
### Motivation

- The codebase had multiple overlapping term entry points (`/terms/*`, `/word/*`, legacy static `index.html`/`script.js`) that could produce inconsistent rendering and split internal links.
- Centralizing to a single canonical route reduces duplication, simplifies backlink generation, and keeps sitemap entries consistent.

### Description

- Deprecate the `app/terms/[slug]` renderer by replacing it with a redirect to the canonical route using `redirect('/term/[slug]')` in `app/terms/[slug]/page.tsx`.
- Deprecate the `app/word/[slug]` renderer by replacing it with a redirect to the canonical route using `redirect('/term/[slug]')` in `app/word/[slug]/page.tsx`.
- Update `app/sitemap.ts` so sitemap entries use the canonical `/term/${slug}` URLs instead of `/terms/${slug}`.
- Add `docs/term-routing-migration.md` documenting the chosen canonical stack (`/term/[slug]` served by `app/(site)/term/[slug]/page.tsx`), the inventory of overlapping entry points, deprecation/redirect rules, and migration steps, and add a README pointer to that doc.

### Testing

- Ran `npm test`, which executes `html-validate` and the repository tests, and all checks passed (`Diagnostics render test passed` and `useCopyFormats tests passed`).
- No additional automated tests were added; redirects use Next.js `redirect` and should be validated during integration/staging deployments.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f94c87d9608328ba91380cec652220)